### PR TITLE
Update geolocator_apple package

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.6.0
+
+- Make sure the `getCurrentPosition` method returns the current position and not a cached location which might be wrong (see issue [#629](https://github.com/Baseflow/flutter-geolocator/issues/629)). Note that this means that in some cases fetching the current position might take several seconds. If you want to have a fast initial result, call the `getLastKnownPosition` first and update the position with the result from `getCurrentPosition`.
+
 ## 7.5.0
 
 - Added support for macOS Desktop.

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 7.5.0
+version: 7.6.0
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 
@@ -24,9 +24,9 @@ dependencies:
   flutter:
     sdk: flutter
   
-  geolocator_platform_interface: ^2.3.2
+  geolocator_platform_interface: ^2.3.4
   geolocator_android: ^1.0.0
-  geolocator_apple: ^1.1.0
+  geolocator_apple: ^1.2.0
   geolocator_web: ^2.0.1
 
 dev_dependencies:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

At the moment `getCurrentPosition` returns the first position received when listening for location updates. However on iOS this is most often the cached "last known location" which is misleading to users.

### :new: What is the new behavior (if this is a feature change)?

Updated the code on iOS so that instead of listening for location updates and returning the first item, the geolocator uses the specialized `requestLocation` (see [here](https://developer.apple.com/documentation/corelocation/cllocationmanager/1620548-requestlocation?language=objc) for details) method.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- Closes #629

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
