### PR TITLE
Default ios accuracy interface

### DIFF
--- a/.github/workflows/platform_interface_package.yaml
+++ b/.github/workflows/platform_interface_package.yaml
@@ -31,7 +31,7 @@ jobs:
       # Make sure the stable version of Flutter is available
       - uses: subosito/flutter-action@v1
         with:
-          channel: 'beta'
+          channel: 'stable'
 
       # Download all Flutter packages the geolocator depends on
       - name: Download dependencies

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0
+
+- Added the possibility to request temporary Precise Accuracy on iOS 14+ devices.
+
 ## 2.2.0
 
 - Added the possibility to query for the LocationAccuracyStatus on devices running iOS 14.0 and higher.

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0
+
+- Added the possibility to force the default location accuracy on iOS 14+ devices.
+
 ## 2.3.0
 
 - Added the possibility to request temporary Precise Accuracy on iOS 14+ devices.

--- a/geolocator_platform_interface/lib/src/errors/approximate_location_not_supported_exception.dart
+++ b/geolocator_platform_interface/lib/src/errors/approximate_location_not_supported_exception.dart
@@ -1,0 +1,21 @@
+/// An exception thrown when users using iOS 13 or below try to execute the
+/// 'requestTemporaryFullAccuracy' method.
+///
+/// Since Approximate location only supports iOS 14 or above, the exception is
+/// only thrown when using iOS 13 or below.
+class ApproximateLocationNotSupportedException implements Exception {
+  /// Constructs the [ApproximateLocationNotSupportedException]
+  const ApproximateLocationNotSupportedException(this.message);
+
+  /// A [message] describing more details about the exception
+  final String? message;
+
+  @override
+  String toString() {
+    if (message == null || message == '') {
+      return 'The requestTemporaryFullAccuracy method only supports iOS 14'
+          ' or above.';
+    }
+    return message!;
+  }
+}

--- a/geolocator_platform_interface/lib/src/errors/errors.dart
+++ b/geolocator_platform_interface/lib/src/errors/errors.dart
@@ -1,8 +1,10 @@
 export 'activity_missing_exception.dart';
 export 'already_subscribed_exception.dart';
+export 'approximate_location_not_supported_exception.dart';
 export 'invalid_permission_exception.dart';
 export 'location_service_disabled_exception.dart';
 export 'permission_definitions_not_found_exception.dart';
 export 'permission_denied_exception.dart';
 export 'permission_request_in_progress_exception.dart';
 export 'position_update_exception.dart';
+export 'precise_accuracy_enabled_exception.dart';

--- a/geolocator_platform_interface/lib/src/errors/precise_accuracy_enabled_exception.dart
+++ b/geolocator_platform_interface/lib/src/errors/precise_accuracy_enabled_exception.dart
@@ -1,0 +1,21 @@
+/// An exception thrown when the user already enabled Precise Location fetching.
+///
+/// This exception is thrown only when using iOS 14 or above.
+class PreciseAccuracyEnabledException implements Exception {
+  /// Constructs the [PreciseAccuracyEnabledException]
+  const PreciseAccuracyEnabledException(this.message);
+
+  /// A [message] describing more details about the exception.
+  final String? message;
+
+  @override
+  String toString() {
+    if (message == null || message == '') {
+      return 'The user already enabled Precise location fetching, when using '
+          'the requestTemporaryFullAccuracy, make sure to check whether the '
+          'user has already given permission to use Precise Accuracy.';
+    }
+
+    return message!;
+  }
+}

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -175,6 +175,21 @@ abstract class GeolocatorPlatform extends PlatformInterface {
     throw UnimplementedError('getPositionStream() has not been implemented.');
   }
 
+  /// Asks the user for Temporary Precise location access (iOS 14 or above).
+  ///
+  /// Throws a [AccuracyDictionaryNotFoundException] when the key
+  /// `NSLocationTemporaryUsageDescriptionDictionary` has not been set in the
+  /// `Infop.list`.
+  /// Throws a [PreciseAccuracyEnabledException] when the user already gave
+  /// permission to use Precise Accuracy location fetching.
+  /// Throws a [ApproximateLocationNotSupportedException] when Approximate
+  /// Location is not supported (iOS 13 or below).
+  Future<void> requestTemporaryFullAccuracy() {
+    // ignore: lines_longer_than_80_chars
+    throw UnimplementedError(
+        'requestTemporaryFullAccuracy() has not been implemented');
+  }
+
   /// Returns a [Future] containing a [LocationAccuracyStatus].
   ///
   /// When on iOS the user has given permission for approximate location,

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -92,6 +92,13 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// FusedLocationProvider by setting the [forceAndroidLocationManager]
   /// parameter to true. The [timeLimit] parameter allows you to specify a
   /// timeout interval (by default no time limit is configured).
+  /// On iOS you can force the use of the default accuracy
+  /// authorization status by setting the [defaultIosAccuracyAuthorization] to
+  /// true. For users using iOS 13 or below, the default will be
+  /// precise accuracy and for users using iOS 14+ the default is reduced
+  /// accuracy (except if the user explicitly chose for precise accuracy).
+  /// When setting the [defaultIosAccuracyAuthorization] to true, the
+  /// [desiredAccuracy] will be redundant.
   ///
   /// Throws a [TimeoutException] when no location is received within the
   /// supplied [timeLimit] duration.
@@ -101,6 +108,7 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// but the location services of the device are disabled.
   Future<Position> getCurrentPosition({
     LocationAccuracy desiredAccuracy = LocationAccuracy.best,
+    bool defaultIosAccuracyAuthorization = false,
     bool forceAndroidLocationManager = false,
     Duration? timeLimit,
   }) {
@@ -138,7 +146,14 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// the update is emitted (default value is 0 indicator no filter is used).
   /// On Android you can force the use of the Android LocationManager instead
   /// of the FusedLocationProvider by setting the [forceAndroidLocationManager]
-  /// parameter to true. Using the [timeInterval] you can control the amount of
+  /// parameter to true. On iOS you can force the use of the default accuracy
+  /// authorization status by setting the [defaultIosAccuracyAuthorization] to
+  /// true. For users using iOS 13 or below, the default will be
+  /// precise accuracy and for users using iOS 14+ the default is reduced
+  /// accuracy (except if the user explicitly chose for precise accuracy).
+  /// When setting the [defaultIosAccuracyAuthorization] to true, the
+  /// [desiredAccuracy] will be redundant.
+  /// Using the [timeInterval] you can control the amount of
   /// time that needs to pass before the next position update is send. The
   /// [timeLimit] parameter allows you to specify a timeout interval (by
   /// default no time limit is configured).
@@ -151,6 +166,7 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// but the location services of the device are disabled.
   Stream<Position> getPositionStream({
     LocationAccuracy desiredAccuracy = LocationAccuracy.best,
+    bool defaultIosAccuracyAuthorization = false,
     int distanceFilter = 0,
     bool forceAndroidLocationManager = false,
     int timeInterval = 0,

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -230,6 +230,17 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
   }
 
   @override
+  Future<void> requestTemporaryFullAccuracy() async {
+    try {
+      await _methodChannel.invokeMethod<void>('requestTemporaryFullAccuracy');
+      return;
+    } on PlatformException catch (e) {
+      _handlePlatformException(e);
+      rethrow;
+    }
+  }
+
+  @override
   Future<bool> openAppSettings() async => _methodChannel
       .invokeMethod<bool>('openAppSettings')
       .then((value) => value ?? false);
@@ -255,6 +266,10 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
         throw PermissionRequestInProgressException(exception.message);
       case 'LOCATION_UPDATE_FAILURE':
         throw PositionUpdateException(exception.message);
+      case 'PRECISE_ACCURACY_ENABLED':
+        throw PreciseAccuracyEnabledException(exception.message);
+      case 'APPROXIMATE_LOCATION_NOT_SUPPORTED':
+        throw ApproximateLocationNotSupportedException(exception.message);
       default:
         throw exception;
     }

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -100,11 +100,13 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
   @override
   Future<Position> getCurrentPosition({
     LocationAccuracy desiredAccuracy = LocationAccuracy.best,
+    bool defaultIosAccuracyAuthorization = false,
     bool forceAndroidLocationManager = false,
     Duration? timeLimit,
   }) async {
     final locationOptions = LocationOptions(
       accuracy: desiredAccuracy,
+      defaultIosAccuracyAuthorization: defaultIosAccuracyAuthorization,
       forceAndroidLocationManager: forceAndroidLocationManager,
     );
 
@@ -158,6 +160,7 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
   @override
   Stream<Position> getPositionStream({
     LocationAccuracy desiredAccuracy = LocationAccuracy.best,
+    bool defaultIosAccuracyAuthorization = false,
     int distanceFilter = 0,
     bool forceAndroidLocationManager = false,
     int timeInterval = 0,
@@ -165,6 +168,7 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
   }) {
     final locationOptions = LocationOptions(
       accuracy: desiredAccuracy,
+      defaultIosAccuracyAuthorization: defaultIosAccuracyAuthorization,
       distanceFilter: distanceFilter,
       forceAndroidLocationManager: forceAndroidLocationManager,
       timeInterval: timeInterval,

--- a/geolocator_platform_interface/lib/src/models/location_options.dart
+++ b/geolocator_platform_interface/lib/src/models/location_options.dart
@@ -7,11 +7,13 @@ class LocationOptions {
   ///
   /// The following default values are used:
   /// - accuracy: best
+  /// - defaultIosAccuracyAuthorization: false
   /// - distanceFilter: 0
   /// - forceAndroidLocationManager: false
   /// - timeInterval: 0
   const LocationOptions(
       {this.accuracy = LocationAccuracy.best,
+      this.defaultIosAccuracyAuthorization = false,
       this.distanceFilter = 0,
       this.forceAndroidLocationManager = false,
       this.timeInterval = 0});
@@ -21,6 +23,14 @@ class LocationOptions {
   ///
   /// The default value for this field is [LocationAccuracy.best].
   final LocationAccuracy accuracy;
+
+  /// Forces the Geolocator plugin to use the default Accuracy Authorization
+  /// (iOS only).
+  ///
+  /// On iOS 13 or below, the default value will always be Precise Accuracy. On
+  /// iOS 14+ the default value is Reduced Accuracy, but the value can change
+  /// based on the choice of the user.
+  final bool defaultIosAccuracyAuthorization;
 
   /// The minimum distance (measured in meters) a device must move
   /// horizontally before an update event is generated.
@@ -49,6 +59,7 @@ class LocationOptions {
   /// Serializes the [LocationOptions] to a map message.
   Map<String, dynamic> toJson() => <String, dynamic>{
         'accuracy': accuracy.index,
+        'defaultIosAccuracyAuthorization': defaultIosAccuracyAuthorization,
         'distanceFilter': distanceFilter,
         'forceAndroidLocationManager': forceAndroidLocationManager,
         'timeInterval': timeInterval

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.2.0
+version: 2.3.0
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.0
+version: 2.4.0
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
+++ b/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
@@ -75,6 +75,20 @@ void main() {
 
     test(
         // ignore: lines_longer_than_80_chars
+        'Default implementation of reqquestTemporaryAccuracy should throw unimplemented error',
+        () {
+      // Arrange
+      final geolocatorPlatform = ExtendsGeolocatorPlatform();
+
+      // Act & Assert
+      expect(
+        geolocatorPlatform.requestTemporaryFullAccuracy,
+        throwsUnimplementedError,
+      );
+    });
+
+    test(
+        // ignore: lines_longer_than_80_chars
         'Default implementation of getCurrentPosition should throw unimplemented error',
         () {
       // Arrange

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -585,10 +585,12 @@ void main() {
         );
         final expectedFirstArguments = LocationOptions(
           accuracy: LocationAccuracy.low,
+          defaultIosAccuracyAuthorization: false,
           forceAndroidLocationManager: false,
         );
         final expectedSecondArguments = LocationOptions(
           accuracy: LocationAccuracy.high,
+          defaultIosAccuracyAuthorization: true,
           forceAndroidLocationManager: true,
         );
 
@@ -596,10 +598,12 @@ void main() {
         final methodChannelGeolocator = MethodChannelGeolocator();
         final firstPosition = await methodChannelGeolocator.getCurrentPosition(
           desiredAccuracy: LocationAccuracy.low,
+          defaultIosAccuracyAuthorization: false,
           forceAndroidLocationManager: false,
         );
         final secondPosition = await methodChannelGeolocator.getCurrentPosition(
           desiredAccuracy: LocationAccuracy.high,
+          defaultIosAccuracyAuthorization: true,
           forceAndroidLocationManager: true,
         );
 

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -134,10 +134,127 @@ void main() {
       });
     });
 
+    group(
+        // ignore: lines_longer_than_80_chars
+        'requestTemporaryFullAccuracy: When requesting Temporary Precise location',
+        () {
+      test('Should receive an exception when precise location is enabled',
+          () async {
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator',
+          method: 'requestTemporaryFullAccuracy',
+          result: PlatformException(
+            code: 'PRECISE_ACCURACY_ENABLED',
+            message: 'Precise location is enabled.',
+            details: null,
+          ),
+        );
+
+        // Act
+        final accuracyFuture =
+            MethodChannelGeolocator().requestTemporaryFullAccuracy();
+
+        // Assert
+        expect(
+          accuracyFuture,
+          throwsA(
+            isA<PreciseAccuracyEnabledException>().having(
+              (e) => e.toString(),
+              'description',
+              'Precise location is enabled.',
+            ),
+          ),
+        );
+      });
+      test('Should receive an exception when iOS 13 or below is used',
+          () async {
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator',
+          method: 'requestTemporaryFullAccuracy',
+          result: PlatformException(
+            code: 'APPROXIMATE_LOCATION_NOT_SUPPORTED',
+            message: 'Approximate location not supported.',
+            details: null,
+          ),
+        );
+
+        // Act
+        final accuracyFuture =
+            MethodChannelGeolocator().requestTemporaryFullAccuracy();
+
+        // Assert
+        expect(
+          accuracyFuture,
+          throwsA(
+            isA<ApproximateLocationNotSupportedException>().having(
+              (e) => e.toString(),
+              'description',
+              'Approximate location not supported.',
+            ),
+          ),
+        );
+      });
+      test('Should receive an exception when precise location is enabled',
+          () async {
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator',
+          method: 'requestTemporaryFullAccuracy',
+          result: PlatformException(
+            code: 'PRECISE_ACCURACY_ENABLED',
+            message: null,
+            details: null,
+          ),
+        );
+
+        // Act
+        final accuracyFuture =
+            MethodChannelGeolocator().requestTemporaryFullAccuracy();
+
+        // Assert
+        expect(
+          accuracyFuture,
+          throwsA(isA<PreciseAccuracyEnabledException>().having(
+              (e) => e.toString(),
+              '',
+              'The user already enabled Precise location fetching, when using '
+                  'the requestTemporaryFullAccuracy, make sure to check '
+                  'whether the user has already given permission to use '
+                  'Precise Accuracy.')),
+        );
+      });
+      test('Should receive an exception when iOS 13 or below is used',
+          () async {
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator',
+          method: 'requestTemporaryFullAccuracy',
+          result: PlatformException(
+            code: 'APPROXIMATE_LOCATION_NOT_SUPPORTED',
+            message: null,
+            details: null,
+          ),
+        );
+
+        // Act
+        final accuracyFuture =
+            MethodChannelGeolocator().requestTemporaryFullAccuracy();
+
+        // Assert
+        expect(
+          accuracyFuture,
+          throwsA(
+            isA<ApproximateLocationNotSupportedException>().having(
+                (e) => e.toString(),
+                '',
+                'The requestTemporaryFullAccuracy method only supports iOS 14'
+                    ' or above.'),
+          ),
+        );
+      });
+    });
+
     group('getLocationAccuracy: When requesting the Location Accuracy Status',
         () {
-      test(
-          'Should receive reduced accuracy if Location Accuracy is reduced',
+      test('Should receive reduced accuracy if Location Accuracy is reduced',
           () async {
         // Arrange
         MethodChannelMock(
@@ -154,24 +271,22 @@ void main() {
         expect(locationAccuracy, LocationAccuracyStatus.reduced);
       });
 
-      test(
-          'Should receive reduced accuracy if Location Accuracy is reduced',
-              () async {
-            // Arrange
-            MethodChannelMock(
-              channelName: 'flutter.baseflow.com/geolocator',
-              method: 'getLocationAccuracy',
-              result: 1,
-            );
+      test('Should receive reduced accuracy if Location Accuracy is reduced',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator',
+          method: 'getLocationAccuracy',
+          result: 1,
+        );
 
-            // Act
-            final locationAccuracy =
+        // Act
+        final locationAccuracy =
             await MethodChannelGeolocator().getLocationAccuracy();
 
-            // Assert
-            expect(locationAccuracy, LocationAccuracyStatus.precise);
-          });
-
+        // Assert
+        expect(locationAccuracy, LocationAccuracyStatus.precise);
+      });
     });
 
     group('requestPermission: When requesting for permission', () {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently users can't force the default location accuracy on iOS 14+ devices to be used when executing the `getCurrentPosition()` or `getPositionStream()` method.

### :new: What is the new behavior (if this is a feature change)?
The`boolean` parameter `defaultIosAccuracyAuthorization` can be added to `getCurrentPosition()` and the `getPositionStream()` method. `defaultIosAccuracyAuthorization` will be false on default.
 
### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Use the example application

### :memo: Links to relevant issues/docs
Does not apply

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
