### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ android {
   ...
 }
 ```
-3. Make sure you replace all the `android.` dependencies to their AndroidX counterparts (a full list can be found here: https://developer.android.com/jetpack/androidx/migrate).
+3. Make sure you replace all the `android.` dependencies to their AndroidX counterparts (a full list can be found here: https://developer.android.com/jetpack/androidx/migrate ).
 
 **Permissions**
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix invalid URL on Android section of README.md


### :arrow_heading_down: What is the current behavior?
On pub.dev the URL for https://developer.android.com/jetpack/androidx/migrate includes also those two characters `).`, and that redirects to wrong page.

### :new: What is the new behavior (if this is a feature change)?
It should now redirect normally, sorry but I'm not possible to test that but im 99% sure that will fix the issue.


### :boom: Does this PR introduce a breaking change?
no


### :bug: Recommendations for testing
No idea how publishing packages to pub.dev looks like

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build (if everything was working before, yes)
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md)), that link also gives 404 :(
- [x] Relevant documentation was updated
- [x] Rebased onto current develop