### PR TITLE
[Android]: Improve retrieving the current location(new Android API)

### DIFF
--- a/geolocator/android/build.gradle
+++ b/geolocator/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 }
 
@@ -27,7 +27,7 @@ project.getTasks().withType(JavaCompile){
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 16
@@ -42,5 +42,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-location:17.0.0'
+    implementation 'com.google.android.gms:play-services-location:17.1.0'
 }

--- a/geolocator/android/gradle/wrapper/gradle-wrapper.properties
+++ b/geolocator/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-rc-1-bin.zip


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

- The latest improvements to the Fused Location Provider API (FLP).
   - **Prerequisites**: Android API Level >v27
- compileSdkVersion -> 30
- Gradle update2date

### :arrow_heading_down: What is the current behavior?

In order to get the current position, it has to subscribe to ongoing location changes.

### :new: What is the new behavior (if this is a feature change)?

Developers wanted an easier way to retrieve the current location. With the new `getCurrentLocation`() API (**Android API Level >v27**)  developers can get the current location in a single request, rather than having to subscribe to ongoing location changes. By allowing developers to request location only when needed (and automatically timing out and closing open location requests), this new API also improves battery life.

A sample of Kotlin https://github.com/android/location-samples/tree/main/CurrentLocationKotlin
 
- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop