### PR TITLE
fix: operator == takes Object parameter

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.2
+
+- Resolved analyzer error when using mockito (see issue [#709](https://github.com/Baseflow/flutter-geolocator/issues/709)).
+
 ## 7.0.1
 
 - Resolved bug when requesting permissions for the web (see issue [#673](https://github.com/Baseflow/flutter-geolocator/issues/673)).

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 7.0.1
+version: 7.0.2
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 
 environment:

--- a/geolocator_platform_interface/lib/src/models/position.dart
+++ b/geolocator_platform_interface/lib/src/models/position.dart
@@ -75,7 +75,7 @@ class Position {
   final bool isMocked;
 
   @override
-  bool operator ==(dynamic o) {
+  bool operator ==(Object o) {
     var areEqual = o is Position &&
         o.accuracy == accuracy &&
         o.altitude == altitude &&


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Update to remove analyser warning when using mockito

### :arrow_heading_down: What is the current behavior?
When flutter analyzer runs with sound null safety enabled and a class using Position is mocked you receive an error like:
```
  error • 'Object.==' ('bool Function(Object)') isn't a valid concrete implementation of 'Position.==' ('bool Function(dynamic)') • test/unit-tests/geolocation/geolocation_service_test.mocks.dart:16:7 • invalid_implementation_override
```

### :new: What is the new behavior (if this is a feature change)?
The analyzer is happy as the operator definition matches the correct parameters.


### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

No other changes are required so all existing tests should succeed to verify behaviour has not changed.

### :memo: Links to relevant issues/docs
https://github.com/dart-lang/mockito/issues/354

https://api.dart.dev/stable/2.12.2/dart-core/Object/operator_equals.html


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
