### PR TITLE
Added floor property to position model

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 1.0.8
+
+- Added the optional floor property to the position model and can be used by implementations to specify the floor on which the device is located (see [#562](https://github.com/Baseflow/flutter-geolocator/issues/562)).
+
 ## 1.0.7
 
-- Solves a bug causing less accurate location fixes (see [#531]((https://github.com/Baseflow/flutter-geolocator/issues/531))).
+- Solves a bug causing less accurate location fixes (see [#531](https://github.com/Baseflow/flutter-geolocator/issues/531)).
 
 ## 1.0.6+1
 

--- a/geolocator_platform_interface/lib/src/models/position.dart
+++ b/geolocator_platform_interface/lib/src/models/position.dart
@@ -13,18 +13,7 @@ class Position {
     this.accuracy,
     this.altitude,
     this.heading,
-    this.speed,
-    this.speedAccuracy,
-    this.isMocked,
-  });
-
-  Position._({
-    this.longitude,
-    this.latitude,
-    this.timestamp,
-    this.accuracy,
-    this.altitude,
-    this.heading,
+    this.floor,
     this.speed,
     this.speedAccuracy,
     this.isMocked,
@@ -59,6 +48,13 @@ class Position {
   /// 0.0.
   final double heading;
 
+  /// The floor specifies the floor of the building on which the device is
+  /// located.
+  ///
+  /// The floor property is only available on iOS and only when the information
+  /// is available. In all other cases this value will be null.
+  final int floor;
+
   /// The speed at which the devices is traveling in meters per second over
   /// ground.
   ///
@@ -86,6 +82,7 @@ class Position {
         o.heading == heading &&
         o.latitude == latitude &&
         o.longitude == longitude &&
+        o.floor == o.floor &&
         o.speed == speed &&
         o.speedAccuracy == speedAccuracy &&
         o.timestamp == timestamp &&
@@ -101,6 +98,7 @@ class Position {
       heading.hashCode ^
       latitude.hashCode ^
       longitude.hashCode ^
+      floor.hashCode ^
       speed.hashCode ^
       speedAccuracy.hashCode ^
       timestamp.hashCode ^
@@ -134,13 +132,14 @@ class Position {
             isUtc: true)
         : null;
 
-    return Position._(
+    return Position(
       latitude: positionMap['latitude'],
       longitude: positionMap['longitude'],
       timestamp: timestamp,
       altitude: positionMap['altitude'] ?? 0.0,
       accuracy: positionMap['accuracy'] ?? 0.0,
       heading: positionMap['heading'] ?? 0.0,
+      floor: positionMap['floor'],
       speed: positionMap['speed'] ?? 0.0,
       speedAccuracy: positionMap['speed_accuracy'] ?? 0.0,
       isMocked: positionMap['is_mocked'] ?? false,
@@ -155,6 +154,7 @@ class Position {
         'timestamp': timestamp?.millisecondsSinceEpoch,
         'accuracy': accuracy,
         'altitude': altitude,
+        'floor': floor,
         'heading': heading,
         'speed': speed,
         'speed_accuracy': speedAccuracy,

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.7
+version: 1.0.8
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/test/src/models/position_test.dart
+++ b/geolocator_platform_interface/test/src/models/position_test.dart
@@ -315,6 +315,40 @@ void main() {
         true,
       );
     });
+
+    test('hashCode should not match when the floor property is different', () {
+      // Arrange
+      final firstPosition = Position(
+        longitude: 0,
+        latitude: 0,
+        timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+        accuracy: 0,
+        altitude: 0,
+        heading: 0,
+        floor: 0,
+        speed: 0,
+        speedAccuracy: 0,
+        isMocked: false,
+      );
+      final secondPosition = Position(
+        longitude: 0,
+        latitude: 0,
+        timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+        accuracy: 0,
+        altitude: 0,
+        heading: 0,
+        floor: 1,
+        speed: 0,
+        speedAccuracy: 0,
+        isMocked: false,
+      );
+
+      // Act & Assert
+      expect(
+        firstPosition.hashCode != secondPosition.hashCode,
+        true,
+      );
+    });
   });
 
   group('fromMap tests:', () {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

The position object doesn't contain any information about the floor the device on which the device is located. In some cases (i.e. on iOS and if the WiFi supports it) the location services can provide floor information. 

### :new: What is the new behavior (if this is a feature change)?

This pull requests adds the `floor` property to the `position` object preparing the interface for platform implementations to provide information about on which floor the device is located (if available).

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

#562 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop