### PR TITLE
Fix issue with concurrent access to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,8 @@ A Flutter geolocation plugin which provides easy access to platform specific loc
 
 ## Usage
 
-To use this plugin, add `geolocator` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/). For example:
-
-```yaml
-dependencies:
-  geolocator: ^6.1.7
-```
-
+To add the geolocator to your Flutter application read the [install](https://pub.dev/packages/geolocator/install) instructions. Below are some Android and iOS specifics that are required for the geolocator to work correctly.
+  
 <details>
 <summary>Android</summary>
   
@@ -54,7 +49,7 @@ android {
   ...
 }
 ```
-3. Make sure you replace all the `android.` dependencies to their AndroidX counterparts (a full list can be found here: https://developer.android.com/jetpack/androidx/migrate ).
+3. Make sure you replace all the `android.` dependencies to their AndroidX counterparts (a full list can be found here: https://developer.android.com/jetpack/androidx/migrate).
 
 **Permissions**
 

--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.11
+
+- Solve issue on Android which can throw a `ConcurrentModificationException` when accessing locations simultaneously (see issue [#620](https://github.com/Baseflow/flutter-geolocator/issues/620)).
+
 ## 6.1.10
 
 - Filter false positive notifications on Android indicating location services are not available (see issue [#585](https://github.com/Baseflow/flutter-geolocator/issues/585)).

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
@@ -13,7 +13,7 @@ import com.baseflow.geolocator.permission.LocationPermission;
 import com.baseflow.geolocator.permission.PermissionManager;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
-;
+
 import io.flutter.plugin.common.PluginRegistry.ActivityResultListener;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +24,7 @@ public class GeolocationManager implements ActivityResultListener {
 
   public GeolocationManager(@NonNull PermissionManager permissionManager) {
     this.permissionManager = permissionManager;
-    this.locationClients = new ArrayList<>();
+    this.locationClients = new CopyOnWriteArrayList<>();
   }
 
   public void getLastKnownPosition(

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
@@ -15,8 +15,8 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 
 import io.flutter.plugin.common.PluginRegistry.ActivityResultListener;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class GeolocationManager implements ActivityResultListener {
   @NonNull private final PermissionManager permissionManager;

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 6.1.10
+version: 6.1.11
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 
 environment:

--- a/geolocator_platform_interface/README.md
+++ b/geolocator_platform_interface/README.md
@@ -19,13 +19,8 @@ A Flutter geolocation plugin which provides easy access to platform specific loc
 
 ## Usage
 
-To use this plugin, add `geolocator` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/). For example:
-
-```yaml
-dependencies:
-  geolocator: ^6.1.7
-```
-
+To add the geolocator to your Flutter application read the [install](https://pub.dev/packages/geolocator/install) instructions. Below are some Android and iOS specifics that are required for the geolocator to work correctly.
+  
 <details>
 <summary>Android</summary>
   


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

In some situations the Android App can crash with a `ConcurrentModificationException`.

### :new: What is the new behavior (if this is a feature change)?

Convert the `locationClients` list from `ArrayList` type to a `CopyOnWriteArrayList` which is safe in concurrent situations and should prevent the exception above.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- Fixes #620 
### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop