### PR TITLE
Add pausesLocationUpdatesAutomatically parameter

### DIFF
--- a/geolocator/lib/geolocator.dart
+++ b/geolocator/lib/geolocator.dart
@@ -114,6 +114,7 @@ class Geolocator {
     LocationAccuracy desiredAccuracy = LocationAccuracy.best,
     int distanceFilter = 0,
     bool forceAndroidLocationManager = false,
+    bool iosPausesLocationUpdatesAutomatically = false,
     Duration? intervalDuration,
     Duration? timeLimit,
   }) =>
@@ -121,6 +122,7 @@ class Geolocator {
         desiredAccuracy: desiredAccuracy,
         distanceFilter: distanceFilter,
         forceAndroidLocationManager: forceAndroidLocationManager,
+        iosPausesLocationUpdatesAutomatically: iosPausesLocationUpdatesAutomatically,
         timeInterval: intervalDuration?.inMilliseconds ?? 0,
         timeLimit: timeLimit,
       );

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -22,10 +22,25 @@ dependencies:
   flutter:
     sdk: flutter
   
-  geolocator_platform_interface: ^2.3.2
-  geolocator_android: ^1.0.0
-  geolocator_apple: ^1.0.0
-  geolocator_web: ^2.0.1
+  geolocator_platform_interface:
+    git:
+      url: https://github.com/cdfq152313/flutter-geolocator
+      path: geolocator_platform_interface
+
+  geolocator_android:
+    git:
+      url: https://github.com/cdfq152313/flutter-geolocator
+      path: geolocator_android
+
+  geolocator_apple:
+    git:
+      url: https://github.com/cdfq152313/flutter-geolocator
+      path: geolocator_apple
+
+  geolocator_web:
+    git:
+      url: https://github.com/cdfq152313/flutter-geolocator
+      path: geolocator_web
 
 dev_dependencies:
   flutter_test:

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -19,7 +19,10 @@ dependencies:
   flutter:
     sdk: flutter
   
-  geolocator_platform_interface: ^2.3.2
+  geolocator_platform_interface:
+    git:
+      url: https://github.com/cdfq152313/flutter-geolocator
+      path: geolocator_platform_interface
   
 dev_dependencies:
   flutter_test:

--- a/geolocator_apple/ios/Classes/GeolocatorPlugin.m
+++ b/geolocator_apple/ios/Classes/GeolocatorPlugin.m
@@ -123,7 +123,8 @@
     
     [geolocationHandler startListeningWithDesiredAccuracy:accuracy
                                            distanceFilter:distanceFilter
-                                            resultHandler:^(CLLocation *location) {
+                                           pausesLocationUpdatesAutomatically:NO
+                                           resultHandler:^(CLLocation *location) {
       [geolocationHandler stopListening];
       
       result([LocationMapper toDictionary:location]);

--- a/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.h
+++ b/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.h
@@ -20,6 +20,7 @@ typedef void (^GeolocatorResult)(CLLocation *_Nullable location);
 
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
                            distanceFilter:(CLLocationDistance)distanceFilter
+                           pausesLocationUpdatesAutomatically:(BOOL)pausesLocationUpdatesAutomatically
                             resultHandler:(GeolocatorResult _Nonnull)resultHandler
                              errorHandler:(GeolocatorError _Nonnull)errorHandler;
 

--- a/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
@@ -25,6 +25,7 @@
 
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
                            distanceFilter:(CLLocationDistance)distanceFilter
+                           pausesLocationUpdatesAutomatically:(BOOL)pausesLocationUpdatesAutomatically
                             resultHandler:(GeolocatorResult _Nonnull )resultHandler
                              errorHandler:(GeolocatorError _Nonnull)errorHandler {
     
@@ -34,6 +35,8 @@
     CLLocationManager *locationManager = self.locationManager;
     locationManager.desiredAccuracy = desiredAccuracy;
     locationManager.distanceFilter = distanceFilter == 0 ? kCLDistanceFilterNone : distanceFilter;
+    locationManager.activityType = CLActivityTypeAutomotiveNavigation;
+    [locationManager setPausesLocationUpdatesAutomatically:pausesLocationUpdatesAutomatically];
     if (@available(iOS 9.0, *)) {
         locationManager.allowsBackgroundLocationUpdates = [GeolocationHandler shouldEnableBackgroundLocationUpdates];
     }

--- a/geolocator_apple/ios/Classes/Handlers/PositionStreamHandler.m
+++ b/geolocator_apple/ios/Classes/Handlers/PositionStreamHandler.m
@@ -55,9 +55,11 @@
       
       CLLocationAccuracy accuracy = [LocationAccuracyMapper toCLLocationAccuracy:(NSNumber *)arguments[@"accuracy"]];
       CLLocationDistance distanceFilter = [LocationDistanceMapper toCLLocationDistance:(NSNumber *)arguments[@"distanceFilter"]];
+      BOOL pausesLocationUpdatesAutomatically = [[arguments objectForKey: @"iosPausesLocationUpdatesAutomatically"] boolValue];
       
       [[weakSelf geolocationHandler] startListeningWithDesiredAccuracy:accuracy
                                                     distanceFilter:distanceFilter
+                                                    pausesLocationUpdatesAutomatically: pausesLocationUpdatesAutomatically
                                                      resultHandler:^(CLLocation *location) {
           [weakSelf onLocationDidChange: location];
       }

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -18,7 +18,10 @@ dependencies:
   flutter:
     sdk: flutter
   
-  geolocator_platform_interface: ^2.3.2
+  geolocator_platform_interface:
+    git:
+      url: https://github.com/cdfq152313/flutter-geolocator
+      path: geolocator_platform_interface
   
 dev_dependencies:
   flutter_test:

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -154,6 +154,7 @@ abstract class GeolocatorPlatform extends PlatformInterface {
     LocationAccuracy desiredAccuracy = LocationAccuracy.best,
     int distanceFilter = 0,
     bool forceAndroidLocationManager = false,
+    bool iosPausesLocationUpdatesAutomatically = false,
     int timeInterval = 0,
     Duration? timeLimit,
   }) {

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -160,6 +160,7 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
     LocationAccuracy desiredAccuracy = LocationAccuracy.best,
     int distanceFilter = 0,
     bool forceAndroidLocationManager = false,
+    bool iosPausesLocationUpdatesAutomatically = false,
     int timeInterval = 0,
     Duration? timeLimit,
   }) {
@@ -167,6 +168,7 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
       accuracy: desiredAccuracy,
       distanceFilter: distanceFilter,
       forceAndroidLocationManager: forceAndroidLocationManager,
+      iosPausesLocationUpdatesAutomatically: iosPausesLocationUpdatesAutomatically,
       timeInterval: timeInterval,
     );
     if (_positionStream != null) {

--- a/geolocator_platform_interface/lib/src/models/location_options.dart
+++ b/geolocator_platform_interface/lib/src/models/location_options.dart
@@ -14,6 +14,7 @@ class LocationOptions {
       {this.accuracy = LocationAccuracy.best,
       this.distanceFilter = 0,
       this.forceAndroidLocationManager = false,
+      this.iosPausesLocationUpdatesAutomatically = false,
       this.timeInterval = 0});
 
   /// Defines the desired accuracy that should be used to determine the
@@ -39,6 +40,10 @@ class LocationOptions {
   /// set this property to true.
   final bool forceAndroidLocationManager;
 
+  /// Allowing the location manager to pause updates can improve battery life on
+  /// the target device without sacrificing location data.
+  final bool iosPausesLocationUpdatesAutomatically;
+
   /// The desired interval for active location updates, in milliseconds
   /// (Android only).
   ///
@@ -51,6 +56,7 @@ class LocationOptions {
         'accuracy': accuracy.index,
         'distanceFilter': distanceFilter,
         'forceAndroidLocationManager': forceAndroidLocationManager,
+        'iosPausesLocationUpdatesAutomatically': iosPausesLocationUpdatesAutomatically,
         'timeInterval': timeInterval
       };
 }

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -17,7 +17,10 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
 
-  geolocator_platform_interface: ^2.3.2
+  geolocator_platform_interface:
+    git:
+      url: https://github.com/cdfq152313/flutter-geolocator
+      path: geolocator_platform_interface
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature.

### :arrow_heading_down: What is the current behavior?
Location update may be pasue in iOS when user stop for a while.

### :new: What is the new behavior (if this is a feature change)?
Add pausesLocationUpdatesAutomatically parameter.

### :boom: Does this PR introduce a breaking change?
No.

### :memo: Links to relevant issues/docs
https://developer.apple.com/documentation/corelocation/cllocationmanager/1620553-pauseslocationupdatesautomatical?language=objc

### :thinking: Checklist before submitting

- [v] I made sure all projects build.
- [v] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [v] I updated CHANGELOG.md to add a description of the change.
- [v] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [v] I updated the relevant documentation.
- [v] I rebased onto current `master`.
