### PR TITLE
Changed README compileSdkVersion and Corrected spelling mistakes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Setting up your development environment
 Running the example project
 ---------------------------
 
- * Change into the example directory: `cd example`
+ * Change into the example directory: `cd geolocator/example`
  * Run the App: `flutter run`
 
 Contribute

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ The TL;DR version is:
 android.useAndroidX=true
 android.enableJetifier=true
 ```
-2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 28:
+2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 30:
 
 ```
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
 
   ...
 }
@@ -71,7 +71,7 @@ Starting from Android 10 you need to add the `ACCESS_BACKGROUND_LOCATION` permis
 <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 ```
 
-> **NOTE:** Specifying the `ACCESS_COARSE_LOCATION` permission results in location updates with an accuracy approximately equivalant to a city block. It might take a long time (minutes) before you will get your first locations fix as `ACCESS_COARSE_LOCATION` will only use the network services to calculate the position of the device. More information can be found [here](https://developer.android.com/training/location/retrieve-current#permissions). 
+> **NOTE:** Specifying the `ACCESS_COARSE_LOCATION` permission results in location updates with an accuracy approximately equivalent to a city block. It might take a long time (minutes) before you will get your first locations fix as `ACCESS_COARSE_LOCATION` will only use the network services to calculate the position of the device. More information can be found [here](https://developer.android.com/training/location/retrieve-current#permissions). 
 
 
 </details>
@@ -88,7 +88,7 @@ On iOS you'll need to add the following entries to your Info.plist file (located
 <string>This app needs access to location when in the background.</string>
 ```
 
-If you would like to receive updates when your App is in the background, you'll also need to add the Background Modes capability to your XCode project (Project > Signing and Capabilties > "+ Capability" button) and select Location Updates. Be carefull with this, you will need to explain in detail to Apple why your App needs this when submitting your App to the AppStore. If Apple isn't satisfied with the explanation your App will be rejected.
+If you would like to receive updates when your App is in the background, you'll also need to add the Background Modes capability to your XCode project (Project > Signing and Capabilities > "+ Capability" button) and select Location Updates. Be careful with this, you will need to explain in detail to Apple why your App needs this when submitting your App to the AppStore. If Apple isn't satisfied with the explanation your App will be rejected.
 
 </details>
 
@@ -170,7 +170,7 @@ always | Permission to access the device's location is allowed even when the App
 
 ### Settings
 
-In some cases it is necessary to ask the user and update their device settings. For example when the user initially permantly denied permissions to access the device's location or if the location services are not enabled (and, on Android, automatic resolution didn't work). In these cases you can use the `openAppSettings` or `openLocationSettings` methods to immidiately redirect the user to the device's settings page. 
+In some cases it is necessary to ask the user and update their device settings. For example when the user initially permanently denied permissions to access the device's location or if the location services are not enabled (and, on Android, automatic resolution didn't work). In these cases you can use the `openAppSettings` or `openLocationSettings` methods to immediately redirect the user to the device's settings page. 
 
 On Android the `openAppSettings` method will redirect the user to the App specific settings where the user can update necessary permissions. The `openLocationSettings` method will redirect the user to the location settings where the user can enable/ disable the location services.
 

--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## 6.0.0+4
 
-* Android: fix crash when multiple permissions requests are make simultanuous (see issue [#513](https://github.com/Baseflow/flutter-geolocator/issues/513)).
+* Android: fix crash when multiple permissions requests are make simultaneous (see issue [#513](https://github.com/Baseflow/flutter-geolocator/issues/513)).
 
 ## 6.0.0+3
 
 * Make the `bearingBetween` and `distanceBetween` methods directly available from the geolocator package (see issue [#496](https://github.com/Baseflow/flutter-geolocator/issues/496));
-* Android: check if permissions and grantresults are available in `onRequestPermissionsResult` (see issue [#511](https://github.com/Baseflow/flutter-geolocator/issues/511))
+* Android: check if permissions and grant results are available in `onRequestPermissionsResult` (see issue [#511](https://github.com/Baseflow/flutter-geolocator/issues/511))
 
 ## 6.0.0+2
 
@@ -66,7 +66,7 @@ Complete rebuild of the geolocator plugin. Please note the this version contains
 
 * Added unit-tests to guard for breaking API changes;
 * Added support to supply a locale identifier when requesting a placemark using a [Position](https://pub.dev/documentation/geolocator/latest/geolocator/Position-class.html) instance;
-* **breaking** Stop hiding parsing exceptions when converting coordinates into an address. Instead of returning `null` the `placemarkFromCoordinates` method will now throw and `ArgumentError` if illigal values are returned (which should never happen).
+* **breaking** Stop hiding parsing exceptions when converting coordinates into an address. Instead of returning `null` the `placemarkFromCoordinates` method will now throw and `ArgumentError` if illegal values are returned (which should never happen).
 
 ## 5.2.1
 
@@ -75,7 +75,7 @@ Complete rebuild of the geolocator plugin. Please note the this version contains
 
 ## 5.2.0
 
-* iOS: keep trying to get the location when a `kCLErrorLocationUnknow` error is received (as per Apple's [documentation](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/1423786-locationmanager));
+* iOS: keep trying to get the location when a `kCLErrorLocationUnknown` error is received (as per Apple's [documentation](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/1423786-locationmanager));
 * Android: synchronize gradle versions with current stable version of Flutter (1.12.13+hotfix.5).
 
 ## 5.1.5
@@ -228,7 +228,7 @@ Complete rebuild of the geolocator plugin. Please note the this version contains
 * It is now possible to check the location permissions using the `checkGeolocationStatus` method [[ISSUE #51](https://github.com/BaseflowIT/flutter-geolocator/issues/51)].
 * Improved the example App [[ISSUE #54](https://github.com/BaseflowIT/flutter-geolocator/issues/54)]
 * Solved a bug on Android causing a memory leak when you stop listening to the position stream.
-* **breaking** Solved a bug on Android where permissions could be requested more then once simultaniously [[ISSUE #58](https://github.com/BaseflowIT/flutter-geolocator/issues/58)]
+* **breaking** Solved a bug on Android where permissions could be requested more then once simultaneously [[ISSUE #58](https://github.com/BaseflowIT/flutter-geolocator/issues/58)]
 * Solved a bug on Android where requesting permissions twice would cause the App to crash [[ISSUE #61](https://github.com/BaseflowIT/flutter-geolocator/issues/61)]
 
 > **Important:**
@@ -248,7 +248,7 @@ Complete rebuild of the geolocator plugin. Please note the this version contains
 * Added feature to query the last known location that is stored on the device using the `getLastKnownLocation` method;
 * **breaking** Renamed the `getPosition` to `getCurrentPosition`;
 * Fixed bug where calling `getCurrentPosition` on Android resulted in returning the last known location;
-* **breaking** Renamed methods `toPlacemark` and `fromPlacemark` respectively to the, more meaningfull names, `placemarkFromAddress` and `placemarkFromCoordinates`;
+* **breaking** Renamed methods `toPlacemark` and `fromPlacemark` respectively to the, more meaningful names, `placemarkFromAddress` and `placemarkFromCoordinates`;
 
 ## 1.3.1
 

--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -71,7 +71,7 @@ Starting from Android 10 you need to add the `ACCESS_BACKGROUND_LOCATION` permis
 <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 ```
 
-> **NOTE:** Specifying the `ACCESS_COARSE_LOCATION` permission results in location updates with an accuracy approximately equivalant to a city block. It might take a long time (minutes) before you will get your first locations fix as `ACCESS_COARSE_LOCATION` will only use the network services to calculate the position of the device. More information can be found [here](https://developer.android.com/training/location/retrieve-current#permissions). 
+> **NOTE:** Specifying the `ACCESS_COARSE_LOCATION` permission results in location updates with an accuracy approximately equivalent to a city block. It might take a long time (minutes) before you will get your first locations fix as `ACCESS_COARSE_LOCATION` will only use the network services to calculate the position of the device. More information can be found [here](https://developer.android.com/training/location/retrieve-current#permissions). 
 
 
 </details>
@@ -88,7 +88,7 @@ On iOS you'll need to add the following entries to your Info.plist file (located
 <string>This app needs access to location when in the background.</string>
 ```
 
-If you would like to receive updates when your App is in the background, you'll also need to add the Background Modes capability to your XCode project (Project > Signing and Capabilties > "+ Capability" button) and select Location Updates. Be carefull with this, you will need to explain in detail to Apple why your App needs this when submitting your App to the AppStore. If Apple isn't satisfied with the explanation your App will be rejected.
+If you would like to receive updates when your App is in the background, you'll also need to add the Background Modes capability to your XCode project (Project > Signing and Capabilities > "+ Capability" button) and select Location Updates. Be careful with this, you will need to explain in detail to Apple why your App needs this when submitting your App to the AppStore. If Apple isn't satisfied with the explanation your App will be rejected.
 
 </details>
 
@@ -170,7 +170,7 @@ always | Permission to access the device's location is allowed even when the App
 
 ### Settings
 
-In some cases it is necessary to ask the user and update their device settings. For example when the user initially permantly denied permissions to access the device's location or if the location services are not enabled (and, on Android, automatic resolution didn't work). In these cases you can use the `openAppSettings` or `openLocationSettings` methods to immidiately redirect the user to the device's settings page. 
+In some cases it is necessary to ask the user and update their device settings. For example when the user initially permanently denied permissions to access the device's location or if the location services are not enabled (and, on Android, automatic resolution didn't work). In these cases you can use the `openAppSettings` or `openLocationSettings` methods to immediately redirect the user to the device's settings page. 
 
 On Android the `openAppSettings` method will redirect the user to the App specific settings where the user can update necessary permissions. The `openLocationSettings` method will redirect the user to the location settings where the user can enable/ disable the location services.
 

--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -45,11 +45,11 @@ The TL;DR version is:
 android.useAndroidX=true
 android.enableJetifier=true
 ```
-2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 28:
+2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 30:
 
 ```
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
 
   ...
 }

--- a/geolocator_platform_interface/README.md
+++ b/geolocator_platform_interface/README.md
@@ -71,7 +71,7 @@ Starting from Android 10 you need to add the `ACCESS_BACKGROUND_LOCATION` permis
 <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 ```
 
-> **NOTE:** Specifying the `ACCESS_COARSE_LOCATION` permission results in location updates with an accuracy approximately equivalant to a city block. It might take a long time (minutes) before you will get your first locations fix as `ACCESS_COARSE_LOCATION` will only use the network services to calculate the position of the device. More information can be found [here](https://developer.android.com/training/location/retrieve-current#permissions). 
+> **NOTE:** Specifying the `ACCESS_COARSE_LOCATION` permission results in location updates with an accuracy approximately equivalent to a city block. It might take a long time (minutes) before you will get your first locations fix as `ACCESS_COARSE_LOCATION` will only use the network services to calculate the position of the device. More information can be found [here](https://developer.android.com/training/location/retrieve-current#permissions). 
 
 
 </details>
@@ -88,7 +88,7 @@ On iOS you'll need to add the following entries to your Info.plist file (located
 <string>This app needs access to location when in the background.</string>
 ```
 
-If you would like to receive updates when your App is in the background, you'll also need to add the Background Modes capability to your XCode project (Project > Signing and Capabilties > "+ Capability" button) and select Location Updates. Be carefull with this, you will need to explain in detail to Apple why your App needs this when submitting your App to the AppStore. If Apple isn't satisfied with the explanation your App will be rejected.
+If you would like to receive updates when your App is in the background, you'll also need to add the Background Modes capability to your XCode project (Project > Signing and Capabilities > "+ Capability" button) and select Location Updates. Be careful with this, you will need to explain in detail to Apple why your App needs this when submitting your App to the AppStore. If Apple isn't satisfied with the explanation your App will be rejected.
 
 </details>
 
@@ -170,7 +170,7 @@ always | Permission to access the device's location is allowed even when the App
 
 ### Settings
 
-In some cases it is necessary to ask the user and update their device settings. For example when the user initially permantly denied permissions to access the device's location or if the location services are not enabled (and, on Android, automatic resolution didn't work). In these cases you can use the `openAppSettings` or `openLocationSettings` methods to immidiately redirect the user to the device's settings page. 
+In some cases it is necessary to ask the user and update their device settings. For example when the user initially permanently denied permissions to access the device's location or if the location services are not enabled (and, on Android, automatic resolution didn't work). In these cases you can use the `openAppSettings` or `openLocationSettings` methods to immediately redirect the user to the device's settings page. 
 
 On Android the `openAppSettings` method will redirect the user to the App specific settings where the user can update necessary permissions. The `openLocationSettings` method will redirect the user to the location settings where the user can enable/ disable the location services.
 

--- a/geolocator_platform_interface/README.md
+++ b/geolocator_platform_interface/README.md
@@ -45,11 +45,11 @@ The TL;DR version is:
 android.useAndroidX=true
 android.enableJetifier=true
 ```
-2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 28:
+2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 30:
 
 ```
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
 
   ...
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR changed the compileSdkVersion in the READMEs from 28/29 to 30 and also corrected spelling mistakes in the markdown files.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
No. This PR does not introduce any breaking change.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop