### PR TITLE
Purpose key arg temporary full accuracy

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.2
+
+- Added the possibility to pass your own purposeKey name to the requestTemporaryFullAccuracy method.
+
 ## 2.3.1
 
 - Solves a bug which resulted in an issue when closing the position stream.

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -167,10 +167,17 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// [LocationAccuracyStatus.precise] will also be returned. On other platforms
   /// an PlatformException will be thrown.
   ///
+  /// The `required` property [purposeKey] should correspond with the [key]
+  /// value set in the [NSLocationTemporaryUsageDescriptionDictionary]
+  /// dictionary, which should be added to the `Info.plist` as stated in the
+  /// documentation.
+  ///
   /// Throws a [PermissionDefinitionsNotFoundException] when the key
   /// `NSLocationTemporaryUsageDescriptionDictionary` has not been set in the
   /// `Infop.list`.
-  Future<LocationAccuracyStatus> requestTemporaryFullAccuracy() async {
+  Future<LocationAccuracyStatus> requestTemporaryFullAccuracy({
+    required String purposeKey,
+  }) async {
     throw UnimplementedError(
         'requestTemporaryFullAccuracy() has not been implemented');
   }

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -170,13 +170,14 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// The `required` property [purposeKey] should correspond with the [key]
   /// value set in the [NSLocationTemporaryUsageDescriptionDictionary]
   /// dictionary, which should be added to the `Info.plist` as stated in the
-  /// documentation.
+  /// documentation. The default value of the [purposeKey] is set to
+  /// `TemporaryFullAccuracyDescription`.
   ///
   /// Throws a [PermissionDefinitionsNotFoundException] when the key
   /// `NSLocationTemporaryUsageDescriptionDictionary` has not been set in the
   /// `Infop.list`.
   Future<LocationAccuracyStatus> requestTemporaryFullAccuracy({
-    required String purposeKey,
+    String purposeKey = "TemporaryFullAccuracyDescription",
   }) async {
     throw UnimplementedError(
         'requestTemporaryFullAccuracy() has not been implemented');

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -170,15 +170,14 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// The `required` property [purposeKey] should correspond with the [key]
   /// value set in the [NSLocationTemporaryUsageDescriptionDictionary]
   /// dictionary, which should be added to the `Info.plist` as stated in the
-  /// documentation. The default value of the [purposeKey] is set to
-  /// `TemporaryFullAccuracyDescription`.
+  /// [documentation](https://developer.apple.com/documentation/bundleresources/information_property_list/nslocationtemporaryusagedescriptiondictionary).
   ///
   /// Throws a [PermissionDefinitionsNotFoundException] when the key
   /// `NSLocationTemporaryUsageDescriptionDictionary` has not been set in the
   /// `Infop.list`.
   Future<LocationAccuracyStatus> requestTemporaryFullAccuracy({
-    String purposeKey = "TemporaryFullAccuracyDescription",
-  }) async {
+    required String purposeKey,
+  }) {
     throw UnimplementedError(
         'requestTemporaryFullAccuracy() has not been implemented');
   }

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -177,7 +177,7 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// `Infop.list`.
   Future<LocationAccuracyStatus> requestTemporaryFullAccuracy({
     required String purposeKey,
-  }) {
+  }) async {
     throw UnimplementedError(
         'requestTemporaryFullAccuracy() has not been implemented');
   }

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -215,7 +215,7 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
   @override
   Future<LocationAccuracyStatus> requestTemporaryFullAccuracy({
-    String purposeKey = "TemporaryFullAccuracyDescription",
+    required String purposeKey,
   }) async {
     try {
       final int status = await _methodChannel.invokeMethod(

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -215,7 +215,7 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
   @override
   Future<LocationAccuracyStatus> requestTemporaryFullAccuracy({
-    required String purposeKey,
+     String purposeKey = "TemporaryFullAccuracyDescription",
   }) async {
     try {
       final int status = await _methodChannel.invokeMethod(

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -214,10 +214,16 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
   }
 
   @override
-  Future<LocationAccuracyStatus> requestTemporaryFullAccuracy() async {
+  Future<LocationAccuracyStatus> requestTemporaryFullAccuracy({
+    required String purposeKey,
+  }) async {
     try {
-      final int status =
-          await _methodChannel.invokeMethod('requestTemporaryFullAccuracy');
+      final int status = await _methodChannel.invokeMethod(
+        'requestTemporaryFullAccuracy',
+        <String, dynamic>{
+          'purposeKey': purposeKey,
+        },
+      );
       return LocationAccuracyStatus.values[status];
     } on PlatformException catch (e) {
       _handlePlatformException(e);

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -215,7 +215,7 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
   @override
   Future<LocationAccuracyStatus> requestTemporaryFullAccuracy({
-     String purposeKey = "TemporaryFullAccuracyDescription",
+    String purposeKey = "TemporaryFullAccuracyDescription",
   }) async {
     try {
       final int status = await _methodChannel.invokeMethod(

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.1
+version: 2.3.2
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
+++ b/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
@@ -82,7 +82,8 @@ void main() {
 
       // Act & Assert
       expect(
-        geolocatorPlatform.requestTemporaryFullAccuracy,
+        geolocatorPlatform.requestTemporaryFullAccuracy(
+            purposeKey: 'purposeKey'),
         throwsUnimplementedError,
       );
     });

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -179,9 +179,7 @@ void main() {
 
         // Act
         final accuracy =
-            await MethodChannelGeolocator().requestTemporaryFullAccuracy(
-          purposeKey: 'purposeKeyValue',
-        );
+            await MethodChannelGeolocator().requestTemporaryFullAccuracy();
 
         // Assert
         expect(accuracy, LocationAccuracyStatus.precise);
@@ -201,9 +199,7 @@ void main() {
         );
 
         // Act
-        final future = MethodChannelGeolocator().requestTemporaryFullAccuracy(
-          purposeKey: 'purposeKeyValue',
-        );
+        final future = MethodChannelGeolocator().requestTemporaryFullAccuracy();
 
         // Assert
         expect(

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -178,8 +178,8 @@ void main() {
             result: 1);
 
         // Act
-        final accuracy =
-            await MethodChannelGeolocator().requestTemporaryFullAccuracy();
+        final accuracy = await MethodChannelGeolocator()
+            .requestTemporaryFullAccuracy(purposeKey: 'purposeKey');
 
         // Assert
         expect(accuracy, LocationAccuracyStatus.precise);
@@ -199,7 +199,8 @@ void main() {
         );
 
         // Act
-        final future = MethodChannelGeolocator().requestTemporaryFullAccuracy();
+        final future = MethodChannelGeolocator()
+            .requestTemporaryFullAccuracy(purposeKey: 'purposeKey');
 
         // Assert
         expect(

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -142,17 +142,30 @@ void main() {
           'Should receive reduced accuracy if Location Accuracy is pinned to'
           ' reduced', () async {
         // Arrange
-        MethodChannelMock(
+        final methodChannel = MethodChannelMock(
             channelName: 'flutter.baseflow.com/geolocator',
             method: 'requestTemporaryFullAccuracy',
             result: 0);
 
+        final expectedArguments = <String, dynamic>{
+          'purposeKey': 'purposeKeyValue',
+        };
+
         // Act
         final accuracy =
-            await MethodChannelGeolocator().requestTemporaryFullAccuracy();
+            await MethodChannelGeolocator().requestTemporaryFullAccuracy(
+          purposeKey: 'purposeKeyValue',
+        );
 
         // Assert
         expect(accuracy, LocationAccuracyStatus.reduced);
+
+        expect(methodChannel.log, <Matcher>[
+          isMethodCall(
+            'requestTemporaryFullAccuracy',
+            arguments: expectedArguments,
+          ),
+        ]);
       });
 
       test(
@@ -166,7 +179,9 @@ void main() {
 
         // Act
         final accuracy =
-            await MethodChannelGeolocator().requestTemporaryFullAccuracy();
+            await MethodChannelGeolocator().requestTemporaryFullAccuracy(
+          purposeKey: 'purposeKeyValue',
+        );
 
         // Assert
         expect(accuracy, LocationAccuracyStatus.precise);
@@ -186,7 +201,9 @@ void main() {
         );
 
         // Act
-        final future = MethodChannelGeolocator().requestTemporaryFullAccuracy();
+        final future = MethodChannelGeolocator().requestTemporaryFullAccuracy(
+          purposeKey: 'purposeKeyValue',
+        );
 
         // Assert
         expect(


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature change

### :arrow_heading_down: What is the current behavior?
Currently the user can't pass a custom purposeKey parameter to the requestTemporaryFullAccuracy method, instead the default value is always used.

### :new: What is the new behavior (if this is a feature change)?
The user can now pass a custom purposeKey parameter to the requestTemporaryFullAccuracy method. This also allows the user to specify more then one purpose key in the NSLocationTemporaryUsageDescription dictionary in the Info.plist

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Does not apply

### :memo: Links to relevant issues/docs
Does not apply

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
