### PR TITLE
Update location_permissions and google_api_availability plugins

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,9 @@
-include: package:pedantic/analysis_options.1.7.0.yaml
+include: package:pedantic/analysis_options.1.8.0.yaml
+analyzer:
+  exclude:
+    # Ignore generated files
+    - '**/*.g.dart'
+    - 'lib/src/generated/*.dart'
+linter:
+  rules:
+    - public_member_api_docs

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,15 +13,15 @@ dependencies:
 
   meta: ^1.1.6
 
-  google_api_availability: ^2.0.1
-  location_permissions: ^2.0.3
+  google_api_availability: ^2.0.2
+  location_permissions: ^2.0.4
   vector_math: ^2.0.8
 
 dev_dependencies:
   flutter_test:
     sdk: flutter  
 
-  pedantic: ^1.7.0
+  pedantic: ^1.8.0+1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   meta: ^1.1.6
 
   google_api_availability: ^2.0.2
-  location_permissions: ^2.0.4
+  location_permissions: ^2.0.4+1
   vector_math: ^2.0.8
 
 dev_dependencies:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Update dependencies

### :arrow_heading_down: What is the current behavior?

Geolocator relies on outdated versions of the `google_api_availability` and `location_permissions` plugins.

### :new: What is the new behavior (if this is a feature change)?

Updated the plugins to the latest versions.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop