### PR TITLE
Add support for the NSLocationAlwaysAndWhenInUseUsageDescription key in Info.plist

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 7.0.3
 
-- Android: Throw the `ActivityMissingException` when requesting permissions while the activity is not available (e.g. when the App is in the background).
+- Android: Throw the `ActivityMissingException` when requesting permissions while the activity is not available (e.g. when the App is in the background);
+- iOS: Support the `NSLocationAlwaysAndWhenInUseUsageDescription` key on iOS 11+ (this key replaces the `NSLocationAlwaysDescription` key which has been marked [deprecated](https://developer.apple.com/documentation/bundleresources/information_property_list/nslocationalwaysusagedescription?language=objc)). 
 
 ## 7.0.2
 

--- a/geolocator/ios/Classes/Handlers/PermissionHandler.m
+++ b/geolocator/ios/Classes/Handlers/PermissionHandler.m
@@ -49,7 +49,7 @@
     if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] != nil) {
         [self.locationManager requestWhenInUseAuthorization];
     }
-    else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] != nil) {
+    else if ([self containsLocationAlwaysDescription]) {
         [self.locationManager requestAlwaysAuthorization];
     }
     else {
@@ -63,6 +63,17 @@
         [self cleanUp];
         return;
     }
+}
+
+- (BOOL) containsLocationAlwaysDescription {
+    BOOL containsAlwaysDescription = NO;
+    if (@available(iOS 11.0, *)) {
+        containsAlwaysDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysAndWhenInUseUsageDescription"] != nil;
+    }
+    
+    return containsAlwaysDescription
+        ? containsAlwaysDescription
+        : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] != nil;
 }
 
 - (void) locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

The geolocator plugin doesn't recognize the `NSLocationAlwaysAndWhenInUseUsageDescription` key which is supported since iOS 11 and therefor doesn't support requesting background permissions when added to the Info.plist of an App.

### :new: What is the new behavior (if this is a feature change)?

Added support for the `NSLocationAlwaysAndWhenInUseUsageDescription` key on iOS. 

### :boom: Does this PR introduce a breaking change?

No, the `NSLocationAlwaysDescription` key is still supported and will be supported until Apple removes it.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- Related to issue #699

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
