### PR TITLE
Throw ActivityMissingException when activity is required but not available

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.3
+
+- Android: Throw the `ActivityMissingException` when requesting permissions while the activity is not available (e.g. when the App is in the background).
+
 ## 7.0.2
 
 - Upgrade to `geolocator_platform_interface: 2.0.1`

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/errors/ErrorCodes.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/errors/ErrorCodes.java
@@ -1,7 +1,7 @@
 package com.baseflow.geolocator.errors;
 
 public enum ErrorCodes {
-  activityNotSupplied,
+  activityMissing,
   errorWhileAcquiringPosition,
   locationServicesDisabled,
   permissionDefinitionsNotFound,
@@ -10,8 +10,8 @@ public enum ErrorCodes {
 
   public String toString() {
     switch (this) {
-      case activityNotSupplied:
-        return "ACTIVITY_NOT_SUPPLIED";
+      case activityMissing:
+        return "ACTIVITY_MISSING";
       case errorWhileAcquiringPosition:
         return "ERROR_WHILE_ACQUIRING_POSITION";
       case locationServicesDisabled:
@@ -29,7 +29,7 @@ public enum ErrorCodes {
 
   public String toDescription() {
     switch (this) {
-      case activityNotSupplied:
+      case activityMissing:
         return "Activity is missing. This might happen when running a certain function from the background that requires a UI element (e.g. requesting permissions or enabling the location services).";
       case errorWhileAcquiringPosition:
         return "An unexpected error occurred while trying to acquire the device's position.";

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
@@ -26,7 +26,6 @@ public class PermissionManager
   @Nullable private Activity activity;
   @Nullable private ErrorCallback errorCallback;
   @Nullable private PermissionResultCallback resultCallback;
-  private boolean permissionsDeniedBefore;
 
   public LocationPermission checkPermissionStatus(Context context, Activity activity)
       throws PermissionUndefinedException {
@@ -153,14 +152,10 @@ public class PermissionManager
       } else {
         permission = LocationPermission.always;
       }
-
-      permissionsDeniedBefore = false;
     } else {
       if (activity != null && !ActivityCompat.shouldShowRequestPermissionRationale(activity, requestedPermission)) {
         permission = LocationPermission.deniedForever;
       }
-
-      permissionsDeniedBefore = true;
     }
 
     if (this.resultCallback != null) {

--- a/geolocator/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
+++ b/geolocator/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
@@ -67,6 +67,11 @@ public class PermissionManager
       throws PermissionUndefinedException {
     final ArrayList<String> permissionsToRequest = new ArrayList<>();
 
+    if (activity == null) {
+      errorCallback.onError(ErrorCodes.activityMissing);
+      return;
+    }
+
     // Before Android M, requesting permissions was not needed.
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
       resultCallback.onResult(LocationPermission.always);
@@ -100,7 +105,7 @@ public class PermissionManager
     if (this.activity == null) {
       Log.e("Geolocator", "Trying to process permission result without an valid Activity instance");
       if (this.errorCallback != null) {
-        this.errorCallback.onError(ErrorCodes.activityNotSupplied);
+        this.errorCallback.onError(ErrorCodes.activityMissing);
       }
       return false;
     }

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 7.0.2
+version: 7.0.3
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   
-  geolocator_platform_interface: ^2.0.1
+  geolocator_platform_interface: ^2.0.2
   geolocator_web: ^2.0.1
 
 dev_dependencies:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When executing code on Android that requires an activity in a state where there is no activity available (e.g. when the App is running in the background), the geolocator will throw the exception mentioned in issue #704 which doesn't explain clearly what is really happening.

Note: this PR contains the actual Android implementation.

### :new: What is the new behavior (if this is a feature change)?

Throw a clear `ActivityMissingException` when the above situation occurs.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Added unit-tests to verify the code is working correctly.

### :memo: Links to relevant issues/docs

- Fixes #704

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
