### PR TITLE
Added checkPermissions to Android

### DIFF
--- a/geolocator/android/build.gradle
+++ b/geolocator/android/build.gradle
@@ -22,12 +22,16 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 16
     }
     lintOptions {
         disable 'InvalidPackage'
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/Geolocator.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/Geolocator.java
@@ -1,0 +1,9 @@
+package com.baseflow.geolocator;
+
+import android.content.Context;
+
+class Geolocator {
+    Geolocator(){
+
+    }
+}

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -1,53 +1,100 @@
 package com.baseflow.geolocator;
 
+import android.app.Activity;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.embedding.engine.plugins.activity.ActivityAware;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
-/** GeolocatorPlugin */
-public class GeolocatorPlugin implements FlutterPlugin, MethodCallHandler {
-  /// The MethodChannel that will the communication between Flutter and native Android
-  ///
-  /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-  /// when the Flutter Engine is detached from the Activity
-  private MethodChannel channel;
+/**
+ * GeolocatorPlugin
+ */
+public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
+    private static final String TAG = "GeocodingPlugin";
+    @Nullable
+    private MethodCallHandlerImpl methodCallHandler;
 
-  @Override
-  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
-    channel = new MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "geolocator");
-    channel.setMethodCallHandler(this);
-  }
+    // This static function is optional and equivalent to onAttachedToEngine. It supports the old
+    // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
+    // plugin registration via this function while apps migrate to use the new Android APIs
+    // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
+    //
+    // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
+    // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
+    // depending on the user's project. onAttachedToEngine or registerWith must both be defined
+    // in the same class.
+    public static void registerWith(Registrar registrar) {
+        MethodCallHandlerImpl handler = new MethodCallHandlerImpl();
+        handler.startListening(registrar.activeContext(), registrar.messenger());
 
-  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-  // plugin registration via this function while apps migrate to use the new Android APIs
-  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-  //
-  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-  // in the same class.
-  public static void registerWith(Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), "geolocator");
-    channel.setMethodCallHandler(new GeolocatorPlugin());
-  }
-
-  @Override
-  public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
-    if (call.method.equals("getPlatformVersion")) {
-      result.success("Android " + android.os.Build.VERSION.RELEASE);
-    } else {
-      result.notImplemented();
+        if (registrar.activeContext() instanceof Activity) {
+            handler.startListeningToActivity(
+                    registrar.activity(),
+                    registrar::addActivityResultListener,
+                    registrar::addRequestPermissionsResultListener
+            );
+        }
     }
-  }
 
