### PR TITLE
Update functions documentation

### DIFF
--- a/geolocator/lib/geolocator.dart
+++ b/geolocator/lib/geolocator.dart
@@ -28,8 +28,10 @@ Future<bool> isLocationServiceEnabled() =>
 
 /// Returns the last known position stored on the users device.
 ///
-/// On Android we look for the location provider matching best with the
-/// supplied [desiredAccuracy]. On iOS this parameter is ignored.
+/// On Android you can force the plugin to use the old Android
+/// LocationManager implementation over the newer FusedLocationProvider by
+/// passing true to the [forceAndroidLocationManager] parameter. On iOS
+/// this parameter is ignored.
 /// When no position is available, null is returned.
 /// Throws a [PermissionDeniedException] when trying to request the device's
 /// location when the user denied access.
@@ -71,9 +73,8 @@ Future<Position> getCurrentPosition({
 /// is killed.
 ///
 /// ```
-/// StreamSubscription<Position> positionStream = Geolocator()
-///     .GetPostionStream()
-///     .listen((Position position) => {
+/// StreamSubscription<Position> positionStream = getPositionStream()
+///     .listen((Position position) {
 ///       // Handle position changes
 ///     });
 ///

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -113,9 +113,8 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// is killed.
   ///
   /// ```
-  /// StreamSubscription<Position> positionStream = Geolocator()
-  ///     .GetPostionStream()
-  ///     .listen((Position position) => {
+  /// StreamSubscription<Position> positionStream = getPositionStream()
+  ///     .listen((Position position) {
   ///       // Handle position changes
   ///     });
   ///


### PR DESCRIPTION
Some functions from `geolocator_platform_interface.dart` are exposed through `geolocator.dart`, so they share the documentation. It seems like `getLastKnownPosition()`'s documentation was updated in `geolocator_platform_interface.dart`, but kept outdated in `geolocator.dart`, so I sorted that out.

Furthermore, `getPositionStream()`'s documentation doesn't contemplate geolocator's 6.0.0 refactor, since it instantiates `Geolocator` class, which no longer exists. I also updated that one.