### PR TITLE
Current position retrieval timeouts, updated example

### DIFF
--- a/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -55,16 +55,35 @@ public class GeolocatorPlugin implements
   @Override
   public void onMethodCall(MethodCall call, Result result) {
     switch (call.method) {
+      case "_createTask":
+        result.success(UUID.randomUUID().toString());
+        break;
+      case "_stopTask":
+        if (call.arguments instanceof String) {
+          UUID taskID = UUID.fromString((String) call.arguments);
+          Task task = mTasks.get(taskID);
+
+          if (task != null) {
+            task.stopTask();
+          }
+          // FWIW, return whether the task has been tracked before.
+          result.success(task != null);
+        } else {
+          result.error("INVALID_TASK_ID", "This is a internal Geolocator error.", null);
+        }
+        break;
       case "getLastKnownPosition": {
+        String taskID = call.argument("taskID");
         Task task = TaskFactory.createLastKnownLocationTask(
-                mRegistrar, result, call.arguments, this);
+            taskID, mRegistrar, result, call.arguments, this);
         mTasks.put(task.getTaskID(), task);
         task.startTask();
         break;
       }
       case "getCurrentPosition": {
+        String taskID = call.argument("taskID");
         Task task = TaskFactory.createCurrentLocationTask(
-                mRegistrar, result, call.arguments, this);
+                taskID, mRegistrar, result, call.arguments, this);
         mTasks.put(task.getTaskID(), task);
         task.startTask();
         break;

--- a/android/src/main/java/com/baseflow/geolocator/data/LocationOptions.java
+++ b/android/src/main/java/com/baseflow/geolocator/data/LocationOptions.java
@@ -1,16 +1,17 @@
 package com.baseflow.geolocator.data;
 
-import java.util.Map;
-
 import static com.baseflow.geolocator.tasks.LocationUpdatesUsingLocationManagerTask.GeolocationAccuracy;
+
+import java.util.Map;
 
 public class LocationOptions {
 
   @GeolocationAccuracy
-  private int accuracy;
-  private long distanceFilter;
-  private boolean forceAndroidLocationManager;
-  private long timeInterval;
+  private final int accuracy;
+  private final long distanceFilter;
+  private final boolean forceAndroidLocationManager;
+  private final long timeInterval;
+  private final long timeout;
 
   public static LocationOptions parseArguments(Object arguments) {
     @SuppressWarnings("unchecked")
@@ -20,16 +21,20 @@ public class LocationOptions {
     final long distanceFilter = (int) map.get("distanceFilter");
     final boolean forceAndroidLocationManager = (boolean) map.get("forceAndroidLocationManager");
     final long timeInterval = (int) map.get("timeInterval");
+    final long timeout = (int) map.get("timeout");
 
-    return new LocationOptions(accuracy, distanceFilter, forceAndroidLocationManager, timeInterval);
+    return new LocationOptions(accuracy, distanceFilter, forceAndroidLocationManager, timeInterval,
+        timeout);
   }
 
 
-  private LocationOptions(@GeolocationAccuracy int accuracy, long distanceFilter, boolean forceAndroidLocationManager, long timeInterval) {
+  private LocationOptions(@GeolocationAccuracy int accuracy, long distanceFilter,
+      boolean forceAndroidLocationManager, long timeInterval, long timeout) {
     this.accuracy = accuracy;
     this.distanceFilter = distanceFilter;
     this.forceAndroidLocationManager = forceAndroidLocationManager;
     this.timeInterval = timeInterval;
+    this.timeout = timeout;
   }
 
   @GeolocationAccuracy
@@ -47,5 +52,13 @@ public class LocationOptions {
 
   public long getTimeInterval() {
     return timeInterval;
+  }
+
+  /**
+   * @return The timeout for a single location request. May be {@code 0} if no timeout has been
+   * set.
+   */
+  public long getTimeout() {
+    return timeout;
   }
 }

--- a/android/src/main/java/com/baseflow/geolocator/data/LocationOptions.java
+++ b/android/src/main/java/com/baseflow/geolocator/data/LocationOptions.java
@@ -11,7 +11,6 @@ public class LocationOptions {
   private final long distanceFilter;
   private final boolean forceAndroidLocationManager;
   private final long timeInterval;
-  private final long timeout;
 
   public static LocationOptions parseArguments(Object arguments) {
     @SuppressWarnings("unchecked")
@@ -21,20 +20,17 @@ public class LocationOptions {
     final long distanceFilter = (int) map.get("distanceFilter");
     final boolean forceAndroidLocationManager = (boolean) map.get("forceAndroidLocationManager");
     final long timeInterval = (int) map.get("timeInterval");
-    final long timeout = (int) map.get("timeout");
 
-    return new LocationOptions(accuracy, distanceFilter, forceAndroidLocationManager, timeInterval,
-        timeout);
+    return new LocationOptions(accuracy, distanceFilter, forceAndroidLocationManager, timeInterval);
   }
 
 
   private LocationOptions(@GeolocationAccuracy int accuracy, long distanceFilter,
-      boolean forceAndroidLocationManager, long timeInterval, long timeout) {
+      boolean forceAndroidLocationManager, long timeInterval) {
     this.accuracy = accuracy;
     this.distanceFilter = distanceFilter;
     this.forceAndroidLocationManager = forceAndroidLocationManager;
     this.timeInterval = timeInterval;
-    this.timeout = timeout;
   }
 
   @GeolocationAccuracy
@@ -52,13 +48,5 @@ public class LocationOptions {
 
   public long getTimeInterval() {
     return timeInterval;
-  }
-
-  /**
-   * @return The timeout for a single location request. May be {@code 0} if no timeout has been
-   * set.
-   */
-  public long getTimeout() {
-    return timeout;
   }
 }

--- a/android/src/main/java/com/baseflow/geolocator/tasks/CalculateDistanceTask.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/CalculateDistanceTask.java
@@ -8,7 +8,7 @@ import com.baseflow.geolocator.data.wrapper.ChannelResponse;
 class CalculateDistanceTask extends Task<CalculateDistanceOptions> {
 
   CalculateDistanceTask(TaskContext<CalculateDistanceOptions> context) {
-    super(context);
+    super(null, context);
   }
 
   @Override

--- a/android/src/main/java/com/baseflow/geolocator/tasks/ForwardGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/ForwardGeocodingTask.java
@@ -19,7 +19,7 @@ class ForwardGeocodingTask extends Task<ForwardGeocodingOptions> {
   private final Context mContext;
 
   ForwardGeocodingTask(TaskContext<ForwardGeocodingOptions> context) {
-    super(context);
+    super(null, context);
 
     PluginRegistry.Registrar registrar = context.getRegistrar();
 

--- a/android/src/main/java/com/baseflow/geolocator/tasks/LastKnownLocationUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/LastKnownLocationUsingLocationManagerTask.java
@@ -3,14 +3,16 @@ package com.baseflow.geolocator.tasks;
 import android.location.Location;
 import android.location.LocationManager;
 
+import androidx.annotation.NonNull;
 import com.baseflow.geolocator.data.LocationOptions;
 import com.baseflow.geolocator.data.PositionMapper;
 import com.baseflow.geolocator.data.wrapper.ChannelResponse;
+import java.util.UUID;
 
 class LastKnownLocationUsingLocationManagerTask extends LocationUsingLocationManagerTask {
 
-  LastKnownLocationUsingLocationManagerTask(TaskContext<LocationOptions> context) {
-    super(context);
+  LastKnownLocationUsingLocationManagerTask(@NonNull UUID taskID, TaskContext<LocationOptions> context) {
+    super(taskID, context);
   }
 
   @Override

--- a/android/src/main/java/com/baseflow/geolocator/tasks/LastKnownLocationUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/LastKnownLocationUsingLocationServicesTask.java
@@ -10,12 +10,13 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 
 import java.util.Map;
+import java.util.UUID;
 
 class LastKnownLocationUsingLocationServicesTask extends LocationUsingLocationServicesTask {
   private final FusedLocationProviderClient mFusedLocationProviderClient;
 
-  LastKnownLocationUsingLocationServicesTask(TaskContext<LocationOptions> taskContext) {
-    super(taskContext);
+  LastKnownLocationUsingLocationServicesTask(@NonNull UUID taskID, TaskContext<LocationOptions> taskContext) {
+    super(taskID, taskContext);
 
     mFusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(taskContext.getAndroidContext());
   }

--- a/android/src/main/java/com/baseflow/geolocator/tasks/LocationUpdatesUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/LocationUpdatesUsingLocationManagerTask.java
@@ -6,7 +6,6 @@ import android.location.LocationListener;
 import android.location.LocationManager;
 import android.location.LocationProvider;
 import android.os.Bundle;
-import android.os.Handler;
 import android.os.Looper;
 
 import androidx.annotation.Nullable;
@@ -76,7 +75,6 @@ public class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocati
     // and report back the last known location (if we have one).
     if (mStopAfterFirstLocationUpdate && mBestLocation != null) {
       reportLocationUpdate(mBestLocation);
-      stopTask();
       return;
     }
 

--- a/android/src/main/java/com/baseflow/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
@@ -4,6 +4,7 @@ import android.location.Location;
 import android.os.Looper;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.baseflow.geolocator.data.LocationOptions;
 import com.baseflow.geolocator.data.PositionMapper;
 import com.google.android.gms.location.FusedLocationProviderClient;
@@ -14,6 +15,7 @@ import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.tasks.OnCompleteListener;
 
 import java.util.Map;
+import java.util.UUID;
 
 
 class LocationUpdatesUsingLocationServicesTask extends LocationUsingLocationServicesTask {
@@ -22,8 +24,8 @@ class LocationUpdatesUsingLocationServicesTask extends LocationUsingLocationServ
   private final LocationCallback mLocationCallback;
 
 
-  LocationUpdatesUsingLocationServicesTask(TaskContext<LocationOptions> taskContext, boolean stopAfterFirstLocationUpdate) {
-    super(taskContext);
+  LocationUpdatesUsingLocationServicesTask(@Nullable UUID taskID, TaskContext<LocationOptions> taskContext, boolean stopAfterFirstLocationUpdate) {
+    super(taskID, taskContext);
 
     mStopAfterFirstLocationUpdate = stopAfterFirstLocationUpdate;
     mFusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(taskContext.getAndroidContext());

--- a/android/src/main/java/com/baseflow/geolocator/tasks/LocationUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/LocationUsingLocationManagerTask.java
@@ -5,9 +5,11 @@ import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
 
+import androidx.annotation.Nullable;
 import com.baseflow.geolocator.data.LocationOptions;
 
 import io.flutter.plugin.common.PluginRegistry;
+import java.util.UUID;
 
 abstract class LocationUsingLocationManagerTask extends Task<LocationOptions> {
   private static final long TWO_MINUTES = 120000;
@@ -15,8 +17,8 @@ abstract class LocationUsingLocationManagerTask extends Task<LocationOptions> {
   private final Context mAndroidContext;
   final LocationOptions mLocationOptions;
 
-  LocationUsingLocationManagerTask(TaskContext<LocationOptions> context) {
-    super(context);
+  LocationUsingLocationManagerTask(@Nullable UUID taskID, TaskContext<LocationOptions> context) {
+    super(taskID, context);
 
     PluginRegistry.Registrar registrar = context.getRegistrar();
 

--- a/android/src/main/java/com/baseflow/geolocator/tasks/LocationUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/LocationUsingLocationServicesTask.java
@@ -1,12 +1,14 @@
 package com.baseflow.geolocator.tasks;
 
+import androidx.annotation.Nullable;
 import com.baseflow.geolocator.data.LocationOptions;
+import java.util.UUID;
 
 abstract class LocationUsingLocationServicesTask extends Task<LocationOptions> {
     final LocationOptions mLocationOptions;
 
-    LocationUsingLocationServicesTask(TaskContext<LocationOptions> taskContext) {
-        super(taskContext);
+    LocationUsingLocationServicesTask(@Nullable UUID taskID, TaskContext<LocationOptions> taskContext) {
+        super(taskID, taskContext);
 
         mLocationOptions = taskContext.getOptions();
     }

--- a/android/src/main/java/com/baseflow/geolocator/tasks/ReverseGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/ReverseGeocodingTask.java
@@ -24,7 +24,7 @@ class ReverseGeocodingTask extends Task<ReverseGeocodingOptions> {
   private Locale mLocale;
 
   ReverseGeocodingTask(TaskContext<ReverseGeocodingOptions> context) {
-    super(context);
+    super(null, context);
 
     PluginRegistry.Registrar registrar = context.getRegistrar();
 

--- a/android/src/main/java/com/baseflow/geolocator/tasks/Task.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/Task.java
@@ -8,6 +8,8 @@ public abstract class Task<TOptions> {
     private final UUID mTaskID;
     private final TaskContext<TOptions> mTaskContext;
 
+    private boolean stopped = false;
+
     Task(TaskContext<TOptions> context) {
         mTaskID = UUID.randomUUID();
         mTaskContext = context;
@@ -29,5 +31,11 @@ public abstract class Task<TOptions> {
         if(completionListener != null) {
             completionListener.onCompletion(getTaskID());
         }
+
+        stopped = true;
+    }
+
+    public boolean isStopped() {
+        return stopped;
     }
 }

--- a/android/src/main/java/com/baseflow/geolocator/tasks/Task.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/Task.java
@@ -1,5 +1,6 @@
 package com.baseflow.geolocator.tasks;
 
+import androidx.annotation.Nullable;
 import com.baseflow.geolocator.OnCompletionListener;
 
 import java.util.UUID;
@@ -8,10 +9,12 @@ public abstract class Task<TOptions> {
     private final UUID mTaskID;
     private final TaskContext<TOptions> mTaskContext;
 
-    private boolean stopped = false;
-
-    Task(TaskContext<TOptions> context) {
-        mTaskID = UUID.randomUUID();
+    Task(@Nullable UUID taskID, TaskContext<TOptions> context) {
+        if (taskID == null) {
+            mTaskID = UUID.randomUUID();
+        } else {
+            mTaskID = taskID;
+        }
         mTaskContext = context;
     }
 
@@ -31,11 +34,5 @@ public abstract class Task<TOptions> {
         if(completionListener != null) {
             completionListener.onCompletion(getTaskID());
         }
-
-        stopped = true;
-    }
-
-    public boolean isStopped() {
-        return stopped;
     }
 }

--- a/android/src/main/java/com/baseflow/geolocator/tasks/TaskFactory.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/TaskFactory.java
@@ -9,6 +9,7 @@ import com.baseflow.geolocator.data.ReverseGeocodingOptions;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry;
+import java.util.UUID;
 
 public class TaskFactory {
   public static Task<CalculateDistanceOptions> createCalculateDistanceTask(
@@ -28,6 +29,7 @@ public class TaskFactory {
   }
 
   public static Task<LocationOptions> createCurrentLocationTask(
+      String taskID,
       PluginRegistry.Registrar registrar,
       MethodChannel.Result result,
       Object arguments,
@@ -42,10 +44,12 @@ public class TaskFactory {
 
     if (!options.isForceAndroidLocationManager()) {
       return new LocationUpdatesUsingLocationServicesTask(
+          UUID.fromString(taskID),
           taskContext,
           true);
     } else {
       return new LocationUpdatesUsingLocationManagerTask(
+          UUID.fromString(taskID),
           taskContext,
           true);
     }
@@ -68,6 +72,7 @@ public class TaskFactory {
   }
 
   public static Task<LocationOptions> createLastKnownLocationTask(
+      String taskID,
       PluginRegistry.Registrar registrar,
       MethodChannel.Result result,
       Object arguments,
@@ -81,9 +86,9 @@ public class TaskFactory {
         completionListener);
 
     if (!options.isForceAndroidLocationManager()) {
-      return new LastKnownLocationUsingLocationServicesTask(taskContext);
+      return new LastKnownLocationUsingLocationServicesTask(UUID.fromString(taskID), taskContext);
     } else {
-      return new LastKnownLocationUsingLocationManagerTask(taskContext);
+      return new LastKnownLocationUsingLocationManagerTask(UUID.fromString(taskID), taskContext);
     }
   }
 
@@ -118,10 +123,12 @@ public class TaskFactory {
 
     if (!options.isForceAndroidLocationManager()) {
       return new LocationUpdatesUsingLocationServicesTask(
+          null,
           taskContext,
           false);
     } else {
       return new LocationUpdatesUsingLocationManagerTask(
+          null,
           taskContext,
           false);
     }

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -183,7 +183,6 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 7624MWN53C;
 					};
 				};
 			};
@@ -275,15 +274,11 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../.symlinks/flutter/ios-release/Flutter.framework",
+				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 			);
@@ -384,7 +379,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 7624MWN53C;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -516,7 +511,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 7624MWN53C;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -540,7 +535,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 7624MWN53C;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'pages/calculate_distance_widget.dart';
@@ -6,7 +8,7 @@ import 'pages/location_stream_widget.dart';
 
 void main() => runApp(GeolocatorExampleApp());
 
-enum TabItem { singleLocation, locationStream, distance }
+enum TabItem { singleLocation, singleFusedLocation, locationStream, distance }
 
 class GeolocatorExampleApp extends StatefulWidget {
   @override
@@ -35,9 +37,11 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
         return LocationStreamWidget();
       case TabItem.distance:
         return CalculateDistanceWidget();
+      case TabItem.singleFusedLocation:
+        return CurrentLocationWidget(androidFusedLocation: true);
       case TabItem.singleLocation:
       default:
-        return CurrentLocationWidget();
+        return CurrentLocationWidget(androidFusedLocation: false);
     }
   }
 
@@ -47,6 +51,9 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
       items: <BottomNavigationBarItem>[
         _buildBottomNavigationBarItem(
             Icons.location_on, TabItem.singleLocation),
+        if (Platform.isAndroid)
+          _buildBottomNavigationBarItem(
+              Icons.location_on, TabItem.singleFusedLocation),
         _buildBottomNavigationBarItem(Icons.clear_all, TabItem.locationStream),
         _buildBottomNavigationBarItem(Icons.redo, TabItem.distance),
       ],
@@ -78,14 +85,20 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
     TabItem selectedTabItem;
 
     switch (index) {
+      case 0:
+        selectedTabItem = TabItem.singleLocation;
+        break;
       case 1:
-        selectedTabItem = TabItem.locationStream;
+        selectedTabItem = Platform.isAndroid
+            ? TabItem.singleFusedLocation
+            : TabItem.locationStream;
         break;
       case 2:
-        selectedTabItem = TabItem.distance;
+        selectedTabItem =
+            Platform.isAndroid ? TabItem.locationStream : TabItem.distance;
         break;
       default:
-        selectedTabItem = TabItem.singleLocation;
+        selectedTabItem = TabItem.distance;
     }
 
     setState(() {

--- a/example/lib/pages/current_location_widget.dart
+++ b/example/lib/pages/current_location_widget.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:geolocator/geolocator.dart';
 
 import '../common_widgets/placeholder_widget.dart';
@@ -47,34 +46,40 @@ class _LocationState extends State<CurrentLocationWidget> {
 
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> _initLastKnownLocation() async {
-    Geolocator()
-      ..forceAndroidLocationManager = !widget.androidFusedLocation
-      ..getLastKnownPosition(
-        desiredAccuracy: LocationAccuracy.best,
-        timeout: Duration(seconds: 5),
-      ).then((position) {
-        if (mounted) {
-          setState(() => _lastKnownPosition = position);
-        }
-      }).catchError((e) {
-        //
-      });
+    final geolocator = Geolocator()
+      ..forceAndroidLocationManager = !widget.androidFusedLocation;
+
+    await geolocator
+        .getLastKnownPosition(
+      desiredAccuracy: LocationAccuracy.best,
+      timeout: Duration(seconds: 5),
+    )
+        .then((position) {
+      if (mounted) {
+        setState(() => _lastKnownPosition = position);
+      }
+    }).catchError((e) {
+      //
+    });
   }
 
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> _initCurrentLocation() async {
-    Geolocator()
-      ..forceAndroidLocationManager = !widget.androidFusedLocation
-      ..getCurrentPosition(
-        desiredAccuracy: LocationAccuracy.best,
-        timeout: Duration(seconds: 5),
-      ).then((position) {
-        if (mounted) {
-          setState(() => _currentPosition = position);
-        }
-      }).catchError((e) {
-        //
-      });
+    final geolocator = Geolocator()
+      ..forceAndroidLocationManager = !widget.androidFusedLocation;
+
+    await geolocator
+        .getCurrentPosition(
+      desiredAccuracy: LocationAccuracy.best,
+      timeout: Duration(seconds: 5),
+    )
+        .then((position) {
+      if (mounted) {
+        setState(() => _currentPosition = position);
+      }
+    }).catchError((e) {
+      //
+    });
   }
 
   @override

--- a/example/lib/pages/current_location_widget.dart
+++ b/example/lib/pages/current_location_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:geolocator/geolocator.dart';
@@ -5,6 +7,15 @@ import 'package:geolocator/geolocator.dart';
 import '../common_widgets/placeholder_widget.dart';
 
 class CurrentLocationWidget extends StatefulWidget {
+  const CurrentLocationWidget({
+    Key key,
+
+    /// If set, enable the FusedLocationProvider on Android
+    @required this.androidFusedLocation,
+  }) : super(key: key);
+
+  final bool androidFusedLocation;
+
   @override
   _LocationState createState() => _LocationState();
 }
@@ -16,6 +27,20 @@ class _LocationState extends State<CurrentLocationWidget> {
   @override
   void initState() {
     super.initState();
+
+    _initLastKnownLocation();
+    _initCurrentLocation();
+  }
+
+  @override
+  void didUpdateWidget(Widget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    setState(() {
+      _lastKnownPosition = null;
+      _currentPosition = null;
+    });
+
     _initLastKnownLocation();
     _initCurrentLocation();
   }
@@ -26,7 +51,7 @@ class _LocationState extends State<CurrentLocationWidget> {
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
       final Geolocator geolocator = Geolocator()
-        ..forceAndroidLocationManager = true;
+        ..forceAndroidLocationManager = !widget.androidFusedLocation;
       position = await geolocator.getLastKnownPosition(
           desiredAccuracy: LocationAccuracy.best);
     } on PlatformException {
@@ -47,27 +72,23 @@ class _LocationState extends State<CurrentLocationWidget> {
 
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> _initCurrentLocation() async {
-    Position position;
-    // Platform messages may fail, so we use a try/catch PlatformException.
-    try {
-      final Geolocator geolocator = Geolocator()
-        ..forceAndroidLocationManager = true;
-      position = await geolocator.getCurrentPosition(
-          desiredAccuracy: LocationAccuracy.best);
-    } on PlatformException {
-      position = null;
-    }
-
-    // If the widget was removed from the tree while the asynchronous platform
-    // message was in flight, we want to discard the reply rather than calling
-    // setState to update our non-existent appearance.
-    if (!mounted) {
-      return;
-    }
-
-    setState(() {
-      _currentPosition = position;
-    });
+    // This timeout is managed by the Geolocator plugin internally.
+    // The FusedLocationProvider in Android will account for accurate & quick readings - therefore timeouts are not needed.
+    // If Geolocator uses the raw GPS sensor though, no data can be returned until the phone has an GPS signal (line of sight with the satellites).
+    final Duration timeout =
+        widget.androidFusedLocation ? Duration.zero : Duration(seconds: 5);
+    Geolocator()
+      ..forceAndroidLocationManager = !widget.androidFusedLocation
+      ..getCurrentPosition(
+        desiredAccuracy: LocationAccuracy.best,
+        timeout: timeout,
+      ).then((position) {
+        if (mounted) {
+          setState(() => _currentPosition = position);
+        }
+      }).catchError((e) {
+        //
+      });
   }
 
   @override
@@ -90,6 +111,16 @@ class _LocationState extends State<CurrentLocationWidget> {
               crossAxisAlignment: CrossAxisAlignment.center,
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 32,
+                    vertical: 16,
+                  ),
+                  child: Text(
+                    _fusedLocationNote(),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
                 PlaceholderWidget(
                     'Last known location:', _lastKnownPosition.toString()),
                 PlaceholderWidget(
@@ -98,5 +129,13 @@ class _LocationState extends State<CurrentLocationWidget> {
             ),
           );
         });
+  }
+
+  String _fusedLocationNote() {
+    if (widget.androidFusedLocation) {
+      return 'Geolocator is using the Android FusedLocationProvider. This requires Google Play Services to be installed on the target device.';
+    }
+
+    return 'Geolocator is using the raw location manager classes shipped with the operating system.';
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the geolocator plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
   flutter:

--- a/ios/Classes/GeolocatorPlugin.m
+++ b/ios/Classes/GeolocatorPlugin.m
@@ -29,7 +29,21 @@ NSString *const EVENT_CHANNEL_NAME = @"flutter.baseflow.com/geolocator/events";
         [self->_tasks removeObjectForKey:taskID];
     };
     
-    if ([call.method isEqualToString:@"getCurrentPosition"]) {
+    if ([call.method isEqualToString:@"_createTask"]) {
+        result([[[NSUUID alloc] init] UUIDString]);
+    } else if ([call.method isEqualToString:@"_stopTask"]) {
+        NSString *taskID = call.arguments;
+        if (taskID != nil) {
+            NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:taskID];
+            if (_tasks[uuid] != nil) {
+                NSLog(@"got one!");
+                [_tasks[uuid] stopTask];
+            }
+            result([NSNumber numberWithBool:_tasks[uuid] != nil]);
+        } else {
+            result([FlutterError errorWithCode:@"INVALID_TASK_ID" message:@"This is a internal Geolocator error." details:nil]);
+        }
+    } else if ([call.method isEqualToString:@"getCurrentPosition"]) {
         [self executeTask:[[CurrentLocationTask alloc] initWithContext:[self buildTaskContext:call.arguments resultHandler:result] completionHandler:completionAction]];
     } else if ([call.method isEqualToString:@"getLastKnownPosition"]) {
         [self executeTask:[[LastKnownLocationTask alloc] initWithContext:[self buildTaskContext:call.arguments resultHandler:result] completionHandler:completionAction]];

--- a/ios/Classes/Tasks/Task.h
+++ b/ios/Classes/Tasks/Task.h
@@ -17,6 +17,7 @@
 @property TaskContext *context;
 @property CompletionHandler completionHandler;
 
+- (instancetype)initWithTaskID:(NSUUID*)taskID context:(TaskContext *)context completionHandler:(CompletionHandler)completionHandler;
 - (instancetype)initWithContext:(TaskContext *)context completionHandler:(CompletionHandler)completionHandler;
 
 - (void)stopTask;

--- a/ios/Classes/Tasks/Task.m
+++ b/ios/Classes/Tasks/Task.m
@@ -9,6 +9,17 @@
 
 @implementation Task
 
+- (instancetype)initWithTaskID:(NSUUID *)taskID context:(TaskContext *)context completionHandler:(CompletionHandler)completionHandler {
+    self = [super init];
+    if (self) {
+        self.context = context;
+        self.completionHandler = completionHandler;
+        self.taskID = taskID;
+    }
+    
+    return self;
+}
+
 - (instancetype)initWithContext:(TaskContext *)context completionHandler:(CompletionHandler)completionHandler {
     self = [super init];
     if (self) {

--- a/lib/models/location_options.dart
+++ b/lib/models/location_options.dart
@@ -3,11 +3,13 @@ part of geolocator;
 /// Represents different options to configure the quality and frequency
 /// of location updates.
 class LocationOptions {
-  const LocationOptions(
-      {this.accuracy = LocationAccuracy.best,
-      this.distanceFilter = 0,
-      this.forceAndroidLocationManager = false,
-      this.timeInterval = 0});
+  const LocationOptions({
+    this.accuracy = LocationAccuracy.best,
+    this.distanceFilter = 0,
+    this.forceAndroidLocationManager = false,
+    this.timeInterval = 0,
+    this.timeout = 0,
+  });
 
   /// Defines the desired accuracy that should be used to determine the location data.
   ///
@@ -28,4 +30,11 @@ class LocationOptions {
   ///
   /// On iOS this value is ignored since position updates based on time intervals are not supported.
   final int timeInterval;
+
+  /// The timeout for a single location request.
+  ///
+  /// The request will either finish successfully within the timeout, or return `null` when its expired.
+  ///
+  /// On iOS this value currently ignored.
+  final int timeout;
 }

--- a/lib/models/location_options.dart
+++ b/lib/models/location_options.dart
@@ -8,7 +8,6 @@ class LocationOptions {
     this.distanceFilter = 0,
     this.forceAndroidLocationManager = false,
     this.timeInterval = 0,
-    this.timeout = 0,
   });
 
   /// Defines the desired accuracy that should be used to determine the location data.
@@ -30,11 +29,4 @@ class LocationOptions {
   ///
   /// On iOS this value is ignored since position updates based on time intervals are not supported.
   final int timeInterval;
-
-  /// The timeout for a single location request.
-  ///
-  /// The request will either finish successfully within the timeout, or return `null` when its expired.
-  ///
-  /// On iOS this value currently ignored.
-  final int timeout;
 }

--- a/lib/utils/codec.dart
+++ b/lib/utils/codec.dart
@@ -8,6 +8,7 @@ class Codec {
         'distanceFilter': locationOptions.distanceFilter,
         'forceAndroidLocationManager':
             locationOptions.forceAndroidLocationManager,
-        'timeInterval': locationOptions.timeInterval
+        'timeInterval': locationOptions.timeInterval,
+        'timeout': locationOptions.timeout,
       };
 }

--- a/lib/utils/codec.dart
+++ b/lib/utils/codec.dart
@@ -9,6 +9,5 @@ class Codec {
         'forceAndroidLocationManager':
             locationOptions.forceAndroidLocationManager,
         'timeInterval': locationOptions.timeInterval,
-        'timeout': locationOptions.timeout,
       };
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Baseflow <hello@baseflow.com>
 homepage: https://github.com/baseflowit/flutter-geolocator
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bugfix & Features

### :arrow_heading_down: What is the current behavior?

The PR solves a few things, but it started with:
I noticed that my phone would never switch off the GPS antenna when retrieving the location. The root cause was that `geolocator` tried to fetch the position through Androids LocationManager class. My office has no GPS signal, therefore the call would run forever. I attached a timeout to the Dart future (which worked), but the location request would stay because the actual Task was not closed when the Dart Future was cancelled.
As a workaround, I added a timeout option to the getCurrentPosition call and extended the Android Location Task.

To test everything, a few other things were needed:
 - The example needed an additional page for the FusedLocationProvider on Android.
 - The previous implementation of getCurrentPosition would keep the task queue busy by having a `await` call in there, which I tried to avoid.

The PR should probably be split before continuing. Will put it through test.

#### RFC from the maintainer 

Looking back at the PR, I think the introduction of a internal `timeout` field (and the os Handler etc) may not be the best way.
I'd very much prefer to use Darts `.timeout` method on a Future. To use it successfully though, a bit of the task management has to be moved into the Dart side.
For comparison, this PR enables code like this:
``` dart
Geolocator()
  ..forceAndroidLocationManager = false
  ..getCurrentPosition(
    desiredAccuracy: LocationAccuracy.best,
    timeout: Duration(seconds: 5),
  ).then((position) {
    if (mounted) {
      setState(() => _currentPosition = position);
    }
  }).catchError((e) {
    //
  });
```

However, it would be a lot better if Dart could specify the timeout like so:

``` dart
Geolocator()
  ..forceAndroidLocationManager = false
  ..getCurrentPosition(
    desiredAccuracy: LocationAccuracy.best,
  ).timeout(Duration(seconds: 5)).then((position) {
    if (mounted) {
      setState(() => _currentPosition = position);
    }
  }).catchError((e) {
    //
  });
```

Using the below way would be better as the error is not library-defined ("just return null on timeout") and Dart could raise its `TimeoutException` properly. To make that work, the Geolocator API internally would fetch a `TaskID` first, then start a task with that task ID and install a `whenComplete` handler on the returned future to cancel the task.

This comes with another set of problems though - namely what should happen when the Dart side disappears completely (e.g. the UI/ Activity is killed), and the location provider still runs in the background.

### :new: What is the new behavior (if this is a feature change)?

Added `timeout` option to `getCurrentPosition` API.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

This will need to be tested indoors / outdoors in high GPS and no-GPS situations.

### :memo: Links to relevant issues/docs

#248 
#242 
#199 
#135 
#123 

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [ ] Rebased onto current develop