### PR TITLE
Changed the README so it doesn't cause a 404 when clicking a link

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 7.1.1
+
+- Resolved a 404 error when clicking on the AndroidX migration link in the README.md
+
 ## 7.1.0
 
 - Added the locationServiceStream which fires an event if the location service of the device are disabled/enabled in the Android/iOS notification bar or in the Settings of the device.

--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -51,7 +51,7 @@ android {
   ...
 }
 ```
-3. Make sure you replace all the `android.` dependencies to their AndroidX counterparts (a full list can be found here: [Migrate to AndroidX](https://developer.android.com/jetpack/androidx/migrate)).
+3. Make sure you replace all the `android.` dependencies to their AndroidX counterparts (a full list can be found here: [Migrating to AndroidX](https://developer.android.com/jetpack/androidx/migrate)).
 
 **Permissions**
 

--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -51,7 +51,7 @@ android {
   ...
 }
 ```
-3. Make sure you replace all the `android.` dependencies to their AndroidX counterparts (a full list can be found here: https://developer.android.com/jetpack/androidx/migrate).
+3. Make sure you replace all the `android.` dependencies to their AndroidX counterparts (a full list can be found here: [Migrate to AndroidX](https://developer.android.com/jetpack/androidx/migrate)).
 
 **Permissions**
 

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 7.1.0
+version: 7.1.1
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update

### :arrow_heading_down: What is the current behavior?
When clicking the AndroidX migration link in the README Usage section -> Android -> Step 3 an 404 error will be shown

### :new: What is the new behavior (if this is a feature change)?
The user will be redirected to the correct link

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
does not apply

### :memo: Links to relevant issues/docs
does not apply

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
