### PR TITLE
Issue/704

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+- Added definition of the `ActivityMissingException`.
+
 ## 2.0.1
 
 - Resolved analyzer error when using mockito (see issue [#709](https://github.com/Baseflow/flutter-geolocator/issues/709)).

--- a/geolocator_platform_interface/lib/src/errors/activity_missing_exception.dart
+++ b/geolocator_platform_interface/lib/src/errors/activity_missing_exception.dart
@@ -1,0 +1,23 @@
+/// An exception thrown when executing functionality which requires an Android
+/// while no activity is provided.
+/// 
+/// This exception is thrown on Android only and might occur hen running a 
+/// certain function from the background that requires a UI element (e.g. 
+/// requesting permissions or enabling the location services).
+class ActivityMissingException implements Exception {
+  /// Constructs the [ActivityMissingException]
+  const ActivityMissingException(this.message);
+
+  /// A [message] describing more details on the missing activity.
+  final String? message;
+
+  @override
+  String toString() {
+    if (message == null || message == '') {
+      return 'Activity is missing. This might happen when running a certain '
+             'function from the background that requires a UI element (e.g. '
+             'requesting permissions or enabling the location services).';
+    }
+    return message!;
+  }
+}

--- a/geolocator_platform_interface/lib/src/errors/activity_missing_exception.dart
+++ b/geolocator_platform_interface/lib/src/errors/activity_missing_exception.dart
@@ -1,8 +1,8 @@
 /// An exception thrown when executing functionality which requires an Android
 /// while no activity is provided.
-/// 
-/// This exception is thrown on Android only and might occur hen running a 
-/// certain function from the background that requires a UI element (e.g. 
+///
+/// This exception is thrown on Android only and might occur hen running a
+/// certain function from the background that requires a UI element (e.g.
 /// requesting permissions or enabling the location services).
 class ActivityMissingException implements Exception {
   /// Constructs the [ActivityMissingException]
@@ -15,8 +15,8 @@ class ActivityMissingException implements Exception {
   String toString() {
     if (message == null || message == '') {
       return 'Activity is missing. This might happen when running a certain '
-             'function from the background that requires a UI element (e.g. '
-             'requesting permissions or enabling the location services).';
+          'function from the background that requires a UI element (e.g. '
+          'requesting permissions or enabling the location services).';
     }
     return message!;
   }

--- a/geolocator_platform_interface/lib/src/errors/errors.dart
+++ b/geolocator_platform_interface/lib/src/errors/errors.dart
@@ -1,3 +1,4 @@
+export 'activity_missing_exception.dart';
 export 'already_subscribed_exception.dart';
 export 'invalid_permission_exception.dart';
 export 'location_service_disabled_exception.dart';

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -187,7 +187,7 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
   void _handlePlatformException(PlatformException exception) {
     switch (exception.code) {
-      case 'ACTIVITY_NOT_SUPPLIED':
+      case 'ACTIVITY_MISSING':
         throw ActivityMissingException(exception.message);
       case 'LOCATION_SERVICES_DISABLED':
         throw LocationServiceDisabledException();

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -187,6 +187,8 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
   void _handlePlatformException(PlatformException exception) {
     switch (exception.code) {
+      case 'ACTIVITY_NOT_SUPPLIED':
+        throw ActivityMissingException(exception.message);
       case 'LOCATION_SERVICES_DISABLED':
         throw LocationServiceDisabledException();
       case 'LOCATION_SUBSCRIPTION_ACTIVE':

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.0.2
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/test/src/errors/activity_missing_exception_test.dart
+++ b/geolocator_platform_interface/test/src/errors/activity_missing_exception_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
+
+void main() {
+  test('toString: Should return the default description when message is null',
+      () {
+    // Arrange
+    final expected =
+        'Activity is missing. This might happen when running a certain '
+        'function from the background that requires a UI element (e.g. '
+        'requesting permissions or enabling the location services).';
+    final exception = ActivityMissingException(null);
+
+    // Act
+    final actual = exception.toString();
+
+    // Assert
+    expect(actual, expected);
+  });
+
+  test('toString: Should return the default description when message is empty',
+      () {
+    // Arrange
+    final expected =
+        'Activity is missing. This might happen when running a certain '
+        'function from the background that requires a UI element (e.g. '
+        'requesting permissions or enabling the location services).';
+    final exception = ActivityMissingException('');
+
+    // Act
+    final actual = exception.toString();
+
+    // Assert
+    expect(actual, expected);
+  });
+
+  test('toString: Should return the message as description', () {
+    // Arrange
+    final expected = 'Dummy error message.';
+    final exception = ActivityMissingException(expected);
+
+    // Act
+    final actual = exception.toString();
+
+    // Assert
+    expect(actual, expected);
+  });
+}

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -189,7 +189,7 @@ void main() {
         );
       });
 
-      test('Should receive deniedForEver if permission is denied for ever',
+      test('Should receive deniedForever if permission is denied for ever',
           () async {
         // Arrange
         MethodChannelMock(
@@ -260,6 +260,35 @@ void main() {
               (e) => e.message,
               'description',
               'Permission definitions are not found.',
+            ),
+          ),
+        );
+      });
+
+      test('Should receive an exception when android activity is missing',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator',
+          method: 'requestPermission',
+          result: PlatformException(
+            code: 'ACTIVITY_MISSING',
+            message: 'Activity is missing.',
+            details: null,
+          ),
+        );
+
+        // Act
+        final permissionFuture = MethodChannelGeolocator().requestPermission();
+
+        // Assert
+        expect(
+          permissionFuture,
+          throwsA(
+            isA<ActivityMissingException>().having(
+              (e) => e.message,
+              'description',
+              'Activity is missing.',
             ),
           ),
         );


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When executing code on Android that requires an activity in a state where there is no activity available (e.g. when the App is running in the background), the geolocator will throw the exception mentioned in issue #704 which doesn't explain clearly what is really happening.

### :new: What is the new behavior (if this is a feature change)?

Throw a clear `ActivityMissingException` when the above situation occurs.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Added unit-tests to verify the code is working correctly.

### :memo: Links to relevant issues/docs

- Fixes #704

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
