### PR TITLE
Report error when location services are disabled while listening to stream

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.1
+
+* Android: throw `LocationServiceDisabledException` when location services are disabled while listening to the position update stream (see issue [#548](https://github.com/Baseflow/flutter-geolocator/issues/548)).
+
 ## 6.1.0
 
 * Wrapped all global functions to a static class, thus changing the way geolocator methods should be called. (see issue [#524] (https://github.com/Baseflow/flutter-geolocator/issues/524));

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/Geolocator.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/Geolocator.java
@@ -1,9 +1,0 @@
-package com.baseflow.geolocator;
-
-import android.content.Context;
-
-class Geolocator {
-    Geolocator(){
-
-    }
-}

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
@@ -23,7 +23,7 @@ import io.flutter.plugin.common.MethodChannel;
 
 /**
  * Translates incoming Geolocator MethodCalls into well formed Java function calls for {@link
- * Geolocator}.
+ * GeolocationManager}.
  */
 class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     private static final String TAG = "MethodCallHandlerImpl";

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -4,17 +4,13 @@ import android.app.Activity;
 import android.content.Context;
 import android.location.Location;
 import android.util.Log;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.baseflow.geolocator.errors.ErrorCodes;
 import com.baseflow.geolocator.location.GeolocationManager;
-import com.baseflow.geolocator.location.LocationAccuracy;
 import com.baseflow.geolocator.location.LocationMapper;
 import com.baseflow.geolocator.location.LocationOptions;
-import com.baseflow.geolocator.permission.PermissionManager;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
-import io.flutter.plugin.common.MethodChannel;
 
 import java.util.Map;
 

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -82,7 +82,8 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
                 activity,
                 locationOptions,
                 (Location location) -> events.success(LocationMapper.toHashMap(location)),
-                (ErrorCodes errorCodes) -> events.error(errorCodes.toString(), errorCodes.toDescription(), null));
+                (ErrorCodes errorCodes) -> events.error(errorCodes.toString(), errorCodes.toDescription(), null)
+        );
     }
 
     @Override

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -5,7 +5,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.IntentSender;
 import android.location.Location;
-import android.location.LocationManager;
 import android.os.Looper;
 import android.util.Log;
 import androidx.annotation.NonNull;

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -50,21 +50,35 @@ class FusedLocationClient implements LocationClient {
                 Location location = locationResult.getLastLocation();
                 positionChangedCallback.onPositionChanged(location);
             }
+
+            @Override
+            public void onLocationAvailability(LocationAvailability locationAvailability) {
+                if (!locationAvailability.isLocationAvailable()) {
+                    if (errorCallback != null) {
+                        errorCallback.onError(ErrorCodes.locationServicesDisabled);
+                    }
+                }
+            }
         };
     }
 
     @Override
-    public boolean isLocationServiceEnabled() {
-        LocationManager locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-
-        if (locationManager == null) {
-            return false;
-        }
-
-        boolean gps_enabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
-        boolean network_enabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
-
-        return gps_enabled || network_enabled;
+    public void isLocationServiceEnabled(LocationServiceListener listener) {
+        LocationServices
+                .getSettingsClient(context)
+                .checkLocationSettings(
+                        new LocationSettingsRequest.Builder()
+                                .build()).addOnCompleteListener((response) -> {
+            if (response.isSuccessful()) {
+                LocationSettingsResponse lsr = response.getResult();
+                if (lsr != null) {
+                    LocationSettingsStates settingsStates = lsr.getLocationSettingsStates();
+                    listener.onLocationServiceResult(settingsStates.isGpsUsable() || settingsStates.isNetworkLocationUsable());
+                } else {
+                    listener.onLocationServiceError(ErrorCodes.locationServicesDisabled);
+                }
+            }
+        });
     }
 
     @SuppressLint("MissingPermission")
@@ -123,11 +137,14 @@ class FusedLocationClient implements LocationClient {
         LocationSettingsRequest settingsRequest = buildLocationSettingsRequest(locationRequest);
 
         SettingsClient settingsClient = LocationServices.getSettingsClient(context);
-        settingsClient.checkLocationSettings(settingsRequest)
-                .addOnSuccessListener(locationSettingsResponse -> fusedLocationProviderClient.requestLocationUpdates(
+        settingsClient
+                .checkLocationSettings(settingsRequest)
+                .addOnSuccessListener(locationSettingsResponse -> {
+                    fusedLocationProviderClient.requestLocationUpdates(
                         locationRequest,
                         locationCallback,
-                        Looper.getMainLooper()))
+                        Looper.getMainLooper());
+                })
                 .addOnFailureListener(e -> {
                     if (e instanceof ResolvableApiException) {
                         // When we don't have an activity return an error code explaining the

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
@@ -54,33 +54,9 @@ public class GeolocationManager implements PluginRegistry.ActivityResultListener
         if (context == null) {
             listener.onLocationServiceError(ErrorCodes.locationServicesDisabled);
         }
-        boolean gps_enabled;
-        boolean network_enabled;
-        if (isGooglePlayServicesAvailable(context)) {
-            LocationServices
-                    .getSettingsClient(context)
-                    .checkLocationSettings(
-                            new LocationSettingsRequest.Builder()
-                                    .build()).addOnCompleteListener((response) -> {
-                if (response.isSuccessful()) {
-                    LocationSettingsResponse lsr = response.getResult();
-                    if (lsr != null) {
-                        LocationSettingsStates settingsStates = lsr.getLocationSettingsStates();
-                        listener.onLocationServiceResult(settingsStates.isGpsUsable() || settingsStates.isNetworkLocationUsable());
-                    } else {
-                        listener.onLocationServiceError(ErrorCodes.locationServicesDisabled);
-                    }
-                }
-            });
-        } else {
-            LocationManager locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-            if (locationManager == null) {
-                listener.onLocationServiceResult(false);
-            }
-            gps_enabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
-            network_enabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
-            listener.onLocationServiceResult(gps_enabled || network_enabled);
-        }
+
+        LocationClient locationClient = createLocationClient(context, false);
+        locationClient.isLocationServiceEnabled(listener);
     }
 
 

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
@@ -3,7 +3,6 @@ package com.baseflow.geolocator.location;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.location.LocationManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -15,10 +14,6 @@ import com.baseflow.geolocator.permission.LocationPermission;
 import com.baseflow.geolocator.permission.PermissionManager;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
-import com.google.android.gms.location.LocationServices;
-import com.google.android.gms.location.LocationSettingsRequest;
-import com.google.android.gms.location.LocationSettingsResponse;
-import com.google.android.gms.location.LocationSettingsStates;
 
 import io.flutter.plugin.common.PluginRegistry;
 

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationClient.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationClient.java
@@ -6,7 +6,7 @@ import android.content.Intent;
 import com.baseflow.geolocator.errors.ErrorCallback;
 
 interface LocationClient {
-    boolean isLocationServiceEnabled();
+    void isLocationServiceEnabled(LocationServiceListener listener);
 
     void getLastKnownPosition(
             PositionChangedCallback positionChangedCallback,

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationClient.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationClient.java
@@ -1,7 +1,6 @@
 package com.baseflow.geolocator.location;
 
 import android.app.Activity;
-import android.content.Intent;
 
 import com.baseflow.geolocator.errors.ErrorCallback;
 

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -44,11 +44,16 @@ class LocationManagerClient implements LocationClient, LocationListener {
     }
 
     @Override
-    public boolean isLocationServiceEnabled() {
+    public void isLocationServiceEnabled(LocationServiceListener listener) {
         if (locationManager == null) {
-            return false;
+            listener.onLocationServiceResult(false);
+            return;
         }
 
+        listener.onLocationServiceResult(checkLocationServices());
+    }
+
+    private boolean checkLocationServices() {
         boolean gps_enabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
         boolean network_enabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
 
@@ -85,7 +90,7 @@ class LocationManagerClient implements LocationClient, LocationListener {
             PositionChangedCallback positionChangedCallback,
             ErrorCallback errorCallback) {
 
-        if (!isLocationServiceEnabled()) {
+        if (!checkLocationServices()) {
             errorCallback.onError(ErrorCodes.locationServicesDisabled);
             return;
         }

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -20,8 +20,6 @@ import com.google.android.gms.common.util.Strings;
 
 import java.util.List;
 
-import static com.baseflow.geolocator.location.LocationAccuracy.*;
-
 class LocationManagerClient implements LocationClient, LocationListener {
     private static final long TWO_MINUTES = 120000;
 

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 6.1.0
+version: 6.1.1
 homepage: https://github.com/baseflow/flutter-geolocator
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

On Android the application is not notified that the location services are disabled while listening to position update stream. In this case the position stream just stops reporting events but stays active.

### :new: What is the new behavior (if this is a feature change)?

When the location services are stopped while listening for position updates the stream will error out with an `LocationServicesDisabledException`. The stream will automatically be canceled giving developers the opportunity to handle the exception and restart the position stream when possible.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

See reproduction steps in issue #548

### :memo: Links to relevant issues/docs

Fixes #548

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop