### PR TITLE
Clarified docs getLocationAccuracy and added enum value for Android devices

### DIFF
--- a/.github/workflows/platform_interface_package.yaml
+++ b/.github/workflows/platform_interface_package.yaml
@@ -31,7 +31,7 @@ jobs:
       # Make sure the stable version of Flutter is available
       - uses: subosito/flutter-action@v1
         with:
-          channel: 'beta'
+          channel: 'stable'
 
       # Download all Flutter packages the geolocator depends on
       - name: Download dependencies

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.1
+
+- Documentation `getLocationAccuracy()` method clarified
+- On Android devices, `getLocationAccuracy()` now returns a LocationAccuracyStatus.unknown value
+
 ## 2.2.0
 
 - Added the possibility to query for the LocationAccuracyStatus on devices running iOS 14.0 and higher.

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.2.1
 
-- Documentation `getLocationAccuracy()` method clarified
-- On Android devices, `getLocationAccuracy()` now returns a LocationAccuracyStatus.unknown value
+- Documentation `getLocationAccuracy()` method clarified.
+- Extended the `LocationAccuracyStatus` enum with a `LocationAccuracyStatus.unknown` value, which can be used by platforms that don't support location accuracy features.
 
 ## 2.2.0
 

--- a/geolocator_platform_interface/lib/src/enums/location_accuracy_status.dart
+++ b/geolocator_platform_interface/lib/src/enums/location_accuracy_status.dart
@@ -5,4 +5,9 @@ enum LocationAccuracyStatus {
 
   /// The precise location of the device will be returned.
   precise,
+
+  /// When an Android device is used, an 'unknown' status is returned, since
+  /// Android does not support Approximate Location yet.
+  unknown,
+
 }

--- a/geolocator_platform_interface/lib/src/enums/location_accuracy_status.dart
+++ b/geolocator_platform_interface/lib/src/enums/location_accuracy_status.dart
@@ -9,5 +9,4 @@ enum LocationAccuracyStatus {
   /// When an Android device is used, an 'unknown' status is returned, since
   /// Android does not support Approximate Location yet.
   unknown,
-
 }

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -165,8 +165,8 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// [LocationAccuracyStatus.reduced] will be returned, if the user gave
   /// permission for precise/full accuracy location, [LocationAccuracyStatus.precise]
   /// will be returned.
-  /// When executing the method on Android device's,
-  /// [LocationAccuracyStatus.unknown] will be returned.
+  /// When executing the method on platforms that don't support location
+  /// accuracy features [LocationAccuracyStatus.unknown] should be returned.
   Future<LocationAccuracyStatus> getLocationAccuracy() async {
     throw UnimplementedError('getLocationAccuracy() has not been implemented.');
   }

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -159,12 +159,14 @@ abstract class GeolocatorPlatform extends PlatformInterface {
     throw UnimplementedError('getPositionStream() has not been implemented.');
   }
 
-  /// Returns a [Future] containing a [LocationAccuracyStatus].
+  /// Returns a [Future] containing a [LocationAccuracyStatus] (iOS only).
   ///
   /// When on iOS the user has given permission for approximate location,
   /// [LocationAccuracyStatus.reduced] will be returned, if the user gave
   /// permission for precise/full accuracy location, [LocationAccuracyStatus.precise]
   /// will be returned.
+  /// When executing the method on Android device's,
+  /// [LocationAccuracyStatus.unknown] will be returned.
   Future<LocationAccuracyStatus> getLocationAccuracy() async {
     throw UnimplementedError('getLocationAccuracy() has not been implemented.');
   }

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import '../../geolocator_platform_interface.dart';
@@ -92,6 +93,9 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
   @override
   Future<LocationAccuracyStatus> getLocationAccuracy() async {
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      return LocationAccuracyStatus.unknown;
+    }
     final int accuracy =
         await _methodChannel.invokeMethod('getLocationAccuracy');
     return LocationAccuracyStatus.values[accuracy];

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -93,9 +93,6 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
   @override
   Future<LocationAccuracyStatus> getLocationAccuracy() async {
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
-      return LocationAccuracyStatus.unknown;
-    }
     final int accuracy =
         await _methodChannel.invokeMethod('getLocationAccuracy');
     return LocationAccuracyStatus.values[accuracy];

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import '../../geolocator_platform_interface.dart';

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.2.0
+version: 2.2.1
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -153,7 +153,7 @@ void main() {
         expect(locationAccuracy, LocationAccuracyStatus.reduced);
       });
 
-      test('Should receive reduced accuracy if Location Accuracy is reduced',
+      test('Should receive reduced accuracy if Location Accuracy is precise',
           () async {
         // Arrange
         MethodChannelMock(
@@ -168,23 +168,6 @@ void main() {
 
         // Assert
         expect(locationAccuracy, LocationAccuracyStatus.precise);
-      });
-
-      test('Should receive reduced accuracy if Location Accuracy is reduced',
-          () async {
-        // Arrange
-        MethodChannelMock(
-          channelName: 'flutter.baseflow.com/geolocator',
-          method: 'getLocationAccuracy',
-          result: 2,
-        );
-
-        // Act
-        final locationAccuracy =
-            await MethodChannelGeolocator().getLocationAccuracy();
-
-        // Assert
-        expect(locationAccuracy, LocationAccuracyStatus.unknown);
       });
     });
 

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -136,8 +136,7 @@ void main() {
 
     group('getLocationAccuracy: When requesting the Location Accuracy Status',
         () {
-      test(
-          'Should receive reduced accuracy if Location Accuracy is reduced',
+      test('Should receive reduced accuracy if Location Accuracy is reduced',
           () async {
         // Arrange
         MethodChannelMock(
@@ -154,24 +153,39 @@ void main() {
         expect(locationAccuracy, LocationAccuracyStatus.reduced);
       });
 
-      test(
-          'Should receive reduced accuracy if Location Accuracy is reduced',
-              () async {
-            // Arrange
-            MethodChannelMock(
-              channelName: 'flutter.baseflow.com/geolocator',
-              method: 'getLocationAccuracy',
-              result: 1,
-            );
+      test('Should receive reduced accuracy if Location Accuracy is reduced',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator',
+          method: 'getLocationAccuracy',
+          result: 1,
+        );
 
-            // Act
-            final locationAccuracy =
+        // Act
+        final locationAccuracy =
             await MethodChannelGeolocator().getLocationAccuracy();
 
-            // Assert
-            expect(locationAccuracy, LocationAccuracyStatus.precise);
-          });
+        // Assert
+        expect(locationAccuracy, LocationAccuracyStatus.precise);
+      });
 
+      test('Should receive reduced accuracy if Location Accuracy is reduced',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator',
+          method: 'getLocationAccuracy',
+          result: 2,
+        );
+
+        // Act
+        final locationAccuracy =
+            await MethodChannelGeolocator().getLocationAccuracy();
+
+        // Assert
+        expect(locationAccuracy, LocationAccuracyStatus.unknown);
+      });
     });
 
     group('requestPermission: When requesting for permission', () {


### PR DESCRIPTION
…or android to the LocationAccuracyStatus enum

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update / small implementation change

### :arrow_heading_down: What is the current behavior?
Currently when Android users execute the `getLocationAccuracy()` method a PluginException will be thrown. Also, the code documentation did not mention about the iOS only support.

### :new: What is the new behavior (if this is a feature change)?
When Android users execute the `getLocationAccuracy()` method now, a LocationAccuracyStatus.unknown will be returned, since Android does not support Approximate location yet. Also the documentation has been clarified.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Does not apply

### :memo: Links to relevant issues/docs
Does not apply

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
