### PR TITLE
Fixes IllegalArgumentException on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use this plugin, add `geolocator` as a [dependency in your pubspec.yaml file]
 
 ```yaml
 dependencies:
-  geolocator: ^6.1.4
+  geolocator: ^6.1.7
 ```
 
 <details>

--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.7
+
+- Resolved bug on Android where in some situations an IllegalArgumentException occures (see issue [#590](https://github.com/Baseflow/flutter-geolocator/issues/590)).
+
 ## 6.1.6
 
 - Improved the example app to minimize code that is not relevant, and prevent confusions.

--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -23,7 +23,7 @@ To use this plugin, add `geolocator` as a [dependency in your pubspec.yaml file]
 
 ```yaml
 dependencies:
-  geolocator: ^6.1.4
+  geolocator: ^6.1.7
 ```
 
 <details>

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -14,6 +14,7 @@ import com.baseflow.geolocator.errors.ErrorCodes;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.ResolvableApiException;
 import com.google.android.gms.location.*;
+import java.util.Random;
 
 class FusedLocationClient implements LocationClient {
   private final Context context;
@@ -30,7 +31,7 @@ class FusedLocationClient implements LocationClient {
     this.context = context;
     this.fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(context);
     this.locationOptions = locationOptions;
-    this.activityRequestCode = this.hashCode();
+    this.activityRequestCode = generateActivityRequestCode();
 
     locationCallback =
         new LocationCallback() {
@@ -61,6 +62,11 @@ class FusedLocationClient implements LocationClient {
             }
           }
         };
+  }
+
+  private synchronized int generateActivityRequestCode() {
+    Random random = new Random();
+    return random.nextInt(1 << 16);
   }
 
   @Override

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 6.1.6
+version: 6.1.7
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 
 environment:

--- a/geolocator_platform_interface/README.md
+++ b/geolocator_platform_interface/README.md
@@ -23,7 +23,7 @@ To use this plugin, add `geolocator` as a [dependency in your pubspec.yaml file]
 
 ```yaml
 dependencies:
-  geolocator: ^6.1.4
+  geolocator: ^6.1.7
 ```
 
 <details>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

On Android the geolocator can cause a `IllegalArgumentException` when requesting to enable location services.

### :new: What is the new behavior (if this is a feature change)?

In the old situation an activity request code was used that sometimes exceeded the 16 bit constraint. This PR ensures that the activity request code always falls within the 16 bit constraint.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

- Fixes #590 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop