### PR TITLE
Temporary Precise Location Platform Interface

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0
+
+- Added the possibility to request temporary Precise Accuracy on iOS 14+ devices.
+
 ## 2.2.1
 
 - Documentation `getLocationAccuracy()` method clarified.

--- a/geolocator_platform_interface/lib/src/enums/location_accuracy.dart
+++ b/geolocator_platform_interface/lib/src/enums/location_accuracy.dart
@@ -24,5 +24,5 @@ enum LocationAccuracy {
 
   /// Location accuracy is reduced for iOS 14+ devices, matches the
   /// [LocationAccuracy.lowest] on iOS 13 and below and all other platforms.
-  reduced
+  reduced,
 }

--- a/geolocator_platform_interface/lib/src/enums/location_accuracy.dart
+++ b/geolocator_platform_interface/lib/src/enums/location_accuracy.dart
@@ -20,5 +20,9 @@ enum LocationAccuracy {
 
   /// Location accuracy is optimized for navigation on iOS and matches the
   /// [LocationAccuracy.best] on Android
-  bestForNavigation
+  bestForNavigation,
+
+  /// Location accuracy is reduced for iOS 14+ devices, matches the
+  /// [LocationAccuracy.lowest] on iOS 13 and below and all other platforms.
+  reduced
 }

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:vector_math/vector_math.dart';
 
+import '../geolocator_platform_interface.dart';
 import 'enums/enums.dart';
 import 'implementations/method_channel_geolocator.dart';
 import 'models/models.dart';
@@ -159,7 +160,22 @@ abstract class GeolocatorPlatform extends PlatformInterface {
     throw UnimplementedError('getPositionStream() has not been implemented.');
   }
 
-  /// Returns a [Future] containing a [LocationAccuracyStatus] (iOS only).
+  /// Asks the user for Temporary Precise location access (iOS 14 or above).
+  ///
+  /// Returns [LocationAccuracyStatus.precise] if the user already gave
+  /// permission to use Precise Accuracy. If the user uses iOS 13 or below,
+  /// [LocationAccuracyStatus.precise] will also be returned. On other platforms
+  /// an PlatformException will be thrown.
+  ///
+  /// Throws a [PermissionDefinitionsNotFoundException] when the key
+  /// `NSLocationTemporaryUsageDescriptionDictionary` has not been set in the
+  /// `Infop.list`.
+  Future<LocationAccuracyStatus> requestTemporaryFullAccuracy() async {
+    throw UnimplementedError(
+        'requestTemporaryFullAccuracy() has not been implemented');
+  }
+
+  /// Returns a [Future] containing a [LocationAccuracyStatus].
   ///
   /// When on iOS the user has given permission for approximate location,
   /// [LocationAccuracyStatus.reduced] will be returned, if the user gave

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -226,6 +226,18 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
   }
 
   @override
+  Future<LocationAccuracyStatus> requestTemporaryFullAccuracy() async {
+    try {
+      final int status =
+          await _methodChannel.invokeMethod('requestTemporaryFullAccuracy');
+      return LocationAccuracyStatus.values[status];
+    } on PlatformException catch (e) {
+      _handlePlatformException(e);
+      rethrow;
+    }
+  }
+
+  @override
   Future<bool> openAppSettings() async => _methodChannel
       .invokeMethod<bool>('openAppSettings')
       .then((value) => value ?? false);

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.2.1
+version: 2.3.0
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
+++ b/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
@@ -75,6 +75,20 @@ void main() {
 
     test(
         // ignore: lines_longer_than_80_chars
+        'Default implementation of reqquestTemporaryAccuracy should throw unimplemented error',
+        () {
+      // Arrange
+      final geolocatorPlatform = ExtendsGeolocatorPlatform();
+
+      // Act & Assert
+      expect(
+        geolocatorPlatform.requestTemporaryFullAccuracy,
+        throwsUnimplementedError,
+      );
+    });
+
+    test(
+        // ignore: lines_longer_than_80_chars
         'Default implementation of getCurrentPosition should throw unimplemented error',
         () {
       // Arrange

--- a/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
+++ b/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
@@ -75,7 +75,7 @@ void main() {
 
     test(
         // ignore: lines_longer_than_80_chars
-        'Default implementation of reqquestTemporaryAccuracy should throw unimplemented error',
+        'Default implementation of requestTemporaryAccuracy should throw unimplemented error',
         () {
       // Arrange
       final geolocatorPlatform = ExtendsGeolocatorPlatform();

--- a/geolocator_platform_interface/test/src/enums/location_accuracy_test.dart
+++ b/geolocator_platform_interface/test/src/enums/location_accuracy_test.dart
@@ -2,10 +2,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 
 void main() {
-  test('LocationAccuracy should contain 6 options', () {
+  test('LocationAccuracy should contain 7 options', () {
     final values = LocationAccuracy.values;
 
-    expect(values.length, 6);
+    expect(values.length, 7);
   });
 
   test("LocationAccuracy enum should have items in correct index", () {
@@ -17,5 +17,6 @@ void main() {
     expect(values[3], LocationAccuracy.high);
     expect(values[4], LocationAccuracy.best);
     expect(values[5], LocationAccuracy.bestForNavigation);
+    expect(values[6], LocationAccuracy.reduced);
   });
 }

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -134,6 +134,73 @@ void main() {
       });
     });
 
+    group(
+        'requestTemporaryFullAccuracy: When requesting temporary full'
+        'accuracy.', () {
+      test(
+          'Should receive reduced accuracy if Location Accuracy is pinned to'
+          ' reduced', () async {
+        // Arrange
+        MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator',
+            method: 'requestTemporaryFullAccuracy',
+            result: 0);
+
+        // Act
+        final accuracy =
+            await MethodChannelGeolocator().requestTemporaryFullAccuracy();
+
+        // Assert
+        expect(accuracy, LocationAccuracyStatus.reduced);
+      });
+
+      test(
+          'Should receive reduced accuracy if Location Accuracy is already set'
+          ' to precise location accuracy', () async {
+        // Arrange
+        MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator',
+            method: 'requestTemporaryFullAccuracy',
+            result: 1);
+
+        // Act
+        final accuracy =
+            await MethodChannelGeolocator().requestTemporaryFullAccuracy();
+
+        // Assert
+        expect(accuracy, LocationAccuracyStatus.precise);
+      });
+
+      test('Should receive an exception when permission definitions not found',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator',
+          method: 'requestTemporaryFullAccuracy',
+          result: PlatformException(
+            code: 'PERMISSION_DEFINITIONS_NOT_FOUND',
+            message: 'Permission definitions are not found.',
+            details: null,
+          ),
+        );
+
+        // Act
+        final future = MethodChannelGeolocator().requestTemporaryFullAccuracy();
+
+        // Assert
+        expect(
+          future,
+          throwsA(
+            isA<PermissionDefinitionsNotFoundException>().having(
+              (e) => e.message,
+              'description',
+              'Permission definitions are not found.',
+            ),
+          ),
+        );
+      });
+    });
+
     group('getLocationAccuracy: When requesting the Location Accuracy Status',
         () {
       test('Should receive reduced accuracy if Location Accuracy is reduced',
@@ -153,7 +220,7 @@ void main() {
         expect(locationAccuracy, LocationAccuracyStatus.reduced);
       });
 
-      test('Should receive reduced accuracy if Location Accuracy is precise',
+      test('Should receive reduced accuracy if Location Accuracy is reduced',
           () async {
         // Arrange
         MethodChannelMock(


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently users can't request temporary full accuracy location fetching

### :new: What is the new behavior (if this is a feature change)?
Users can now request temporary full accuracy location fetching by using the 'requestTemporaryFullAccuracy'

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Use the example application

### :memo: Links to relevant issues/docs
Does not apply

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.