### PR TITLE
Location Accuracy method for iOS 14 users

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+- Added the possibility to query for the LocationAccuracyStatus on iOS devices
+
 ## 2.1.1
 
 - Solves a bug which resulted in an issue when closing the position stream and requesting a new one (see issue [#703](https://github.com/Baseflow/flutter-geolocator/issues/703)).

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.0
 
-- Added the possibility to query for the LocationAccuracyStatus on iOS devices
+- Added the possibility to query for the LocationAccuracyStatus on devices running iOS 14.0 and higher.
 
 ## 2.1.1
 

--- a/geolocator_platform_interface/lib/src/enums/enums.dart
+++ b/geolocator_platform_interface/lib/src/enums/enums.dart
@@ -1,3 +1,4 @@
 export 'location_accuracy.dart';
+export 'location_accuracy_status.dart';
 export 'location_permission.dart';
 export 'location_service.dart';

--- a/geolocator_platform_interface/lib/src/enums/location_accuracy_status.dart
+++ b/geolocator_platform_interface/lib/src/enums/location_accuracy_status.dart
@@ -1,0 +1,8 @@
+/// Represent the current Location Accuracy Status on iOS devices
+enum LocationAccuracyStatus {
+  /// A approximate location will be returned (Approximate location)
+  reduced,
+
+  /// The precise location of the device will be returned
+  precise,
+}

--- a/geolocator_platform_interface/lib/src/enums/location_accuracy_status.dart
+++ b/geolocator_platform_interface/lib/src/enums/location_accuracy_status.dart
@@ -1,8 +1,8 @@
-/// Represent the current Location Accuracy Status on iOS devices
+/// Represent the current Location Accuracy Status on iOS 14.0 and higher.
 enum LocationAccuracyStatus {
-  /// A approximate location will be returned (Approximate location)
+  /// A approximate location will be returned (Approximate location).
   reduced,
 
-  /// The precise location of the device will be returned
+  /// The precise location of the device will be returned.
   precise,
 }

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -159,6 +159,15 @@ abstract class GeolocatorPlatform extends PlatformInterface {
     throw UnimplementedError('getPositionStream() has not been implemented.');
   }
 
+  /// Returns a [Future] containing a [LocationAccuracyStatus]
+  /// When on iOS the user has given permission for approximate location,
+  /// [LocationAccuracyStatus.reduced] will be returned, if the user gave
+  /// permission for precise/full accuracy location, [LocationAccuracyStatus.precise]
+  /// will be returned
+  Future<LocationAccuracyStatus> getLocationAccuracy() async {
+    throw UnimplementedError('getLocationAccuracy() has not been implemented.');
+  }
+
   /// Opens the App settings page.
   ///
   /// Returns [true] if the app settings page could be opened, otherwise

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -159,11 +159,12 @@ abstract class GeolocatorPlatform extends PlatformInterface {
     throw UnimplementedError('getPositionStream() has not been implemented.');
   }
 
-  /// Returns a [Future] containing a [LocationAccuracyStatus]
+  /// Returns a [Future] containing a [LocationAccuracyStatus].
+  ///
   /// When on iOS the user has given permission for approximate location,
   /// [LocationAccuracyStatus.reduced] will be returned, if the user gave
   /// permission for precise/full accuracy location, [LocationAccuracyStatus.precise]
-  /// will be returned
+  /// will be returned.
   Future<LocationAccuracyStatus> getLocationAccuracy() async {
     throw UnimplementedError('getLocationAccuracy() has not been implemented.');
   }

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -92,8 +92,9 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
   @override
   Future<LocationAccuracyStatus> getLocationAccuracy() async {
-    final accuracy = await _methodChannel.invokeMethod('getLocationAccuracy');
-    return LocationAccuracyStatus.values[accuracy as int];
+    final int accuracy =
+        await _methodChannel.invokeMethod('getLocationAccuracy');
+    return LocationAccuracyStatus.values[accuracy];
   }
 
   @override

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../../geolocator_platform_interface.dart';

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../../geolocator_platform_interface.dart';
@@ -88,6 +89,12 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
       rethrow;
     }
+  }
+
+  @override
+  Future<LocationAccuracyStatus> getLocationAccuracy() async {
+    final accuracy = await _methodChannel.invokeMethod('getLocationAccuracy');
+    return LocationAccuracyStatus.values[accuracy as int];
   }
 
   @override

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.1
+version: 2.2.0
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
+++ b/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
@@ -103,6 +103,20 @@ void main() {
 
     test(
         // ignore: lines_longer_than_80_chars
+        'Default implementation of getLocationAccuracy should throw unimplemented error',
+        () {
+      // Arrange
+      final geolocatorPlatform = ExtendsGeolocatorPlatform();
+
+      // Act & Assert
+      expect(
+        geolocatorPlatform.getLocationAccuracy(),
+        throwsUnimplementedError,
+      );
+    });
+
+    test(
+        // ignore: lines_longer_than_80_chars
         'Default implementation of getServiceStatusStream should throw unimplemented error',
         () {
       // Arrange

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -151,7 +151,7 @@ void main() {
             await MethodChannelGeolocator().getLocationAccuracy();
 
         // Assert
-            expect(locationAccuracy, LocationAccuracyStatus.reduced);
+        expect(locationAccuracy, LocationAccuracyStatus.reduced);
       });
 
       test(

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -134,6 +134,46 @@ void main() {
       });
     });
 
+    group('getLocationAccuracy: When requesting the Location Accuracy Status',
+        () {
+      test(
+          'Should receive reduced accuracy if Location Accuracy is reduced',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator',
+          method: 'getLocationAccuracy',
+          result: 0,
+        );
+
+        // Act
+        final locationAccuracy =
+            await MethodChannelGeolocator().getLocationAccuracy();
+
+        // Assert
+            expect(locationAccuracy, LocationAccuracyStatus.reduced);
+      });
+
+      test(
+          'Should receive reduced accuracy if Location Accuracy is reduced',
+              () async {
+            // Arrange
+            MethodChannelMock(
+              channelName: 'flutter.baseflow.com/geolocator',
+              method: 'getLocationAccuracy',
+              result: 1,
+            );
+
+            // Act
+            final locationAccuracy =
+            await MethodChannelGeolocator().getLocationAccuracy();
+
+            // Assert
+            expect(locationAccuracy, LocationAccuracyStatus.precise);
+          });
+
+    });
+
     group('requestPermission: When requesting for permission', () {
       test(
           // ignore: lines_longer_than_80_chars
@@ -585,7 +625,7 @@ void main() {
           channelName: 'flutter.baseflow.com/geolocator_updates',
           stream: streamController.stream,
         );
-        
+
         var stream = MethodChannelGeolocator().getPositionStream();
         StreamSubscription<Position>? streamSubscription =
             stream.listen((event) {});


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently iOS 14+ users aren't able to query whether they turned on Approximate location or Precise location fetching

### :new: What is the new behavior (if this is a feature change)?
With the method getLocationAccuracy, iOS users can query if they enabled Approximate location or Precise location fetching

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Does not apply

### :memo: Links to relevant issues/docs
Does not apply

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
