### PR TITLE
Suppress deprecation warning for onStatusChanged override

### DIFF
--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -130,6 +130,7 @@ class LocationManagerClient implements LocationClient, LocationListener {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void onStatusChanged(String provider, int status, Bundle extras) {
         if (status == LocationProvider.AVAILABLE) {

--- a/geolocator/example/android/build.gradle
+++ b/geolocator/example/android/build.gradle
@@ -14,12 +14,6 @@ allprojects {
         google()
         jcenter()
     }
-
-    gradle.projectsEvaluated {
-        tasks.withType(JavaCompile) {
-            options.compilerArgs << "-Xlint:deprecation"
-        }
-    }
 }
 
 rootProject.buildDir = '../build'

--- a/geolocator/example/android/build.gradle
+++ b/geolocator/example/android/build.gradle
@@ -14,6 +14,12 @@ allprojects {
         google()
         jcenter()
     }
+
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:deprecation"
+        }
+    }
 }
 
 rootProject.buildDir = '../build'


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When compiling an Android application that depends on the geolocator plugin you will receive a deprecation warning.

### :new: What is the new behavior (if this is a feature change)?

Suppressed the deprecation warning. The deprecation is informing us that the `onStatusChanged` method is deprecated. We have implemented it for backwards compatibility reasons and should not be causing any troubles when not being called anymore.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

1. Create a new Flutter application;
2. Add a dependency in the geolocator plugin
3. Build the app for Android: `flutter build apk`

Check for warnings in the build log.

### :memo: Links to relevant issues/docs

#502 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop