### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Starting from Android 10 you need to add the `ACCESS_BACKGROUND_LOCATION` permis
 <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 ```
 
-> **NOTE:** Specifying the `ACCESS_COARSE_LOCATION` permission results in location updates with an accuracy approximately equivalent to a city block. It might take a long time (minutes) before you will get your first locations fix as `ACCESS_COARSE_LOCATION` will only use the network services to calculate the position of the device. More information can be found [here](https://developer.android.com/training/location/retrieve-current#permissions). 
+> **NOTE:** Specifying the `ACCESS_COARSE_LOCATION` permission results in only being allowed to request a location with the `getLastKnownPosition` method. The accuracy can be very precise or could be the equivalent to a city block. If the phone already knows where he is this results in a quick response, but it could also take a long time (minutes) before you will get your first locations fix.
 
 
 </details>
@@ -106,6 +106,8 @@ import 'package:geolocator/geolocator.dart';
 
 Position position = await getCurrentPosition(desiredAccuracy: LocationAccuracy.high);
 ```
+
+> **NOTE:** On Android, calling the `getCurrentPosition` method requires the `ACCESS_FINE_LOCATION` permission being set in the `android/app/src/main/AndroidManifest.xml` file.
 
 To query the last known location retrieved stored on the device you can use the `getLastKnownPosition` method (note that this can result in a `null` value when no location details are available):
 


### PR DESCRIPTION
The way ACCESS_COARSE_LOCATION works on Android is slightly different than described in the Readme. 

- To let your app GPS himself, it needs to call `getCurrentPosition();` and therefore needs the permission `ACCESS_FINE_LOCATION`
- To let your app ask the phone if he knows where he is, you can use `getLastKnownPosition();` while having permission `ACCESS_COARSE_LOCATION`.

_Having set just ACCESS_COARSE_LOCATION and trying to get the current position based on GPS will hang the process._

**Therefore I have changed:**

* The NOTE below the permissions, to explain that ACCESS_COARSE_LOCATION only works with `getLastKnownPosition`
* A note below the usage of the `getCurrentPosition` method to explain that `ACCESS_FINE_LOCATION` is necessary for Android. This was driving me nuts ;)

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
It is a docs update

### :arrow_heading_down: What is the current behavior?
Essential stuff was missing, which lead to mis-using the plugin and therefore not working.

### :new: What is the new behavior (if this is a feature change)?
More explicit setup. 

### :boom: Does this PR introduce a breaking change?
Nope..

### :bug: Recommendations for testing
Using `<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />` with 
`Position position = await getCurrentPosition();` does not work and hangs. The phone then tries to GPS, but cannot while having just COARSE permissions. Even with `LocationAccuracy.lowest`

### :memo: Links to relevant issues/docs
I had a 1-on-1 chat with Maurits