### PR TITLE
Bug fix where requestPermission method returns to early

### DIFF
--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 2.0.5
+
+- Ensure the `requestPermission` method correctly awaits the users input and not return prematurely (see issue [#783](https://github.com/Baseflow/flutter-geolocator/issues/783)).
+
 ## 2.0.4
 
 - Added an example App to demonstrate how to directly use the geolocator_web package in a Flutter application.
 
 ## 2.0.3
 
-- Implement missing `isLocationServiceEnabled` for web implementation (see issue[#694](https://github.com/Baseflow/flutter-geolocator/issues/694)).
+- Implement missing `isLocationServiceEnabled` for web implementation (see issue [#694](https://github.com/Baseflow/flutter-geolocator/issues/694)).
 
 ## 2.0.2
 

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -59,10 +59,10 @@ class GeolocatorPlugin extends GeolocatorPlatform {
   @override
   Future<LocationPermission> requestPermission() async {
     try {
-      _geolocation.getCurrentPosition();
+      await _geolocation.getCurrentPosition();
       return LocationPermission.whileInUse;
     } catch (e) {
-      return LocationPermission.denied;
+      return LocationPermission.deniedForever;
     }
   }
 

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: geolocator_web
 description: Official web implementation of the geolocator plugin.
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/geolocator_web
-version: 2.0.4
+version: 2.0.5
 
 flutter:
   plugin:
@@ -16,7 +16,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
 
-  geolocator_platform_interface: ^2.3.0
+  geolocator_platform_interface: ^2.3.2
 
 dev_dependencies:
   flutter_test:
@@ -26,3 +26,4 @@ dev_dependencies:
 environment:
   sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.20.0"
+


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Calling the `requestPermission` method returns to early and not awaiting the user's selection. This results in the geolocator_web always reporting permissions are granted while this might not be the case.

### :new: What is the new behavior (if this is a feature change)?

The `requestPermission` method correctly awaits the user's input and reports the correct permissions back to app developers.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- Fixes #783 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