-  @Override
-  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    channel.setMethodCallHandler(null);
-  }
+    @Override
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
+        methodCallHandler = new MethodCallHandlerImpl();
+        methodCallHandler.startListening(
+                flutterPluginBinding.getApplicationContext(),
+                flutterPluginBinding.getBinaryMessenger());
+    }
+
+    @Override
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+        if (methodCallHandler == null) {
+            Log.wtf(TAG, "Already detached from the engine.");
+            return;
+        }
+
+        methodCallHandler.stopListening();
+        methodCallHandler = null;
+    }
+
+    @Override
+    public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
+        if (methodCallHandler == null) {
+            Log.wtf(TAG, "Not attached to engine while attaching to activity");
+            return;
+        }
+
+        methodCallHandler.startListeningToActivity(
+                binding.getActivity(),
+                binding::addActivityResultListener,
+                binding::addRequestPermissionsResultListener
+        );
+    }
+
+    @Override
+    public void onDetachedFromActivityForConfigChanges() {
+        onDetachedFromActivity();
+    }
+
+    @Override
+    public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
+        onAttachedToActivity(binding);
+    }
+
+    @Override
+    public void onDetachedFromActivity() {
+        if (methodCallHandler == null) {
+            Log.wtf(TAG, "Not attached to engine while detaching from activity");
+            return;
+        }
+
+        methodCallHandler.stopListeningToActivity();
+    }
 }

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
@@ -1,0 +1,119 @@
+package com.baseflow.geolocator;
+
+import android.app.Activity;
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.baseflow.geolocator.errors.ErrorCodes;
+import com.baseflow.geolocator.errors.PermissionUndefinedException;
+import com.baseflow.geolocator.permission.LocationPermission;
+import com.baseflow.geolocator.permission.PermissionManager;
+
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+
+/**
+ * Translates incoming Geolocator MethodCalls into well formed Java function calls for {@link
+ * Geolocator}.
+ */
+class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
+    private static final String TAG = "MethodCallHandlerImpl";
+    private final Geolocator geolocator;
+    private final PermissionManager permissionManager;
+
+    @Nullable
+    private Context context;
+
+    @Nullable
+    private Activity activity;
+
+    @Nullable
+    private PermissionManager.ActivityRegistry activityRegistry;
+
+    @Nullable
+    private PermissionManager.PermissionRegistry permissionRegistry;
+
+
+    MethodCallHandlerImpl() {
+        this.geolocator = new Geolocator();
+        this.permissionManager = new PermissionManager();
+    }
+
+    @Nullable
+    private MethodChannel channel;
+
+    @Override
+    public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+        switch (call.method) {
+            case "checkPermission":
+                onCheckPermission(call, result);
+                break;
+            default:
+                result.notImplemented();
+                break;
+        }
+    }
+
+    /**
+     * Registers this instance as a method call handler on the given {@code messenger}.
+     *
+     * <p>Stops any previously started and unstopped calls.
+     *
+     * <p>This should be cleaned with {@link #stopListening} once the messenger is disposed of.
+     */
+    void startListening(Context context, BinaryMessenger messenger) {
+        if (channel != null) {
+            Log.wtf(TAG, "Setting a method call handler before the last was disposed.");
+            stopListening();
+        }
+
+        channel = new MethodChannel(messenger, "flutter.baseflow.com/geolocator");
+        channel.setMethodCallHandler(this);
+        this.context = context;
+    }
+
+    /**
+     * Clears this instance from listening to method calls.
+     *
+     * <p>Does nothing if {@link #startListening} hasn't been called, or if we're already stopped.
+     */
+    void stopListening() {
+        if (channel == null) {
+            Log.d(TAG, "Tried to stop listening when no MethodChannel had been initialized.");
+            return;
+        }
+
+        channel.setMethodCallHandler(null);
+        channel = null;
+    }
+
+    void startListeningToActivity(
+            Activity activity,
+            PermissionManager.ActivityRegistry activityRegistry,
+            PermissionManager.PermissionRegistry permissionRegistry) {
+        this.activity = activity;
+        this.activityRegistry = activityRegistry;
+        this.permissionRegistry = permissionRegistry;
+    }
+
+    void stopListeningToActivity() {
+        activity = null;
+        activityRegistry = null;
+        permissionRegistry = null;
+    }
+
+    private void onCheckPermission(MethodCall call, MethodChannel.Result result) {
+        try {
+            LocationPermission permission = permissionManager.checkPermissionStatus(context, activity);
+            result.success(permission.toInt());
+        } catch (PermissionUndefinedException e) {
+            result.error(ErrorCodes.GeolocatorErrorPermissionDefinitionsNotFound,
+                    "No location permissions are defined in the manifest. Make sure at least ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION are defined in the manifest",
+                    null);
+        }
+    }
+}

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/errors/ErrorCallback.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/errors/ErrorCallback.java
@@ -1,0 +1,6 @@
+package com.baseflow.geolocator.errors;
+
+@FunctionalInterface
+public interface ErrorCallback {
+    void onError(String errorCode, String errorDescription);
+}

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/errors/ErrorCodes.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/errors/ErrorCodes.java
@@ -1,0 +1,8 @@
+package com.baseflow.geolocator.errors;
+
+public class ErrorCodes {
+    public final static String GeolocatorErrorLocationServicesDisabled = "LOCATION_SERVICES_DISABLED";
+    public final static String GeolocatorErrorPermissionDefinitionsNotFound = "PERMISSION_DEFINITIONS_NOT_FOUND";
+    public final static String GeolocatorErrorPermissionDenied = "PERMISSION_DENIED";
+    public final static String GeolocatorErrorPermissionRequestInProgress = "PERMISSION_REQUEST_IN_PROGRESS";
+}

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/errors/PermissionUndefinedException.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/errors/PermissionUndefinedException.java
@@ -1,0 +1,4 @@
+package com.baseflow.geolocator.errors;
+
+public class PermissionUndefinedException extends Exception {
+}

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/permission/LocationPermission.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/permission/LocationPermission.java
@@ -1,0 +1,37 @@
+package com.baseflow.geolocator.permission;
+
+public enum LocationPermission {
+    /// Permission to access the device's location is denied by the user.
+    denied,
+    /// Permission to access the device's location is denied for ever. The
+    /// permission dialog will not been shown again until the user updates
+    /// the permission in the App settings.
+    deniedForever,
+    /// Permission to access the device's location is allowed only while
+    /// the App is in use.
+    whileInUse,
+    /// Permission to access the device's location is allowed only while
+    /// the App is in use. Permission to access the device's location in the
+    /// background is denied forever.
+    whileInUseForever,
+    /// Permission to access the device's location is allowed even when the
+    /// App is running in the background.
+    always;
+
+    public int toInt(){
+        switch (this){
+            case denied:
+                return 0;
+            case deniedForever:
+                return 1;
+            case whileInUse:
+                return 2;
+            case whileInUseForever:
+                return 3;
+            case always:
+                return 4;
+            default:
+                throw new IndexOutOfBoundsException();
+        }
+    }
+}

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
@@ -1,0 +1,119 @@
+package com.baseflow.geolocator.permission;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+
+import com.baseflow.geolocator.errors.ErrorCallback;
+import com.baseflow.geolocator.errors.PermissionUndefinedException;
+
+import java.util.Map;
+
+import io.flutter.plugin.common.PluginRegistry;
+
+public class PermissionManager {
+    @FunctionalInterface
+    public interface ActivityRegistry {
+        void addListener(PluginRegistry.ActivityResultListener handler);
+    }
+
+    @FunctionalInterface
+    public interface PermissionRegistry {
+        void addListener(PluginRegistry.RequestPermissionsResultListener handler);
+    }
+
+    @FunctionalInterface
+    public interface RequestPermissionsSuccessCallback {
+        void onSuccess(Map<Integer, Integer> results);
+    }
+
+    @FunctionalInterface
+    public interface CheckPermissionsSuccessCallback {
+        void onSuccess(int permissionStatus);
+    }
+
+    @FunctionalInterface
+    public interface ShouldShowRequestPermissionRationaleSuccessCallback {
+        void onSuccess(boolean shouldShowRequestPermissionRationale);
+    }
+
+    public LocationPermission checkPermissionStatus(
+            Context context,
+            Activity activity) throws PermissionUndefinedException {
+        return determinePermissionStatus(
+                context,
+                activity);
+    }
+
+    private LocationPermission determinePermissionStatus(
+            Context context,
+            @Nullable Activity activity) throws PermissionUndefinedException {
+
+        boolean wantsFineLocation = hasPermission(context, Manifest.permission.ACCESS_FINE_LOCATION);
+        boolean wantsCoarseLocation = hasPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION);
+
+        if(!wantsCoarseLocation && !wantsFineLocation){
+            throw new PermissionUndefinedException();
+        }
+        String permission = wantsFineLocation ? Manifest.permission.ACCESS_FINE_LOCATION : Manifest.permission.ACCESS_COARSE_LOCATION;
+        boolean wantsBackgroundLocation = hasPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+
+        final boolean targetsMOrHigher = context.getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.M;
+        final boolean targetsQOrHigher = context.getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.Q;
+
+
+        // If target is not M, permission is always granted
+        if(!targetsMOrHigher){
+            return LocationPermission.always;
+        }
+
+        final int permissionStatus = ContextCompat.checkSelfPermission(context, permission);
+        if (permissionStatus == PackageManager.PERMISSION_DENIED) {
+            if (PermissionUtils.isNeverAskAgainSelected(activity, permission)) {
+                return LocationPermission.deniedForever;
+            } else {
+                return LocationPermission.denied;
+            }
+        }
+
+        if(!targetsQOrHigher){
+            return LocationPermission.always;
+        }
+        if(!wantsBackgroundLocation){
+            return LocationPermission.whileInUse;
+        }
+
+        String backgroundPermission = Manifest.permission.ACCESS_BACKGROUND_LOCATION;
+        final int permissionStatusBackground = ContextCompat.checkSelfPermission(context, backgroundPermission);
+        if(permissionStatusBackground == PackageManager.PERMISSION_DENIED){
+            if (PermissionUtils.isNeverAskAgainSelected(activity, backgroundPermission)) {
+                return LocationPermission.whileInUseForever;
+            } else {
+                return LocationPermission.whileInUse;
+            }
+        }
+        return LocationPermission.always;
+    }
+
+    public boolean hasPermission(Context context, String permission) {
+        try {
+            PackageInfo info = context.getPackageManager().getPackageInfo(context.getPackageName(), PackageManager.GET_PERMISSIONS);
+            if (info.requestedPermissions != null) {
+                for (String p : info.requestedPermissions) {
+                    if (p.equals(permission)) {
+                        return true;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+}

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/permission/PermissionUtils.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/permission/PermissionUtils.java
@@ -1,0 +1,71 @@
+package com.baseflow.geolocator.permission;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.app.ActivityCompat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PermissionUtils {
+
+    public boolean hasPermissionInManifest(Context context, String permission) {
+        try {
+            PackageInfo info = context.getPackageManager().getPackageInfo(context.getPackageName(), PackageManager.GET_PERMISSIONS);
+            if (info.requestedPermissions != null) {
+                for (String p : info.requestedPermissions) {
+                    if (p.equals(permission)) {
+                        return true;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    static void updatePermissionShouldShowStatus(final Activity activity, String permission) {
+        if (activity == null) {
+            return;
+        }
+
+        PermissionUtils.setRequestedPermission(activity, permission);
+    }
+
+    static boolean isNeverAskAgainSelected(final Activity activity, final String name) {
+        if (activity == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.M ) {
+            return false;
+        }
+
+        return PermissionUtils.neverAskAgainSelected(activity, name);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    static boolean neverAskAgainSelected(final Activity activity, final String permission) {
+        final boolean hasRequestedPermissionBefore = getRequestedPermissionBefore(activity, permission);
+        final boolean shouldShowRequestPermissionRationale = ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
+        return hasRequestedPermissionBefore && !shouldShowRequestPermissionRationale;
+    }
+
+    static void setRequestedPermission(final Context context, final String permission) {
+        SharedPreferences prefs = context.getSharedPreferences("GEOLOCATOR_PERMISSIONS_REQUESTED", Context.MODE_PRIVATE);
+        prefs.edit()
+                .putBoolean(permission, true)
+                .apply();
+    }
+
+    static boolean getRequestedPermissionBefore(final Context context, final String permission) {
+        SharedPreferences prefs = context.getSharedPreferences("GEOLOCATOR_PERMISSIONS_REQUESTED", Context.MODE_PRIVATE);
+        return prefs.getBoolean(permission, false);
+    }
+}

--- a/geolocator/example/android/app/src/main/AndroidManifest.xml
+++ b/geolocator/example/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,13 @@
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
+
+
+    <!-- Permissions options for the `location` group -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:label="geolocator_example"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
No platform code for Android

### :new: What is the new behavior (if this is a feature change)?
Check Permission logic on Android Platform

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
I tested the example app.
It said it had no permissions. After turning them on it set 'last known location: null'
I needed to add a catch for MissingPluginException in the example and the `int.toLocationPermission()` needed an extra value. 

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop