### PR TITLE
Report deniedForever when supposed to

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.5
+
+- Android: fixed issue where `checkPermission` reports permissions are `denied` when it should report permissions are `deniedForever` (see [#571](https://github.com/Baseflow/flutter-geolocator/issues/571)) 
+
 ## 6.1.4+1
 
 - Hotfix to make sure the `CLLocation.speedAccuracy` property is only compiled when using Xcode 12 or higher (see [#577](https://github.com/Baseflow/flutter-geolocator/issues/577)).

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
@@ -157,8 +157,11 @@ public class PermissionManager implements PluginRegistry.RequestPermissionsResul
       }
     }
 
-    for (String perm : permissions) {
-      PermissionUtils.setRequestedPermission(activity, perm);
+    for (int i = 0; i < permissions.length; i++) {
+      final String perm = permissions[i];
+      final int grantResult = grantResults[i];
+
+      PermissionUtils.setRequestedPermission(activity, perm, grantResult);
     }
 
     if (this.resultCallback != null) {

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 6.1.4+1
+version: 6.1.5
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

The `checkPermission` method doesn't report that permissions are denied forever when the user selects "don't ask again" on Android API 29 or when the user selects "deny" a second time on Android API 30.

### :new: What is the new behavior (if this is a feature change)?

The `checkPermission` method now correctly reports that permissions are denied forever when the user selects "don't ask again" on Android API 29 or when the user selects "deny" a second time on Android API 30.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- Fixes #571 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop