### PR TITLE
Fixed bug on web where reduced is high accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,11 @@ flutter_export_environment.sh
 **/ios/Runner/GeneratedPluginRegistrant.*
 **/ios/Flutter/Flutter.podspec
 
+# Firebase related
+.firebase/
+.firebaserc
+firebase.json
+
 # Exceptions to above rules.
 !**/ios/**/default.mode1v3
 !**/ios/**/default.mode2v3

--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.6
+
+- Fixes a bug where the `LocationAccuracy.reduced` accuracy value is treated as high accuracy on web.
+
 ## 2.0.5
 
 - Ensure the `requestPermission` method correctly awaits the users input and not return prematurely (see issue [#783](https://github.com/Baseflow/flutter-geolocator/issues/783)).

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -134,8 +134,19 @@ class GeolocatorPlugin extends GeolocatorPlatform {
   Future<bool> openLocationSettings() =>
       throw _unsupported('openLocationSettings');
 
-  bool _enableHighAccuracy(LocationAccuracy accuracy) =>
-      accuracy.index >= LocationAccuracy.high.index;
+  bool _enableHighAccuracy(LocationAccuracy accuracy) {
+    switch (accuracy) {
+      case LocationAccuracy.lowest:
+      case LocationAccuracy.low:
+      case LocationAccuracy.medium:
+      case LocationAccuracy.reduced:
+        return false;
+      case LocationAccuracy.high:
+      case LocationAccuracy.best:
+      case LocationAccuracy.bestForNavigation:
+        return true;
+    }
+  }
 
   PlatformException _unsupported(String method) {
     return PlatformException(

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: geolocator_web
 description: Official web implementation of the geolocator plugin.
 homepage: https://github.com/Baseflow/flutter-geolocator/tree/geolocator_web
-version: 2.0.5
+version: 2.0.6
 
 flutter:
   plugin:
@@ -27,4 +27,3 @@ dev_dependencies:
 environment:
   sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.20.0"
-


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When specifying the `LocationAccuracy.reduced` option to the `getCurrentPosition(desiredAccuracy)` method the web implementation treats it as enabling high accuracy.

### :new: What is the new behavior (if this is a feature change)?

The `LocationAccuracy.reduced` is now correctly treated as a low accuracy setting.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
