### PR TITLE
iOS 14+ users can query the selected Location Accuracy

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,10 +1,10 @@
 # 7.2.0
 
-- iOS 14: Users can now query whether they gave permission for Approximate location fetching or Precise location fetching
+- iOS 14: Users can now query whether they gave permission for Approximate location fetching or Precise location fetching.
 
 # 7.1.1
 
-- Resolved a 404 error when clicking on the AndroidX migration link in the README.md
+- Resolved a 404 error when clicking on the AndroidX migration link in the README.md.
 
 ## 7.1.0
 

--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 7.2.0
+
+- iOS 14: Users can now query whether they gave permission for Approximate location fetching or Precise location fetching
+
 # 7.1.1
 
 - Resolved a 404 error when clicking on the AndroidX migration link in the README.md

--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -202,10 +202,9 @@ StreamSubscription<ServiceStatus> serviceStatusStream = Geolocator.getServiceSta
 ```
 
 **iOS 14+ only**
-To query if a user enabled Approximate location fetching or Precise location fetching, you can call `getLocationAccuracy`.
-This will return a `Future<LocationAccuracyStatus` containing `LocationAccuracyStatus.reduced` if the user has enabled Approximate location fetching and containing `LocationAccuracyStatus.precise` if the user has enabled Precise location fetching.
-When calling `getLocationAccuracy` when the user has not given permission yet, the method will return `LocationAccuracyStatus.reduced` on default.
-If the user uses iOS 13 or below, the method `getLocationAccuracy` will return `LocationAccuracyStatus.precise`, since that is the default value for iOS 13 and below.
+To query if a user enabled Approximate location fetching or Precise location fetching, you can call the `Geolocator().getLocationAccuracy()` method. This will return a `Future<LocationAccuracyStatus>`, which when completed contains a `LocationAccuracyStatus.reduced` if the user has enabled Approximate location fetching or `LocationAccuracyStatus.precise` if the user has enabled Precise location fetching.
+When calling `getLocationAccuracy` before the user has given permission, the method will return `LocationAccuracyStatus.reduced` by default.
+On iOS 13 or below, the method `getLocationAccuracy` will always return `LocationAccuracyStatus.precise`, since that is the default value for iOS 13 and below.
 
 ``` dart
 import 'package:geolocator/geolocator.dart';

--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -201,6 +201,17 @@ StreamSubscription<ServiceStatus> serviceStatusStream = Geolocator.getServiceSta
     });
 ```
 
+**iOS 14+ only**
+To query if a user enabled Approximate location fetching or Precise location fetching, you can call `getLocationAccuracy`.
+This will return a `Future<LocationAccuracyStatus` containing `LocationAccuracyStatus.reduced` if the user has enabled Approximate location fetching and containing `LocationAccuracyStatus.precise` if the user has enabled Precise location fetching.
+When calling `getLocationAccuracy` when the user has not given permission yet, the method will return `LocationAccuracyStatus.reduced` on default.
+If the user uses iOS 13 or below, the method `getLocationAccuracy` will return `LocationAccuracyStatus.precise`, since that is the default value for iOS 13 and below.
+
+``` dart
+import 'package:geolocator/geolocator.dart';
+
+var accuracy = await Geolocator.getLocationAccuracy();
+```
 
 To check if location services are enabled you can call the `isLocationServiceEnabled` method:
 

--- a/geolocator/example/ios/Runner/Info.plist
+++ b/geolocator/example/ios/Runner/Info.plist
@@ -18,8 +18,6 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
-	<key>NSLocationDefaultAccuracyReduced</key>
-    <true/>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/geolocator/example/ios/Runner/Info.plist
+++ b/geolocator/example/ios/Runner/Info.plist
@@ -18,6 +18,8 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>NSLocationDefaultAccuracyReduced</key>
+    <true/>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/geolocator/ios/Classes/GeolocatorPlugin.m
+++ b/geolocator/ios/Classes/GeolocatorPlugin.m
@@ -8,6 +8,7 @@
 #import "Utils/LocationAccuracyMapper.h"
 #import "Utils/LocationDistanceMapper.h"
 #import "Utils/LocationMapper.h"
+#import "Handlers/LocationAccuracyHandler.h"
 #import "LocationServiceStreamHandler.h"
 
 @interface GeolocatorPlugin()
@@ -53,6 +54,9 @@
     } else if ([@"getCurrentPosition" isEqualToString:call.method]) {
         [self onGetCurrentPositionWithArguments:call.arguments
                                          result:result];
+    } else if([@"getLocationAccuracy" isEqualToString:call.method]) {
+        LocationAccuracyHandler *locationAccuracyHandler = [[LocationAccuracyHandler alloc] init];
+        [locationAccuracyHandler getLocationAccuracyWithResult:result];
     } else if ([@"openAppSettings" isEqualToString:call.method]) {
         [self openSettings:result];
     } else if ([@"openLocationSettings" isEqualToString:call.method]) {

--- a/geolocator/ios/Classes/Handlers/LocationAccuracyHandler.h
+++ b/geolocator/ios/Classes/Handlers/LocationAccuracyHandler.h
@@ -1,0 +1,24 @@
+//
+//  LocationAccuracyHandler.h
+//  Pods
+//
+//  Created by Floris Smit on 18/06/2021.
+//
+
+#ifndef LocationAccuracyHandler_h
+#define LocationAccuracyHandler_h
+
+#import <Flutter/Flutter.h>
+
+typedef enum {
+    reduced,
+    precise
+} LocationAccuracy;
+
+@interface LocationAccuracyHandler : NSObject
+
+- (void) getLocationAccuracyWithResult:(FlutterResult)result;
+
+@end
+
+#endif /* LocationAccuracyHandler_h */

--- a/geolocator/ios/Classes/Handlers/LocationAccuracyHandler.m
+++ b/geolocator/ios/Classes/Handlers/LocationAccuracyHandler.m
@@ -16,10 +16,10 @@
 @implementation LocationAccuracyHandler
 
 - (void) getLocationAccuracyWithResult:(FlutterResult)result {
-    CLLocationManager *locationManager = self.locationManager;
+    self.locationManager = [[CLLocationManager alloc] init];
     if (@available(iOS 14, *)) {
-        switch ([locationManager accuracyAuthorization]) {
-            case ".fullAccuracy":
+        switch ([self.locationManager accuracyAuthorization]) {
+            case CLAccuracyAuthorizationFullAccuracy:
                 return result([NSNumber numberWithInt:(LocationAccuracy)precise]);
             case CLAccuracyAuthorizationReducedAccuracy:
                 return result([NSNumber numberWithInt:(LocationAccuracy)reduced]);

--- a/geolocator/ios/Classes/Handlers/LocationAccuracyHandler.m
+++ b/geolocator/ios/Classes/Handlers/LocationAccuracyHandler.m
@@ -19,21 +19,18 @@
     CLLocationManager *locationManager = self.locationManager;
     if (@available(iOS 14, *)) {
         switch ([locationManager accuracyAuthorization]) {
-            case CLAccuracyAuthorizationFullAccuracy:
-                result([NSNumber numberWithInt:(LocationAccuracy)precise]);
-                break;
+            case ".fullAccuracy":
+                return result([NSNumber numberWithInt:(LocationAccuracy)precise]);
             case CLAccuracyAuthorizationReducedAccuracy:
-                result([NSNumber numberWithInt:(LocationAccuracy)reduced]);
-                break;
+                return result([NSNumber numberWithInt:(LocationAccuracy)reduced]);
             default:
-                // The default location accuracy is reduced (approximate location) due to battery life choices
-                result([NSNumber numberWithInt:(LocationAccuracy)precise]);
-                break;
+                // in iOS 14, reduced location accuracy is the default
+                return result([NSNumber numberWithInt:(LocationAccuracy)reduced]);
         }
     } else {
         // If the version of iOS is below version number 14, approximate location is not available, thus
         // precise location is always returned
-        result([NSNumber numberWithInt:(LocationAccuracy)precise]);
+        return result([NSNumber numberWithInt:(LocationAccuracy)precise]);
     }
 }
 

--- a/geolocator/ios/Classes/Handlers/LocationAccuracyHandler.m
+++ b/geolocator/ios/Classes/Handlers/LocationAccuracyHandler.m
@@ -1,0 +1,40 @@
+//
+//  LocationAccuracyHandler.m
+//  geolocator
+//
+//  Created by Floris Smit on 18/06/2021.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreLocation/CoreLocation.h>
+#import "LocationAccuracyHandler.h"
+
+@interface LocationAccuracyHandler()
+  @property (strong, nonatomic) CLLocationManager *locationManager;
+@end
+
+@implementation LocationAccuracyHandler
+
+- (void) getLocationAccuracyWithResult:(FlutterResult)result {
+    CLLocationManager *locationManager = self.locationManager;
+    if (@available(iOS 14, *)) {
+        switch ([locationManager accuracyAuthorization]) {
+            case CLAccuracyAuthorizationFullAccuracy:
+                result([NSNumber numberWithInt:(LocationAccuracy)precise]);
+                break;
+            case CLAccuracyAuthorizationReducedAccuracy:
+                result([NSNumber numberWithInt:(LocationAccuracy)reduced]);
+                break;
+            default:
+                // The default location accuracy is reduced (approximate location) due to battery life choices
+                result([NSNumber numberWithInt:(LocationAccuracy)precise]);
+                break;
+        }
+    } else {
+        // If the version of iOS is below version number 14, approximate location is not available, thus
+        // precise location is always returned
+        result([NSNumber numberWithInt:(LocationAccuracy)precise]);
+    }
+}
+
+@end

--- a/geolocator/ios/Classes/Handlers/LocationAccuracyHandler.m
+++ b/geolocator/ios/Classes/Handlers/LocationAccuracyHandler.m
@@ -9,16 +9,12 @@
 #import <CoreLocation/CoreLocation.h>
 #import "LocationAccuracyHandler.h"
 
-@interface LocationAccuracyHandler()
-  @property (strong, nonatomic) CLLocationManager *locationManager;
-@end
-
 @implementation LocationAccuracyHandler
 
 - (void) getLocationAccuracyWithResult:(FlutterResult)result {
-    self.locationManager = [[CLLocationManager alloc] init];
+    CLLocationManager *locationManager = [[CLLocationManager alloc] init];
     if (@available(iOS 14, *)) {
-        switch ([self.locationManager accuracyAuthorization]) {
+        switch ([locationManager accuracyAuthorization]) {
             case CLAccuracyAuthorizationFullAccuracy:
                 return result([NSNumber numberWithInt:(LocationAccuracy)precise]);
             case CLAccuracyAuthorizationReducedAccuracy:

--- a/geolocator/lib/geolocator.dart
+++ b/geolocator/lib/geolocator.dart
@@ -125,6 +125,14 @@ class Geolocator {
         timeLimit: timeLimit,
       );
 
+  /// Returns a [Future] containing a [LocationAccuracyStatus]
+  /// When the user has given permission for approximate location,
+  /// [LocationAccuracyStatus.reduced] will be returned, if the user has
+  /// given permission for precise location, [LocationAccuracyStatus.precise]
+  /// will be returned
+  static Future<LocationAccuracyStatus> getLocationAccuracy() =>
+      GeolocatorPlatform.instance.getLocationAccuracy();
+
   /// Fires whenever the location services are disabled/enabled in the notification
   /// bar or in the device settings. Returns ServiceStatus.enabled when location
   /// services are enabled and returns ServiceStatus.disabled when location

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 7.1.1
+version: 7.2.0
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   
-  geolocator_platform_interface: ^2.1.1
+  geolocator_platform_interface: ^2.2.0
   geolocator_web: ^2.0.1
 
 dev_dependencies:

--- a/geolocator/test/geolocator_test.dart
+++ b/geolocator/test/geolocator_test.dart
@@ -53,6 +53,12 @@ void main() {
       expect(position, mockPosition);
     });
 
+    test('getLocationAccuracy', () async {
+      final accuracy = await Geolocator.getLocationAccuracy();
+
+      expect(accuracy, LocationAccuracyStatus.reduced);
+    });
+
     test('getServiceStatusStream', () async {
       when(GeolocatorPlatform.instance.getServiceStatusStream())
           .thenAnswer((_) => Stream.value(ServiceStatus.enabled));
@@ -210,6 +216,10 @@ class MockGeolocatorPlatform extends Mock
 
   @override
   Future<bool> openAppSettings() => Future.value(true);
+
+  @override
+  Future<LocationAccuracyStatus> getLocationAccuracy() =>
+      Future.value(LocationAccuracyStatus.reduced);
 
   @override
   Future<bool> openLocationSettings() => Future.value(true);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently, you can't query whether iOS 14+ users gave permission to use Precise/Approximate location fetching

### :new: What is the new behavior (if this is a feature change)?
With `getLocationAccuracy` you can now query whether the user gave permission for Precise/Approximate location fetching

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Look at the docs at pub.dev

### :memo: Links to relevant issues/docs
Does not apply

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
