### PR TITLE
Run actions on 'next' branch

### DIFF
--- a/.github/workflows/geolocator.yaml
+++ b/.github/workflows/geolocator.yaml
@@ -6,11 +6,11 @@ name: geolocator
 # events but only for the develop branch
 on:
   push:
-    branches: [ master ]
+    branches: [ master, next ]
     paths:
     - 'geolocator/**'
   pull_request:
-    branches: [ master ]
+    branches: [ master, next ]
     paths:
     - 'geolocator/**'
 

--- a/.github/workflows/geolocator_platform_interface.yaml
+++ b/.github/workflows/geolocator_platform_interface.yaml
@@ -6,11 +6,11 @@ name: geolocator_platform_interface
 # events but only for the develop branch
 on:
   push:
-    branches: [ master ]
+    branches: [ master, next ]
     paths:
     - 'geolocator_platform_interface/**'
   pull_request:
-    branches: [ master ]
+    branches: [ master, next ]
     paths:
     - 'geolocator_platform_interface/**'
 

--- a/.github/workflows/geolocator_web.yaml
+++ b/.github/workflows/geolocator_web.yaml
@@ -5,11 +5,11 @@ name: geolocator_web
 # events but only for the develop branch
 on:
   push:
-    branches: [ master ]
+    branches: [ master, next ]
     paths:
     - 'geolocator_web/**'
   pull_request:
-    branches: [ master ]
+    branches: [ master, next ]
     paths:
     - 'geolocator_web/**'
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

GitHub actions only run on the `master` branch and not on the `next` branch.

### :new: What is the new behavior (if this is a feature change)?

Configure GitHub workflows to also run actions on the `next` branch.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
