### PR TITLE
Fix for wrongly reporting LocationServiceDisabledException

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.10
+
+- Filter false positive notifications on Android indicating location services are not available (see issue [#585](https://github.com/Baseflow/flutter-geolocator/issues/585)).
+
 ## 6.1.9
 
 - Return `LocationPermission.always` when requesting permission on Android 5.1 and below (see issue [#610](https://github.com/Baseflow/flutter-geolocator/issues/610)).

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -55,7 +55,7 @@ class FusedLocationClient implements LocationClient {
           @Override
           public synchronized void onLocationAvailability(
               LocationAvailability locationAvailability) {
-            if (!locationAvailability.isLocationAvailable() && checkLocationService(context)) {
+            if (!locationAvailability.isLocationAvailable() && !checkLocationService(context)) {
               if (errorCallback != null) {
                 errorCallback.onError(ErrorCodes.locationServicesDisabled);
               }

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -55,7 +55,7 @@ class FusedLocationClient implements LocationClient {
           @Override
           public synchronized void onLocationAvailability(
               LocationAvailability locationAvailability) {
-            if (!locationAvailability.isLocationAvailable()) {
+            if (!locationAvailability.isLocationAvailable() && checkLocationService(context)) {
               if (errorCallback != null) {
                 errorCallback.onError(ErrorCodes.locationServicesDisabled);
               }

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationClient.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationClient.java
@@ -2,6 +2,8 @@ package com.baseflow.geolocator.location;
 
 import android.app.Activity;
 
+import android.content.Context;
+import android.location.LocationManager;
 import com.baseflow.geolocator.errors.ErrorCallback;
 
 public interface LocationClient {
@@ -18,4 +20,11 @@ public interface LocationClient {
       ErrorCallback errorCallback);
 
   void stopPositionUpdates();
+  
+  default boolean checkLocationService(Context context){
+    LocationManager locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+    boolean gps_enabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+    boolean network_enabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+    return gps_enabled || network_enabled;
+  }
 }

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -21,8 +21,9 @@ import com.google.android.gms.common.util.Strings;
 import java.util.List;
 
 class LocationManagerClient implements LocationClient, LocationListener {
-  private static final long TWO_MINUTES = 120000;
 
+  private static final long TWO_MINUTES = 120000;
+  public Context context;
   private final LocationManager locationManager;
   @Nullable private final LocationOptions locationOptions;
 
@@ -37,6 +38,7 @@ class LocationManagerClient implements LocationClient, LocationListener {
       @NonNull Context context, @Nullable LocationOptions locationOptions) {
     this.locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
     this.locationOptions = locationOptions;
+    this.context = context;
   }
 
   @Override
@@ -46,14 +48,7 @@ class LocationManagerClient implements LocationClient, LocationListener {
       return;
     }
 
-    listener.onLocationServiceResult(checkLocationServices());
-  }
-
-  private boolean checkLocationServices() {
-    boolean gps_enabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
-    boolean network_enabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
-
-    return gps_enabled || network_enabled;
+    listener.onLocationServiceResult(checkLocationService(context));
   }
 
   @Override
@@ -85,7 +80,7 @@ class LocationManagerClient implements LocationClient, LocationListener {
       PositionChangedCallback positionChangedCallback,
       ErrorCallback errorCallback) {
 
-    if (!checkLocationServices()) {
+    if (!checkLocationService(context)) {
       errorCallback.onError(ErrorCodes.locationServicesDisabled);
       return;
     }

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 6.1.9
+version: 6.1.10
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

The geolocator wrongly reports a `LocationServiceDisabledException` when Android reports that the location availability status is updated to false.

### :new: What is the new behavior (if this is a feature change)?

The geolocator will now only report the `LocationServiceDisabledException` when Android reports that location is not available and location services are really down (basically added an additional check).

### :boom: Does this PR introduce a breaking change?

no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- Fixes #585 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop