### PR TITLE
Make sure speedAccuracy property is only used on Xcode 12

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.4+1
+
+- Hotfix to make sure the `CLLocation.speedAccuracy` property is only compiled when using Xcode 12 or higher (see [#577](https://github.com/Baseflow/flutter-geolocator/issues/577)).
+
 ## 6.1.4
 
 - When available return the floor on which the devices is located (see [#562](https://github.com/Baseflow/flutter-geolocator/issues/562));

--- a/geolocator/ios/Classes/Utils/LocationMapper.m
+++ b/geolocator/ios/Classes/Utils/LocationMapper.m
@@ -16,9 +16,11 @@
     double timestamp = [LocationMapper currentTimeInMilliSeconds:location.timestamp];
     double speedAccuracy = 0.0;
     
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
     if (@available(iOS 10.0, *)) {
         speedAccuracy = location.speedAccuracy;
     }
+#endif
     
     NSMutableDictionary *locationMap = [[NSMutableDictionary alloc]initWithCapacity:9];
     [locationMap setObject:@(location.coordinate.latitude) forKey: @"latitude"];

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 6.1.4
+version: 6.1.4+1
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When trying to compile an iOS app using geolocator 6.1.4 on pre-Xcode 12 you will get a compile error explaining the `speedAccuracy` property doesn't exist on the `CLLocation` class.

### :new: What is the new behavior (if this is a feature change)?

Make sure the code accessing the `speedAccuracy` property is only run when using Xcode 12 or higher.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- Fixes #577 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop