### PR TITLE
Look for UIBackgroundModes location instead of EnableBackgroundLocationUpdates

### DIFF
--- a/geolocator/ios/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator/ios/Classes/Handlers/GeolocationHandler.m
@@ -84,11 +84,7 @@
 
 + (BOOL) shouldEnableBackgroundLocationUpdates {
     if (@available(iOS 9.0, *)) {
-        id config = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"EnableBackgroundLocationUpdates"];
-
-        if (!config) return NO;
-
-        return [config boolValue];
+        return [[NSBundle.mainBundle objectForInfoDictionaryKey:@"UIBackgroundModes"] containsObject: @"location"];
     } else {
         return NO;
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

EnableBackgroundLocationUpdates needs to be set in Info.plist

### :new: What is the new behavior (if this is a feature change)?

Only the UIBackgroundsMode tag > location tag is required

### :boom: Does this PR introduce a breaking change?

Yes, but the old behavior was undocumented

### :bug: Recommendations for testing

Try in an iOS app with just standard apple Info.plist entries, and press the home button to put the app in the background

### :memo: Links to relevant issues/docs

https://github.com/Baseflow/flutter-geolocator/pull/643#pullrequestreview-569175732

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop