### PR TITLE
Fix unsubscribe not removing position stream

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+- Solves a bug which resulted in an issue when closing the position stream.
+
 ## 2.3.0
 
 - Added the possibility to request temporary Precise Accuracy on iOS 14+ devices.

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -207,22 +207,10 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
   }
 
   Stream<dynamic> _wrapStream(Stream<dynamic> incoming) {
-    late StreamSubscription subscription;
-    late StreamController<dynamic> controller;
-    controller = StreamController<dynamic>(
-      onListen: () {
-        subscription = incoming.listen(
-          (item) => controller.add(item),
-          onError: (error) => controller.addError(error),
-          onDone: () => controller.close(),
-        );
-      },
-      onCancel: () {
-        subscription.cancel();
-        _positionStream = null;
-      },
-    );
-    return controller.stream.asBroadcastStream();
+    return incoming.asBroadcastStream(onCancel: (subscription) {
+      subscription.cancel();
+      _positionStream = null;
+    });
   }
 
   @override

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.0
+version: 2.3.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When using `getPositionStream`, the original position stream is never cancelled despite all listeners of `getPositionStream` being cancelled,
thus the native position subscription is never stopped.

Unfortunately, _from what I understand_,  the accompanying [test](https://github.com/Baseflow/flutter-geolocator/blob/master/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart#L662-L682) has a faulty expectation (`==` instead of `!=`) and also implies that given options have any influence on reusing the `_positionStream` (which might be a different problem by itself). 

### :new: What is the new behavior (if this is a feature change)?
Cancelling all listeners of the position broadcast stream cancels the position stream as well.
Accompanying test is a bit more extensive and does no longer imply that given options influence reuse of `_positionStream`.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Use the example app and adapt to use cancel instead of pause.

### :memo: Links to relevant issues/docs
Issue #780

### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [X] I rebased onto current `master`.
