### PR TITLE
Fix issue #532

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 6.1.0
 
-* Wrapped all global functions to a static class, thus changing the way geolocator methods should be called. (see issue [#524] (https://github.com/Baseflow/flutter-geolocator/issues/524)).
+* Wrapped all global functions to a static class, thus changing the way geolocator methods should be called. (see issue [#524] (https://github.com/Baseflow/flutter-geolocator/issues/524));
+* Fix permission issue on Android where permisisons are reported "Denied forever" after selecting "One time" permission (see issue [#532](https://github.com/Baseflow/flutter-geolocator/issues/532));
+* Added more detailed documentation on the `LocationServiceDisableException` (see issue [#519](https://github.com/Baseflow/flutter-geolocator/issues/519)).
 
 ## 6.0.0+4
 

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/permission/PermissionUtils.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/permission/PermissionUtils.java
@@ -36,14 +36,6 @@ public class PermissionUtils {
         return false;
     }
 
-    static void updatePermissionShouldShowStatus(final Activity activity, String permission) {
-        if (activity == null) {
-            return;
-        }
-
-        PermissionUtils.setRequestedPermission(activity, permission);
-    }
-
     static boolean isNeverAskAgainSelected(final Activity activity, final String name) {
         if (activity == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.M ) {
             return false;
@@ -54,15 +46,17 @@ public class PermissionUtils {
 
     @RequiresApi(api = Build.VERSION_CODES.M)
     static boolean neverAskAgainSelected(final Activity activity, final String permission) {
-        final boolean hasRequestedPermissionBefore = getRequestedPermissionBefore(activity, permission);
+        final boolean shouldShowRequestPermissionRationaleBefore = getRequestedPermissionBefore(activity, permission);
         final boolean shouldShowRequestPermissionRationale = ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
-        return hasRequestedPermissionBefore && !shouldShowRequestPermissionRationale;
+        return shouldShowRequestPermissionRationaleBefore && !shouldShowRequestPermissionRationale;
     }
 
-    static void setRequestedPermission(final Context context, final String permission) {
-        SharedPreferences prefs = context.getSharedPreferences("GEOLOCATOR_PERMISSIONS_REQUESTED", Context.MODE_PRIVATE);
+    static void setRequestedPermission(final Activity activity, final String permission) {
+        final boolean shouldShowRequestPermissionRationale = ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
+
+        SharedPreferences prefs = activity.getSharedPreferences("GEOLOCATOR_PERMISSIONS_REQUESTED", Context.MODE_PRIVATE);
         prefs.edit()
-                .putBoolean(permission, true)
+                .putBoolean(permission, shouldShowRequestPermissionRationale)
                 .apply();
     }
 

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 6.0.0+4
+version: 6.1.0
 homepage: https://github.com/baseflow/flutter-geolocator
 
 environment:

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   
-  geolocator_platform_interface: ^1.0.4
+  geolocator_platform_interface: ^1.0.5
 
 dev_dependencies:
   flutter_test:

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5
+
+- Added more detailed documentation on the `LocationServiceDisableException` (see issue [#519](https://github.com/Baseflow/flutter-geolocator/issues/519)).
+
 ## 1.0.4
 
 - Add the `isMocked` field to the `Position` class to indicate if the position is retrieved using the Android MockLocationProvider (see issue #498);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

On Android API 30 after granting "One time" permissions, subsequent permissions requests will always return "Denied forever".

### :new: What is the new behavior (if this is a feature change)?

Subsequent permission requests will correctly report "Denied" permissions which allows developers to show the permission dialog to request for permissions.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

See issue #532 for reproduction steps

### :memo: Links to relevant issues/docs

Fixes #532 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop