### PR TITLE
Removed dependency on play-services-base from Gradle script

### DIFF
--- a/geolocator/android/build.gradle
+++ b/geolocator/android/build.gradle
@@ -37,6 +37,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-base:17.3.0'
     implementation 'com.google.android.gms:play-services-location:17.0.0'
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When using the geolocator together with plugins that also rely on Google Play Services (e.g. Firebase) it is possible to receive a `java.lang.IllegalArgumentException: Service not registered` exception.

### :new: What is the new behavior (if this is a feature change)?

This pull-request aims on solving this problem.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Use the geolocator together with Firebase in one app.

### :memo: Links to relevant issues/docs

#503 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop