### PR TITLE
Fix app crash when turning of permissions

### DIFF
--- a/geolocator/ios/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator/ios/Classes/Handlers/GeolocationHandler.m
@@ -76,7 +76,10 @@
     }
     
     [self stopListening];
-    self.errorHandler(GeolocatorErrorLocationUpdateFailure, error.localizedDescription);
+    
+    if (self.errorHandler) {
+        self.errorHandler(GeolocatorErrorLocationUpdateFailure, error.localizedDescription);
+    }
 }
 
 + (BOOL) shouldEnableBackgroundLocationUpdates {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

The app crashes when turning off location permissions while receiving location updates.

### :new: What is the new behavior (if this is a feature change)?

Make sure the App doesn't crash

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

See reproduction steps in issue #497 

### :memo: Links to relevant issues/docs

#497 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop