### PR TITLE
Add indication if location is mocked on Android

### DIFF
--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationMapper.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationMapper.java
@@ -29,6 +29,12 @@ public class LocationMapper {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && location.hasSpeedAccuracy())
             position.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
 
+        if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
+            position.put("is_mocked", location.isFromMockProvider());
+        } else {
+            position.put("is_mocked", false);
+        }
+
         return position;
     }
 }

--- a/geolocator/ios/Classes/GeolocatorPlugin.m
+++ b/geolocator/ios/Classes/GeolocatorPlugin.m
@@ -52,9 +52,9 @@
 
 - (FlutterError *_Nullable)onListenWithArguments:(id _Nullable)arguments eventSink:(FlutterEventSink)eventSink {
     if (_eventSink) {
-        return [FlutterError errorWithCode:GeolocatorErrorLocationSubscriptionActive
-                                   message:@"Already listening for location updates. If you want to restart listening please cancel other subscriptions first."
-                                   details:nil];
+        return [FlutterError errorWithCode: GeolocatorErrorLocationSubscriptionActive
+                                   message: @"Already listening for location updates. If you want to restart listening please cancel other subscriptions first."
+                                   details: nil];
     }
     _eventSink = eventSink;
     

--- a/geolocator_platform_interface/lib/src/enums/location_permission.dart
+++ b/geolocator_platform_interface/lib/src/enums/location_permission.dart
@@ -1,7 +1,7 @@
 /// Represent the possible location permissions.
 enum LocationPermission {
   /// This is the initial state on both Android and iOS, but on Android the
-  /// user can still choose to deny permissions, meaning the App can still 
+  /// user can still choose to deny permissions, meaning the App can still
   /// request for permission another time.
   denied,
 

--- a/geolocator_platform_interface/lib/src/models/position.dart
+++ b/geolocator_platform_interface/lib/src/models/position.dart
@@ -15,6 +15,7 @@ class Position {
     this.heading,
     this.speed,
     this.speedAccuracy,
+    this.isMocked,
   });
 
   Position._({
@@ -26,6 +27,7 @@ class Position {
     this.heading,
     this.speed,
     this.speedAccuracy,
+    this.isMocked,
   });
 
   /// The latitude of this position in degrees normalized to the interval -90.0
@@ -70,6 +72,12 @@ class Position {
   /// value is 0.0.
   final double speedAccuracy;
 
+  /// Will be true on Android (starting from API lvl 18) when the location came
+  /// from the mocked provider.
+  ///
+  /// On iOS this value will always be false.
+  final bool isMocked;
+
   @override
   bool operator ==(dynamic o) {
     var areEqual = o is Position &&
@@ -80,7 +88,8 @@ class Position {
         o.longitude == longitude &&
         o.speed == speed &&
         o.speedAccuracy == speedAccuracy &&
-        o.timestamp == timestamp;
+        o.timestamp == timestamp &&
+        o.isMocked == isMocked;
 
     return areEqual;
   }
@@ -94,7 +103,8 @@ class Position {
       longitude.hashCode ^
       speed.hashCode ^
       speedAccuracy.hashCode ^
-      timestamp.hashCode;
+      timestamp.hashCode ^
+      isMocked.hashCode;
 
   @override
   String toString() {
@@ -125,14 +135,16 @@ class Position {
         : null;
 
     return Position._(
-        latitude: positionMap['latitude'],
-        longitude: positionMap['longitude'],
-        timestamp: timestamp,
-        altitude: positionMap['altitude'] ?? 0.0,
-        accuracy: positionMap['accuracy'] ?? 0.0,
-        heading: positionMap['heading'] ?? 0.0,
-        speed: positionMap['speed'] ?? 0.0,
-        speedAccuracy: positionMap['speed_accuracy'] ?? 0.0);
+      latitude: positionMap['latitude'],
+      longitude: positionMap['longitude'],
+      timestamp: timestamp,
+      altitude: positionMap['altitude'] ?? 0.0,
+      accuracy: positionMap['accuracy'] ?? 0.0,
+      heading: positionMap['heading'] ?? 0.0,
+      speed: positionMap['speed'] ?? 0.0,
+      speedAccuracy: positionMap['speed_accuracy'] ?? 0.0,
+      isMocked: positionMap['is_mocked'] ?? false,
+    );
   }
 
   /// Converts the [Position] instance into a [Map] instance that can be
@@ -145,6 +157,7 @@ class Position {
         'altitude': altitude,
         'heading': heading,
         'speed': speed,
-        'speedAccuracy': speedAccuracy,
+        'speed_accuracy': speedAccuracy,
+        'is_mocked': isMocked,
       };
 }

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -17,7 +17,8 @@ Position get mockPosition => Position(
     accuracy: 0.0,
     heading: 0.0,
     speed: 0.0,
-    speedAccuracy: 0.0);
+    speedAccuracy: 0.0,
+    isMocked: false);
 
 Stream<Position> createPositionStream(
   Duration interval, {

--- a/geolocator_platform_interface/test/src/models/position_test.dart
+++ b/geolocator_platform_interface/test/src/models/position_test.dart
@@ -28,6 +28,7 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
       final secondPosition = Position(
         longitude: 1,
@@ -38,11 +39,12 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
 
       // Act & Assert
       expect(
-        firstPosition.hashCode != secondPosition,
+        firstPosition.hashCode != secondPosition.hashCode,
         true,
       );
     });
@@ -59,6 +61,7 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
       final secondPosition = Position(
         longitude: 0,
@@ -69,11 +72,12 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
 
       // Act & Assert
       expect(
-        firstPosition.hashCode != secondPosition,
+        firstPosition.hashCode != secondPosition.hashCode,
         true,
       );
     });
@@ -90,6 +94,7 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
       final secondPosition = Position(
         longitude: 0,
@@ -100,11 +105,12 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
 
       // Act & Assert
       expect(
-        firstPosition.hashCode != secondPosition,
+        firstPosition.hashCode != secondPosition.hashCode,
         true,
       );
     });
@@ -121,6 +127,7 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
       final secondPosition = Position(
         longitude: 0,
@@ -131,11 +138,12 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
 
       // Act & Assert
       expect(
-        firstPosition.hashCode != secondPosition,
+        firstPosition.hashCode != secondPosition.hashCode,
         true,
       );
     });
@@ -152,6 +160,7 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
       final secondPosition = Position(
         longitude: 0,
@@ -162,11 +171,12 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
 
       // Act & Assert
       expect(
-        firstPosition.hashCode != secondPosition,
+        firstPosition.hashCode != secondPosition.hashCode,
         true,
       );
     });
