### PR TITLE
Refactored position stream logic iOS

### DIFF
--- a/geolocator/ios/Classes/GeolocatorPlugin.m
+++ b/geolocator/ios/Classes/GeolocatorPlugin.m
@@ -20,7 +20,7 @@
     FlutterMethodChannel *methodChannel = [FlutterMethodChannel
                                            methodChannelWithName:@"flutter.baseflow.com/geolocator"
                                            binaryMessenger:registrar.messenger];
-    FlutterEventChannel *eventChannel = [FlutterEventChannel
+    FlutterEventChannel *positionUpdatesEventChannel = [FlutterEventChannel
                                          eventChannelWithName:@"flutter.baseflow.com/geolocator_updates"
                                          binaryMessenger:registrar.messenger];
     
@@ -29,7 +29,7 @@
   
     PositionStreamHandler *positionStreamHandler = [[PositionStreamHandler alloc] initWithGeolocationHandler:instance.geolocationHandler
                                                                                            PermissionHandler:instance.permissionHandler];
-    [eventChannel setStreamHandler:positionStreamHandler];
+    [positionUpdatesEventChannel setStreamHandler:positionStreamHandler];
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {

--- a/geolocator/ios/Classes/GeolocatorPlugin.m
+++ b/geolocator/ios/Classes/GeolocatorPlugin.m
@@ -3,19 +3,18 @@
 #import "Constants/ErrorCodes.h"
 #import "Handlers/GeolocationHandler.h"
 #import "Handlers/PermissionHandler.h"
+#import "Handlers/PositionStreamHandler.h"
 #import "Utils/AuthorizationStatusMapper.h"
 #import "Utils/LocationAccuracyMapper.h"
 #import "Utils/LocationDistanceMapper.h"
 #import "Utils/LocationMapper.h"
 
-@interface GeolocatorPlugin() <FlutterStreamHandler>
+@interface GeolocatorPlugin()
 @property (strong, nonatomic) GeolocationHandler *geolocationHandler;
 @property (strong, nonatomic) PermissionHandler *permissionHandler;
 @end
 
-@implementation GeolocatorPlugin {
-    FlutterEventSink _eventSink;
-}
+@implementation GeolocatorPlugin
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
     FlutterMethodChannel *methodChannel = [FlutterMethodChannel
@@ -27,7 +26,10 @@
     
     GeolocatorPlugin *instance = [[GeolocatorPlugin alloc] init];
     [registrar addMethodCallDelegate:instance channel:methodChannel];
-    [eventChannel setStreamHandler:instance];
+  
+    PositionStreamHandler *positionStreamHandler = [[PositionStreamHandler alloc] initWithGeolocationHandler:instance.geolocationHandler
+                                                                                           PermissionHandler:instance.permissionHandler];
+    [eventChannel setStreamHandler:positionStreamHandler];
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
@@ -51,68 +53,6 @@
     } else { 
         result(FlutterMethodNotImplemented);
     }
-}
-
-- (FlutterError *_Nullable)onListenWithArguments:(id _Nullable)arguments eventSink:(FlutterEventSink)eventSink {
-    if (_eventSink) {
-        return [FlutterError errorWithCode: GeolocatorErrorLocationSubscriptionActive
-                                   message: @"Already listening for location updates. If you want to restart listening please cancel other subscriptions first."
-                                   details: nil];
-    }
-    _eventSink = eventSink;
-    
-    __weak typeof(self) weakSelf = self;
-    
-    [self.permissionHandler
-     requestPermission:^(CLAuthorizationStatus status) {
-        if (status != kCLAuthorizationStatusAuthorizedWhenInUse && status != kCLAuthorizationStatusAuthorizedAlways) {
-            [weakSelf onLocationFailureWithErrorCode: GeolocatorErrorPermissionDenied
-                                    errorDescription: @"User denied permissions to access the device's location."];
-            return;
-        }
-        
-        CLLocationAccuracy accuracy = [LocationAccuracyMapper toCLLocationAccuracy:(NSNumber *)arguments[@"accuracy"]];
-        CLLocationDistance distanceFilter = [LocationDistanceMapper toCLLocationDistance:(NSNumber *)arguments[@"distanceFilter"]];
-        
-        [[weakSelf geolocationHandler] startListeningWithDesiredAccuracy:accuracy
-                                                      distanceFilter:distanceFilter
-                                                       resultHandler:^(CLLocation *location) {
-            [weakSelf onLocationDidChange: location];
-        }
-                                                        errorHandler:^(NSString *errorCode, NSString *errorDescription){
-            [weakSelf onLocationFailureWithErrorCode:errorCode
-                                errorDescription:errorDescription];
-        }];
-    }
-     errorHandler:^(NSString *errorCode, NSString *errorDescription) {
-        [weakSelf onLocationFailureWithErrorCode:errorCode
-                                errorDescription:errorDescription];
-    }];
-    
-    return nil;
-}
-
-- (FlutterError *_Nullable)onCancelWithArguments:(id _Nullable)arguments {
-    [[self geolocationHandler] stopListening];
-    _eventSink = nil;
-    
-    return nil;
-}
-
-- (void)onLocationDidChange:(CLLocation *_Nullable)location {
-    if (!_eventSink) return;
-    
-    _eventSink([LocationMapper toDictionary:location]);
-}
-
-- (void)onLocationFailureWithErrorCode:(NSString *_Nonnull)errorCode
-                      errorDescription:(NSString *_Nonnull)errorDescription {
-    if (!_eventSink) return;
-    
-    _eventSink([FlutterError errorWithCode:errorCode
-                                   message:errorDescription
-                                   details:nil]);
-    _eventSink = nil;
 }
 
 - (void)onRequestPermission:(FlutterResult)result {

--- a/geolocator/ios/Classes/Handlers/GeolocationHandler.h
+++ b/geolocator/ios/Classes/Handlers/GeolocationHandler.h
@@ -5,6 +5,9 @@
 //  Created by Maurits van Beusekom on 23/06/2020.
 //
 
+#ifndef GeolocatorHandler_h
+#define GeolocatorHandler_h
+
 #import <CoreLocation/CoreLocation.h>
 #import <Foundation/Foundation.h>
 
@@ -22,3 +25,5 @@ typedef void (^GeolocatorResult)(CLLocation *_Nullable location);
 
 - (void)stopListening;
 @end
+
+#endif /* GeolocatorHandler_h */

--- a/geolocator/ios/Classes/Handlers/PermissionHandler.h
+++ b/geolocator/ios/Classes/Handlers/PermissionHandler.h
@@ -5,6 +5,9 @@
 //  Created by Maurits van Beusekom on 26/06/2020.
 //
 
+#ifndef PermissionHandler_h
+#define PermissionHandler_h
+
 #import <CoreLocation/CoreLocation.h>
 #import <Foundation/Foundation.h>
 
@@ -18,3 +21,5 @@ typedef void (^PermissionError)(NSString *errorCode, NSString *errorDiscription)
               errorHandler:(PermissionError)errorHandler;
 
 @end
+
+#endif /* PermissionHandler_h */

--- a/geolocator/ios/Classes/Handlers/PositionStreamHandler.h
+++ b/geolocator/ios/Classes/Handlers/PositionStreamHandler.h
@@ -1,0 +1,22 @@
+//
+//  PositionStreamHandler.h
+//  Pods
+//
+//  Created by Maurits van Beusekom on 04/06/2021.
+//
+
+#ifndef PositionStreamHandler_h
+#define PositionStreamHandler_h
+
+#import <Flutter/Flutter.h>
+#import "GeolocationHandler.h"
+#import "PermissionHandler.h"
+
+@interface PositionStreamHandler : NSObject<FlutterStreamHandler>
+
+- (id) initWithGeolocationHandler: (GeolocationHandler *)geolocationHandler
+                PermissionHandler: (PermissionHandler *)permissionHandler;
+
+@end
+
+#endif /* PositionStreamHandler_h */

--- a/geolocator/ios/Classes/Handlers/PositionStreamHandler.m
+++ b/geolocator/ios/Classes/Handlers/PositionStreamHandler.m
@@ -1,0 +1,100 @@
+//
+//  PositionStreamHandler.m
+//  geolocator
+//
+//  Created by Maurits van Beusekom on 04/06/2021.
+//
+
+#import "PositionStreamHandler.h"
+#import "../Constants/ErrorCodes.h"
+#import "../Utils/LocationAccuracyMapper.h"
+#import "../Utils/LocationDistanceMapper.h"
+#import "../Utils/LocationMapper.h"
+
+@interface PositionStreamHandler()
+  @property (strong, nonatomic, nonnull) GeolocationHandler *geolocationHandler;
+  @property (strong, nonatomic, nonnull) PermissionHandler *permissionHandler;
+@end
+
+@implementation PositionStreamHandler {
+  FlutterEventSink _eventSink;
+}
+
+- (id) initWithGeolocationHandler: (GeolocationHandler * _Nonnull)geolocationHandler
+                PermissionHandler: (PermissionHandler * _Nonnull)permissionHandler {
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+  
+  self.geolocationHandler = geolocationHandler;
+  self.permissionHandler = permissionHandler;
+  
+  return self;
+}
+
+- (FlutterError *_Nullable)onListenWithArguments:(id _Nullable)arguments eventSink:(FlutterEventSink)eventSink {
+  // When there is already an instance of the _eventSink it means there is already an active stream and
+  // return an error indicating the active stream.
+  if (_eventSink) {
+      return [FlutterError errorWithCode: GeolocatorErrorLocationSubscriptionActive
+                                 message: @"Already listening for location updates. If you want to restart listening please cancel other subscriptions first."
+                                 details: nil];
+  }
+  _eventSink = eventSink;
+  
+  __weak typeof(self) weakSelf = self;
+  
+  [_permissionHandler
+   requestPermission:^(CLAuthorizationStatus status) {
+      if (status != kCLAuthorizationStatusAuthorizedWhenInUse && status != kCLAuthorizationStatusAuthorizedAlways) {
+          [weakSelf onLocationFailureWithErrorCode: GeolocatorErrorPermissionDenied
+                                  errorDescription: @"User denied permissions to access the device's location."];
+          return;
+      }
+      
+      CLLocationAccuracy accuracy = [LocationAccuracyMapper toCLLocationAccuracy:(NSNumber *)arguments[@"accuracy"]];
+      CLLocationDistance distanceFilter = [LocationDistanceMapper toCLLocationDistance:(NSNumber *)arguments[@"distanceFilter"]];
+      
+      [[weakSelf geolocationHandler] startListeningWithDesiredAccuracy:accuracy
+                                                    distanceFilter:distanceFilter
+                                                     resultHandler:^(CLLocation *location) {
+          [weakSelf onLocationDidChange: location];
+      }
+                                                      errorHandler:^(NSString *errorCode, NSString *errorDescription){
+          [weakSelf onLocationFailureWithErrorCode:errorCode
+                              errorDescription:errorDescription];
+      }];
+  }
+   errorHandler:^(NSString *errorCode, NSString *errorDescription) {
+      [weakSelf onLocationFailureWithErrorCode:errorCode
+                              errorDescription:errorDescription];
+  }];
+  
+  return nil;
+}
+
+- (FlutterError *_Nullable)onCancelWithArguments:(id _Nullable)arguments {
+    [_geolocationHandler stopListening];
+    _eventSink = nil;
+    
+    return nil;
+}
+
+- (void)onLocationDidChange:(CLLocation *_Nullable)location {
+    if (!_eventSink) return;
+    
+    _eventSink([LocationMapper toDictionary:location]);
+}
+
+- (void)onLocationFailureWithErrorCode:(NSString *_Nonnull)errorCode
+                      errorDescription:(NSString *_Nonnull)errorDescription {
+    if (!_eventSink) return;
+    
+    _eventSink([FlutterError errorWithCode:errorCode
+                                   message:errorDescription
+                                   details:nil]);
+    _eventSink = nil;
+}
+
+@end


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Maintenance

### :arrow_heading_down: What is the current behavior?

The implementation of the `FlutterStreamHandler` handling position stream updates is part of the main `GeolocationPlugin` class making it difficult to add additional stream handlers and also doesn't respect the Single Responsibility Principle.

### :new: What is the new behavior (if this is a feature change)?

Moved the implementation of the `FlutterStreamHandler` handling position stream updates into its own `PositionStreamHandler` class reducing complexity in the `GeolocatorPlugin` class and allowing multiple stream handlers to be added.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the App on iOS and start listening to the position stream

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
  - It is not necessary to release this change as part of a new release.
- [ ] I updated CHANGELOG.md to add a description of the change.
  - It is not necessary to release this change as part of a new release.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
