### PR TITLE
Add  web support to geolocator package

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.0
+
+- Added web support.
+
 ## 6.1.14
 
 - iOS: Look for UIBackgroundModes location instead of having to register a separate `EnableBackgroundLocationUpdates` key in the Info.plist (see PR [#645](https://github.com/Baseflow/flutter-geolocator/pull/645)).

--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -87,6 +87,19 @@ If you would like to receive updates when your App is in the background, you'll 
 
 </details>
 
+<details>
+<summary>Web</summary>
+
+To use the Geolocator plugin on the web you need to be using Flutter 1.20 or higher. Flutter will automatically add the endorsed [geolocator_web]() package to your application when you add the `geolocator: ^6.2.0` dependency to your `pubspec.yaml`.
+
+Note that the following methods of the geolocator API are not supported on the web and will result in a `PlatformException` with the code `UNSUPPORTED_OPERATION`:
+
+- `getLastKnownPosition({ bool forceAndroidLocationManager = true })`
+- `openAppSettings()`
+- `openLocationSettings()`
+
+</details>
+
 ### Example
 
 The code below shows an example on how to acquire the current position of the device, including checking if the location services are enabled and checking / requesting permission to access the position of the device:
@@ -268,7 +281,7 @@ Please file any issues, bugs or feature requests as an issue on our [GitHub](htt
 
 ## Want to contribute
 
-If you would like to contribute to the plugin (e.g. by improving the documentation, solving a bug or adding a cool new feature), please carefully review our [contribution guide](CONTRIBUTING.md) and send us your [pull request](https://github.com/Baseflow/flutter-geolocator/pulls).
+If you would like to contribute to the plugin (e.g. by improving the documentation, solving a bug or adding a cool new feature), please carefully review our [contribution guide](../CONTRIBUTING.md) and send us your [pull request](https://github.com/Baseflow/flutter-geolocator/pulls).
 
 ## Author
 

--- a/geolocator/example/ios/Flutter/Release.xcconfig
+++ b/geolocator/example/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/geolocator/ios/geolocator.podspec
+++ b/geolocator/ios/geolocator.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'geolocator'
-  s.version          = '6.1.9'
+  s.version          = '6.2.0'
   s.summary          = 'Geolocation plugin for Flutter.'
   s.description      = <<-DESC
   Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 6.1.14
+version: 6.2.0
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 
 environment:
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   
   geolocator_platform_interface: ^1.0.8
+  geolocator_web: ^1.0.0
 
 dev_dependencies:
   flutter_test:
@@ -36,3 +37,5 @@ flutter:
         pluginClass: GeolocatorPlugin
       ios:
         pluginClass: GeolocatorPlugin
+      web:
+        default_package: geolocator_web


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

Although the geolocator_web package is live the geolocator plugin doesn't endorse it yet.

### :new: What is the new behavior (if this is a feature change)?

This PR endorses the geolocator_web package as part of the geolocator plugin, making it effectively the default web implementation for the geolocator.

### :boom: Does this PR introduce a breaking change?

no

### :bug: Recommendations for testing

1. Run the example App in the browser:
```bash
flutter run -d chrome
```

### :memo: Links to relevant issues/docs

- Resolves #392 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop