### PR TITLE
Keep trying to get the location when receive a kCLErrorLocationUnknown error.

### DIFF
--- a/ios/Classes/Tasks/LocationTask.m
+++ b/ios/Classes/Tasks/LocationTask.m
@@ -59,7 +59,8 @@
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
     NSLog(@"%s", sel_getName(_cmd));
-    [[self context] resultHandler]([FlutterError errorWithCode:@"ERROR_UPDATING_LOCATION" message:error.localizedDescription details:nil]);
+    if([error.domain isEqualToString:kCLErrorDomain] && error.code == kCLErrorLocationUnknown) return;
+    [[self context] resultHandler]([FlutterError errorWithCode:@"ERROR_UPDATING_LOCATION" message:error.localizedDescription details:@(error.code)]);
     [self stopTask];
 }
 

--- a/ios/Classes/Tasks/LocationTask.m
+++ b/ios/Classes/Tasks/LocationTask.m
@@ -59,7 +59,10 @@
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
     NSLog(@"%s", sel_getName(_cmd));
-    if([error.domain isEqualToString:kCLErrorDomain] && error.code == kCLErrorLocationUnknown) return;
+    if([error.domain isEqualToString:kCLErrorDomain] && error.code == kCLErrorLocationUnknown) {
+        return;
+    }
+    
     [[self context] resultHandler]([FlutterError errorWithCode:@"ERROR_UPDATING_LOCATION" message:error.localizedDescription details:@(error.code)]);
     [self stopTask];
 }


### PR DESCRIPTION
My some customers complain about can not get the location always.
After check the error logs. I found that they received kCLErrorLocationUnknown error shortly after starting get location  again and again.

As iOS SDK doc said, I think keep trying to get the location when receive a kCLErrorLocationUnknown error can resolve this problem.

iOS SDK doc said:

- (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error;
Discussion

If the location service is unable to retrieve a location right away, it reports a kCLErrorLocationUnknown error and keeps trying. In such a situation, you can simply ignore the error and wait for a new event.
