### PR TITLE
Implement `isLocationServiceEnabled` method for web platform

### DIFF
--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 2.0.3
+
+- Implement missing `isLocationServiceEnabled` for web implementation (see issue[#694](https://github.com/Baseflow/flutter-geolocator/issues/694)).
+
 ## 2.0.2
 
-- Solve bug receiving same location from stream when using ```distantFilter``` (see issue [#674](https://github.com/Baseflow/flutter-geolocator/issues/674))
+- Solve bug receiving same location from stream when using ```distantFilter``` (see issue [#674](https://github.com/Baseflow/flutter-geolocator/issues/674)).
 
 ## 2.0.1
 

--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 2.0.2
 
-- Solve bug receiving same location from stream when using ```distantFilter``` (see issue [#674](https://github.com/Baseflow/flutter-geolocator/issues/674)).
+- Solve bug receiving same location from stream when using `distantFilter` (see issue [#674](https://github.com/Baseflow/flutter-geolocator/issues/674)).
 
 ## 2.0.1
 

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -32,6 +32,14 @@ class GeolocatorPlugin extends GeolocatorPlatform {
       : _geolocation = geolocation,
         _permissions = permissions;
 
+  /// Returns a [Future] containing a [bool] value indicating whether location
+  /// services are enabled on the device.
+  ///
+  /// This will always return `true` on the web as the web platform doesn't know
+  /// the concept of a separate location service which has to be enabled.
+  @override
+  Future<bool> isLocationServiceEnabled() => Future.value(true);
+
   @override
   Future<LocationPermission> checkPermission() async {
     if (!_permissions.permissionsSupported) {

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: geolocator_web
 description: Official web implementation of the geolocator plugin.
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/geolocator_web
-version: 2.0.2
+version: 2.0.3
 
 flutter:
   plugin:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When calling the `isLocationServiceEnabled` method on the web platform the plugin throws an `UnimplementedError`.

### :new: What is the new behavior (if this is a feature change)?

The `isLocationServicesEnabled` method will now always return `true` instead of an `UnimplementedError`.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- Fixes #694 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
