### PR TITLE
Enable sound null safety in unittests

### DIFF
--- a/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
+++ b/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(mvanbeusekom): Remove once Mockito is migrated to null safety.
-// @dart = 2.9
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 import 'package:geolocator_platform_interface/src/implementations/method_channel_geolocator.dart';


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

Unit tests defined in the `geolocator_platform_interface_test.dart` file are still being run on Dart 2.9 which means they don't run in a sound null safe context.

### :new: What is the new behavior (if this is a feature change)?

Removed the `// @dart=2.9` modifier so tests should run in a sound null safe context.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Simply run: `flutter test`

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