@@ -183,6 +193,7 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
       final secondPosition = Position(
         longitude: 0,
@@ -193,11 +204,12 @@ void main() {
         heading: 1,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
 
       // Act & Assert
       expect(
-        firstPosition.hashCode != secondPosition,
+        firstPosition.hashCode != secondPosition.hashCode,
         true,
       );
     });
@@ -213,6 +225,7 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
       final secondPosition = Position(
         longitude: 0,
@@ -223,11 +236,12 @@ void main() {
         heading: 0,
         speed: 1,
         speedAccuracy: 0,
+        isMocked: false,
       );
 
       // Act & Assert
       expect(
-        firstPosition.hashCode != secondPosition,
+        firstPosition.hashCode != secondPosition.hashCode,
         true,
       );
     });
@@ -246,6 +260,7 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 0,
+        isMocked: false,
       );
       final secondPosition = Position(
         longitude: 0,
@@ -256,11 +271,47 @@ void main() {
         heading: 0,
         speed: 0,
         speedAccuracy: 1,
+        isMocked: false,
       );
 
       // Act & Assert
       expect(
-        firstPosition.hashCode != secondPosition,
+        firstPosition.hashCode != secondPosition.hashCode,
+        true,
+      );
+    });
+
+    test(
+        // ignore: lines_longer_than_80_chars
+        'hashCode should not match when the speedAccuracy property is different',
+        () {
+      // Arrange
+      final firstPosition = Position(
+        longitude: 0,
+        latitude: 0,
+        timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+        accuracy: 0,
+        altitude: 0,
+        heading: 0,
+        speed: 0,
+        speedAccuracy: 0,
+        isMocked: false,
+      );
+      final secondPosition = Position(
+        longitude: 0,
+        latitude: 0,
+        timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+        accuracy: 0,
+        altitude: 0,
+        heading: 0,
+        speed: 0,
+        speedAccuracy: 0,
+        isMocked: true,
+      );
+
+      // Act & Assert
+      expect(
+        firstPosition.hashCode != secondPosition.hashCode,
         true,
       );
     });


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

In the 6.0.0 release I (wrongly) removed support for the `isFromMockedProvider` property that can be used since Android API 18 which will indicate if the location is retrieved from a mock provider.

### :new: What is the new behavior (if this is a feature change)?

Added the back support for the `isFromMockedProvider` and expose it via the `Position.isMocked` property.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

#498 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop