### PR TITLE
fix. didChangeAppLifecycleState** goes into a loop when starting the …

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.2
+- Fixed **didChangeAppLifecycleState** goes into a loop after location request (see issue: https://github.com/Baseflow/flutter-geolocator/issues/816).
+
 ## 1.0.1
 
 - Migrate to mavenCentral as jFrog has sunset jCenter (see [official announcement](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter) for more details);

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -114,7 +114,7 @@ class FusedLocationClient implements LocationClient {
           return false;
         }
 
-        startPositionUpdates(this.activity, this.positionChangedCallback, this.errorCallback);
+        startPositionUpdates(true, this.activity, this.positionChangedCallback, this.errorCallback);
 
         return true;
       } else {
@@ -127,8 +127,17 @@ class FusedLocationClient implements LocationClient {
     return false;
   }
 
+    @SuppressLint("MissingPermission")
+    public void startPositionUpdates(
+            @Nullable Activity activity,
+            @NonNull PositionChangedCallback positionChangedCallback,
+            @NonNull ErrorCallback errorCallback) {
+      startPositionUpdates(false, activity, positionChangedCallback, errorCallback);
+    }
+
   @SuppressLint("MissingPermission")
   public void startPositionUpdates(
+      @NonNull boolean forceRequest,
       @Nullable Activity activity,
       @NonNull PositionChangedCallback positionChangedCallback,
       @NonNull ErrorCallback errorCallback) {
@@ -139,6 +148,12 @@ class FusedLocationClient implements LocationClient {
 
     LocationRequest locationRequest = buildLocationRequest(this.locationOptions);
     LocationSettingsRequest settingsRequest = buildLocationSettingsRequest(locationRequest);
+
+      if (forceRequest) {
+          fusedLocationProviderClient.requestLocationUpdates(
+                  locationRequest, locationCallback, Looper.getMainLooper());
+          return;
+      }
 
     SettingsClient settingsClient = LocationServices.getSettingsClient(context);
     settingsClient

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
**didChangeAppLifecycleState** goes into a loop after location request.
Version: 7.6.0
Config: **forceAndroidLocationManager**: false
Platform: Android only
Device Model: Xiaomi Only

### :new: What is the new behavior (if this is a feature change)?
**didChangeAppLifecycleState** not loop after location request.

### :boom: Does this PR introduce a breaking change?
None

### :bug: Recommendations for testing
None

### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter-geolocator/issues/816

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [x] I rebased onto current `master`.
