### PR TITLE
Make sure getCurrentPosition fetches real location

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.1
+## 1.2.0
 
 - Make sure the `getCurrentPosition` method returns the current position and not a cached location which might be wrong (see issue [#629](https://github.com/Baseflow/flutter-geolocator/issues/629)).
 

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Make sure the `getCurrentPosition` method returns the current position and not a cached location which might be wrong (see issue [#629](https://github.com/Baseflow/flutter-geolocator/issues/629)).
+
 ## 1.1.0
 
 - Added support for macOS Desktop.

--- a/geolocator_apple/apple/Classes/GeolocatorPlugin.m
+++ b/geolocator_apple/apple/Classes/GeolocatorPlugin.m
@@ -117,14 +117,9 @@
                                  details:nil]);
       return;
     }
-    
-    CLLocationAccuracy accuracy = [LocationAccuracyMapper toCLLocationAccuracy:(NSNumber *)arguments[@"accuracy"]];
-    CLLocationDistance distanceFilter = [LocationDistanceMapper toCLLocationDistance:(NSNumber *)arguments[@"distanceFilter"]];
     GeolocationHandler *geolocationHandler = [[GeolocationHandler alloc] init];
     
-    [geolocationHandler startListeningWithDesiredAccuracy:accuracy
-                                           distanceFilter:distanceFilter
-                                            resultHandler:^(CLLocation *location) {
+    [geolocationHandler requestPosition:^(CLLocation *location) {
       [geolocationHandler stopListening];
       
       result([LocationMapper toDictionary:location]);

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.h
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.h
@@ -18,6 +18,9 @@ typedef void (^GeolocatorResult)(CLLocation *_Nullable location);
 
 - (CLLocation *_Nullable)getLastKnownPosition;
 
+- (void)requestPosition:(GeolocatorResult _Nonnull)resultHandler
+           errorHandler:(GeolocatorError _Nonnull)errorHandler;
+
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
                            distanceFilter:(CLLocationDistance)distanceFilter
                             resultHandler:(GeolocatorResult _Nonnull)resultHandler

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
@@ -23,6 +23,20 @@
     return [self.locationManager location];
 }
 
+- (void)requestPosition:(GeolocatorResult _Nonnull)resultHandler
+           errorHandler:(GeolocatorError _Nonnull)errorHandler {
+  self.errorHandler = errorHandler;
+  self.resultHandler = resultHandler;
+  
+  if (@available(iOS 9.0, macOS 10.14, *)) {
+    [self.locationManager requestLocation];
+    return;
+  }
+  
+  [self startUpdatingLocationWithDesiredAccuracy:kCLLocationAccuracyBest
+                                  distanceFilter:kCLDistanceFilterNone];
+}
+
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
                            distanceFilter:(CLLocationDistance)distanceFilter
                             resultHandler:(GeolocatorResult _Nonnull )resultHandler
@@ -31,14 +45,20 @@
     self.errorHandler = errorHandler;
     self.resultHandler = resultHandler;
     
-    CLLocationManager *locationManager = self.locationManager;
-    locationManager.desiredAccuracy = desiredAccuracy;
-    locationManager.distanceFilter = distanceFilter == 0 ? kCLDistanceFilterNone : distanceFilter;
-    if (@available(iOS 9.0, macOS 10.15, *)) {
-        locationManager.allowsBackgroundLocationUpdates = [GeolocationHandler shouldEnableBackgroundLocationUpdates];
-    }
-    
-    [locationManager startUpdatingLocation];
+  [self startUpdatingLocationWithDesiredAccuracy:desiredAccuracy
+                                  distanceFilter:distanceFilter];
+}
+
+- (void)startUpdatingLocationWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
+                                  distanceFilter:(CLLocationDistance)distanceFilter {
+  CLLocationManager *locationManager = self.locationManager;
+  locationManager.desiredAccuracy = desiredAccuracy;
+  locationManager.distanceFilter = distanceFilter;
+  if (@available(iOS 9.0, macOS 10.15, *)) {
+      locationManager.allowsBackgroundLocationUpdates = [GeolocationHandler shouldEnableBackgroundLocationUpdates];
+  }
+  
+  [locationManager startUpdatingLocation];
 }
 
 - (void)stopListening {

--- a/geolocator_apple/ios/geolocator_apple.podspec
+++ b/geolocator_apple/ios/geolocator_apple.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'geolocator_apple'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.summary          = 'Geolocation iOS plugin for Flutter.'
   s.description      = <<-DESC
   Geolocation iOS plugin for Flutter. This plugin provides the Apple implementation for the geolocator plugin.

--- a/geolocator_apple/ios/geolocator_apple.podspec
+++ b/geolocator_apple/ios/geolocator_apple.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'geolocator_apple'
-  s.version          = '1.1.1'
+  s.version          = '1.2.0'
   s.summary          = 'Geolocation iOS plugin for Flutter.'
   s.description      = <<-DESC
   Geolocation iOS plugin for Flutter. This plugin provides the Apple implementation for the geolocator plugin.

--- a/geolocator_apple/macos/geolocator_apple.podspec
+++ b/geolocator_apple/macos/geolocator_apple.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'geolocator_apple'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.summary          = 'Geolocation macOS plugin for Flutter.'
   s.description      = <<-DESC
   Geolocation macOS plugin for Flutter. This plugin provides the Apple implementation for the geolocator plugin.

--- a/geolocator_apple/macos/geolocator_apple.podspec
+++ b/geolocator_apple/macos/geolocator_apple.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'geolocator_apple'
-  s.version          = '1.1.1'
+  s.version          = '1.2.0'
   s.summary          = 'Geolocation macOS plugin for Flutter.'
   s.description      = <<-DESC
   Geolocation macOS plugin for Flutter. This plugin provides the Apple implementation for the geolocator plugin.

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
-version: 1.1.0
+version: 1.1.1
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_apple
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
-version: 1.1.1
+version: 1.2.0
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_apple
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.4
+
+- Update the documentation of the `getCurrentPosition` method to explain why it can take several seconds to execute.
+
 ## 2.3.3
 
 - Migrated to [flutter_lints](https://pub.dev/packages/flutter_lints) as linter rule set as it replaces the deprecated [effective_dart](https://pub.dev/packages/effective_dart) package.

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -87,10 +87,14 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// Returns the current position taking the supplied [desiredAccuracy] into
   /// account.
   ///
-  /// You can control the precision of the location updates by supplying the
-  /// [desiredAccuracy] parameter (defaults to "best"). On Android you can
-  /// force the use of the Android LocationManager instead of the
-  /// FusedLocationProvider by setting the [forceAndroidLocationManager]
+  /// Calling the `getCurrentPosition` method will request the platform to
+  /// obtain a location fix, depending on the availability of different location
+  /// services this can take several seconds. The recommended use would be to
+  /// call the `getLastKnownPosition` method to receive a cached position and
+  /// update it with the result of the `getCurrentPosition` method.
+  ///
+  /// On Android you can force the use of the Android LocationManager instead of
+  /// the FusedLocationProvider by setting the [forceAndroidLocationManager]
   /// parameter to true. The [timeLimit] parameter allows you to specify a
   /// timeout interval (by default no time limit is configured).
   ///

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.3
+version: 2.3.4
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

At the moment `getCurrentPosition` returns the first position received when listening for location updates. However on iOS this is most often the cached "last known location" which is misleading to users.

### :new: What is the new behavior (if this is a feature change)?

Updated the code on iOS so that instead of listening for location updates and returning the first item, the geolocator uses the specialized `requestLocation` (see [here](https://developer.apple.com/documentation/corelocation/cllocationmanager/1620548-requestlocation?language=objc) for details) method.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- #629

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
