### PR TITLE
Geolocator_web package location settings implementation

### DIFF
--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+- Made changes to the implementation of the `getCurrentPosition` and `getPositionStream` method. 
+
 ## 2.0.6
 
 - Fixes a bug where the `LocationAccuracy.reduced` accuracy value is treated as high accuracy on web.

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -3,7 +3,8 @@ description: Official web implementation of the geolocator plugin.
 repository: https://github.com/Baseflow/flutter-geolocator/tree/geolocator_web
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 version: 2.0.6
-
+# TODO : Remove the publish_to: none when publishing the final version of the geolocator_platform_interface
+publish_to: none
 flutter:
   plugin:
     platforms:
@@ -16,8 +17,9 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-
-  geolocator_platform_interface: ^2.3.2
+# TODO : Remove the path reference when the final version of geolocator_platform_interface is published
+  geolocator_platform_interface:
+    path: ../geolocator_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/geolocator_web/test/geolocator_web_test.dart
+++ b/geolocator_web/test/geolocator_web_test.dart
@@ -33,10 +33,17 @@ void main() {
         GeolocatorPlugin.private(mockGeolocationManager, mockPermissionManager);
 
     geolocatorPlugin.getPositionStream(
-        desiredAccuracy: LocationAccuracy.medium);
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.medium,
+      ),
+    );
     expect(mockGeolocationManager.enableHighAccuracy, false);
 
-    geolocatorPlugin.getPositionStream(desiredAccuracy: LocationAccuracy.high);
+    geolocatorPlugin.getPositionStream(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.best,
+      ),
+    );
     expect(mockGeolocationManager.enableHighAccuracy, true);
   });
 
@@ -49,10 +56,17 @@ void main() {
         GeolocatorPlugin.private(mockGeolocationManager, mockPermissionManager);
 
     geolocatorPlugin.getCurrentPosition(
-        desiredAccuracy: LocationAccuracy.medium);
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.medium,
+      ),
+    );
     expect(mockGeolocationManager.enableHighAccuracy, false);
 
-    geolocatorPlugin.getCurrentPosition(desiredAccuracy: LocationAccuracy.high);
+    geolocatorPlugin.getCurrentPosition(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.high,
+      ),
+    );
     expect(mockGeolocationManager.enableHighAccuracy, true);
   });
 
@@ -102,7 +116,8 @@ void main() {
       final geolocatorPlugin = GeolocatorPlugin.private(
           mockGeolocationManager, mockPermissionManager);
 
-      final position = await geolocatorPlugin.getCurrentPosition();
+      final position = await geolocatorPlugin.getCurrentPosition(
+          locationSettings: const LocationSettings());
       expect(position, mockPositions.first);
     });
   });
@@ -114,7 +129,8 @@ void main() {
       final geolocatorPlugin = GeolocatorPlugin.private(
           mockGeolocationManager, mockPermissionManager);
 
-      final positionsStream = geolocatorPlugin.getPositionStream();
+      final positionsStream = geolocatorPlugin.getPositionStream(
+          locationSettings: const LocationSettings());
 
       expect(positionsStream, emitsInOrder(mockPositions));
     });
@@ -142,8 +158,11 @@ void main() {
         }
       }());
 
-      final positionsStream =
-          geolocatorPlugin.getPositionStream(distanceFilter: 7);
+      final positionsStream = geolocatorPlugin.getPositionStream(
+        locationSettings: const LocationSettings(
+          distanceFilter: 7,
+        ),
+      );
 
       expect(positionsStream, emitsInOrder(mockPositionsForFilter));
     });


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently the `geolocator_web` package makes use of the old parameters in the `getPositionStream` and `getCurrentLocation` methods

### :new: What is the new behavior (if this is a feature change)?
Now the `LocationSettings` property can be passed to these methods.

### :boom: Does this PR introduce a breaking change?
Yes

### :bug: Recommendations for testing
Does not apply

### :memo: Links to relevant issues/docs
Does not apply

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
