### PR TITLE
Deprecate timeInterval parameter

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.8
+
+- Deprecate the `timeInterval` parameter of the `getPositionStream` method in favor of the more semantic `intervalDuration` parameter.
+
 ## 6.1.7
 
 - Resolved bug on Android where in some situations an IllegalArgumentException occures (see issue [#590](https://github.com/Baseflow/flutter-geolocator/issues/590)).

--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -23,7 +23,7 @@ To use this plugin, add `geolocator` as a [dependency in your pubspec.yaml file]
 
 ```yaml
 dependencies:
-  geolocator: ^6.1.7
+  geolocator: ^6.1.8
 ```
 
 <details>

--- a/geolocator/example/lib/main.dart
+++ b/geolocator/example/lib/main.dart
@@ -20,6 +20,7 @@ void main() {
 
 /// Example [Widget] showing the functionalities of the geolocator plugin
 class GeolocatorWidget extends StatefulWidget {
+  /// Utility method to create a page with the Baseflow templating.
   static ExamplePage createPage() {
     return ExamplePage(Icons.location_on, (context) => GeolocatorWidget());
   }

--- a/geolocator/lib/geolocator.dart
+++ b/geolocator/lib/geolocator.dart
@@ -284,8 +284,8 @@ class Geolocator {
   /// the update is emitted (default value is 0 indicator no filter is used).
   /// On Android you can force the use of the Android LocationManager instead
   /// of the FusedLocationProvider by setting the [forceAndroidLocationManager]
-  /// parameter to true. Using the [timeInterval] you can control the amount of
-  /// time that needs to pass before the next position update is send. The
+  /// parameter to true. Using the [intervalDuration] you can control the amount
+  /// of time that needs to pass before the next position update is send. The
   /// [timeLimit] parameter allows you to specify a timeout interval (by
   /// default no time limit is configured).
   ///
@@ -299,14 +299,18 @@ class Geolocator {
     LocationAccuracy desiredAccuracy = LocationAccuracy.best,
     int distanceFilter = 0,
     bool forceAndroidLocationManager = false,
+    @Deprecated(
+        'The timeInterval parameter has been deprecated, use the ' 
+        'intervalDuration parameter instead')
     int timeInterval = 0,
+    Duration intervalDuration,
     Duration timeLimit,
   }) =>
       GeolocatorPlatform.instance.getPositionStream(
         desiredAccuracy: desiredAccuracy,
         distanceFilter: distanceFilter,
         forceAndroidLocationManager: forceAndroidLocationManager,
-        timeInterval: timeInterval,
+        timeInterval: intervalDuration?.inMilliseconds ?? timeInterval,
         timeLimit: timeLimit,
       );
 

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 6.1.7
+version: 6.1.8
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 
 environment:

--- a/geolocator/test/geolocator_test.dart
+++ b/geolocator/test/geolocator_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:mockito/mockito.dart';
@@ -54,9 +55,44 @@ void main() {
     });
 
     test('getPositionStream', () async {
+      when(GeolocatorPlatform.instance.getPositionStream(
+        desiredAccuracy: LocationAccuracy.best,
+        forceAndroidLocationManager: false,
+        timeInterval: 0,
+        timeLimit: null,
+      )).thenAnswer((_) => Stream.value(mockPosition));
+
       final position = await Geolocator.getPositionStream();
 
       expect(position, emitsInOrder([emits(mockPosition), emitsDone]));
+    });
+
+    test('getPositionStream: time interval should be set to zero if left null.',
+        () async {
+      await Geolocator.getPositionStream(intervalDuration: null);
+
+      verify(GeolocatorPlatform.instance.getPositionStream(
+        desiredAccuracy: LocationAccuracy.best,
+        forceAndroidLocationManager: false,
+        timeInterval: 0,
+        timeLimit: null,
+      ));
+    });
+
+    test(
+        // ignore: lines_longer_than_80_chars
+        'getPositionStream: time interval duration should be set to milliseconds.',
+        () async {
+      await Geolocator.getPositionStream(
+        intervalDuration: Duration(seconds: 10),
+      );
+
+      verify(GeolocatorPlatform.instance.getPositionStream(
+        desiredAccuracy: LocationAccuracy.best,
+        forceAndroidLocationManager: false,
+        timeInterval: 10000,
+        timeLimit: null,
+      ));
     });
 
     test('openAppSettings', () async {
@@ -112,6 +148,7 @@ class MockGeolocatorPlatform extends Mock
   }) =>
       Future.value(mockPosition);
 
+/*  
   @override
   Stream<Position> getPositionStream({
     LocationAccuracy desiredAccuracy = LocationAccuracy.best,
@@ -121,7 +158,7 @@ class MockGeolocatorPlatform extends Mock
     Duration timeLimit,
   }) =>
       Stream.value(mockPosition);
-
+*/
   @override
   Future<bool> openAppSettings() => Future.value(true);
 

--- a/geolocator/test/geolocator_test.dart
+++ b/geolocator/test/geolocator_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:mockito/mockito.dart';


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

The `getPositionStream` method accepts an optional `timeInterval` parameter of type `int` and documentation is lacking on the unit to be used  This makes is difficult for developers to understand if they should supply the interval in hours, minutes, seconds, etc...).

### :new: What is the new behavior (if this is a feature change)?

With this PR the `timeInterval` parameter will be deprecated in favor of the `intervalDuration` parameter which accepts a value of type `Duration` making the API easier to understand and use.

### :boom: Does this PR introduce a breaking change?

No, the optional `timeInterval` parameter is still available but marked deprecated.

### :memo: Links to relevant issues/docs

Fixes #604 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop