### PR TITLE
Grammatical fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/geolocator.svg)](https://pub.dartlang.org/packages/geolocator) [![Build Status](https://app.bitrise.io/app/b0e244f2c82e1678/status.svg?token=x6sBRHLW05ymIpW-dVJlgQ&branch=master)](https://app.bitrise.io/app/b0e244f2c82e1678) [![codecov](https://codecov.io/gh/Baseflow/flutter-geolocator/branch/master/graph/badge.svg)](https://codecov.io/gh/Baseflow/flutter-geolocator)
 
-A Flutter geolocation plugin which provides easy access to the platform specific location services ([FusedLocationProviderClient](https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderClient) or if not available the [LocationManager](https://developer.android.com/reference/android/location/LocationManager) on Android and [CLLocationManager](https://developer.apple.com/documentation/corelocation/cllocationmanager) on iOS).
+A Flutter geolocation plugin which provides easy access to platform specific location services ([FusedLocationProviderClient](https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderClient) or if not available the [LocationManager](https://developer.android.com/reference/android/location/LocationManager) on Android and [CLLocationManager](https://developer.apple.com/documentation/corelocation/cllocationmanager) on iOS).
 
 
 ## Features
@@ -13,9 +13,9 @@ A Flutter geolocation plugin which provides easy access to the platform specific
 * Check if location services are enabled on the device;
 * Translate an address to geocoordinates and vice verse (a.k.a. Geocoding);
 * Calculate the distance (in meters) between two geocoordinates;
-* Check the availability of Google Play services (on Android only).
+* Check the availability of Google Play Services (on Android only).
 
-**Note**: The availability of the Google Play Services depends on your country. If your country doesn't support a connection with the Google Play Services, you need to try a VPN to establish a connection. For more information about how to work with Google Play Services visit the following link: https://developers.google.com/android/guides/overview 
+**Note**: The availability of the Google Play Services depends on your country. If your country doesn't support a connection with the Google Play Services, you'll need to try a VPN to establish a connection. For more information about how to work with Google Play Services visit the following link: https://developers.google.com/android/guides/overview 
 
 ## Usage
 
@@ -70,7 +70,7 @@ Position position = await Geolocator().getLastKnownPosition(desiredAccuracy: Loc
 ```
 
 To listen for location changes you can subscribe to the `onPositionChanged` stream. Supply an instance of the `LocationOptions` class to configure
-the desired accuracy and the minimum distance change (in meters) before updates are send to the application.
+the desired accuracy and the minimum distance change (in meters) before updates are sent to the application.
 
 ``` dart
 import 'package:geolocator/geolocator.dart';
@@ -101,7 +101,7 @@ Geolocator geolocator = Geolocator()..forceAndroidLocationManager = true;
 GeolocationStatus geolocationStatus  = await geolocator.checkGeolocationPermissionStatus();
 ```
 
-To check if location services are enabled(Location Service(GPS) turned on) on the device `checkGeolocationPermissionStatus` will return `disabled` state if location service feature is disabled (or not available) on the device.
+To check if location services are enabled (Location Service(GPS) turned on) on the device, the `checkGeolocationPermissionStatus` method will return `disabled` state if location service feature is disabled (or not available) on the device.
 
 ### Geocoding
 
@@ -121,7 +121,7 @@ import 'package:geolocator/geolocator.dart';
 List<Placemark> placemark = await Geolocator().placemarkFromCoordinates(52.2165157, 6.9437819);
 ```
 
-Both the `placemarkFromAddress` and `placemarkFromCoordinates` accept an optional `localeIdentifier` parameter. This paramter can be used to enforce the resulting placemark to be formatted (and translated) according to the specified locale. The `localeIdentifier` should be formatted using the syntax: [languageCode]_[countryCode]. Use the [ISO 639-1 or ISO 639-2](http://www.loc.gov/standards/iso639-2/php/English_list.php) standard for the language code and the 2 letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) standard for the country code. Some examples are:
+Both the `placemarkFromAddress` and `placemarkFromCoordinates` accept an optional `localeIdentifier` parameter. This parameter can be used to enforce the resulting placemark to be formatted (and translated) according to the specified locale. The `localeIdentifier` should be formatted using the syntax: [languageCode]_[countryCode]. Use the [ISO 639-1 or ISO 639-2](http://www.loc.gov/standards/iso639-2/php/English_list.php) standard for the language code and the 2 letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) standard for the country code. Some examples are:
 
 Locale identifier | Description
 ----------------- | -----------
@@ -196,7 +196,7 @@ The table below outlines the accuracy options per platform:
 
 ## Issues
 
-Please file any issues, bugs or feature request as an issue on our [GitHub](https://github.com/BaseflowIT/flutter-geolocator/issues) page.
+Please file any issues, bugs or feature requests as an issue on our [GitHub](https://github.com/BaseflowIT/flutter-geolocator/issues) page.
 
 ## Want to contribute
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update. 

### :arrow_heading_down: What is the current behavior?
Line 5: The 'the' is unnecessary. 
Line 16: 'Services' is not capitalized, but when it is used elsewhere it is, plus Google Play Services is a proper noun.
Line 18: You will need to try a VPN to establish a connection.
Line 73: Send should be sent. 
Line 104: Added a space between a word and an opening parentheses, also checkGeolocationPermissionStatus is a method so referring to it as such improves clarity.
Line 199: Issues and bugs are plural, and there could potentially be multiple feature requests!



### :new: What is the new behavior (if this is a feature change)?
Improves documentations.

### :boom: Does this PR introduce a breaking change?
Nope.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop

notes: 
This is my first pull request, I just got involved in web/mobile development, currently I'm working on code that uses Geolocator, and I am a bit of a stickler for grammatically accurate markup. I think it helps brands build trust. If I see a grammatical issue I tend to want to tell the author for their sake. The change on line 18 isn't necessarily grammatical, but I believe it reads better this way. Have a wonderful day!