### PR TITLE
Update path in ios permissions instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ On Android you'll need to add either the `ACCESS_COARSE_LOCATION` or the `ACCESS
 
 ### iOS
 
-On iOS you'll need to add the `NSLocationWhenInUseUsageDescription` to your Info.plist file (located under ios/Runner/Base.lproj) in order to access the device's location. Simply open your Info.plist file and add the following:
+On iOS you'll need to add the `NSLocationWhenInUseUsageDescription` to your Info.plist file (located under ios/Runner) in order to access the device's location. Simply open your Info.plist file and add the following:
 
 ``` xml
 <key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
the README.md has the path `ios/Runner/Base.lproj` but Info.plist is found in `ios/Runner/`

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
docs update

### :arrow_heading_down: What is the current behavior?
the README.md has the path `ios/Runner/Base.lproj`

### :new: What is the new behavior (if this is a feature change)?
the path to Info.plist is corrected to `ios/Runner/`

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
none

### :memo: Links to relevant issues/docs
examples in https://github.com/flutter/flutter/tree/master/examples have the Info.plist file in <project-root>/ios/Runner/Info.plist

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x ] Relevant documentation was updated
- [x] Rebased onto current develop