### PR TITLE
Issue/755 remove implicit permission request

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- Removed implicit request for permissions when getting a position.
+
 ## 1.1.0
 
 - Added the [AndroidOptions] class to the `lib` directory.

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.0
+## NEXT
 
 - Removed implicit request for permissions when getting a position.
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -28,7 +28,7 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
 
   public GeolocatorPlugin() {
     this.permissionManager = new PermissionManager();
-    this.geolocationManager = new GeolocationManager(permissionManager);
+    this.geolocationManager = new GeolocationManager();
   }
 
   // This static function is optional and equivalent to onAttachedToEngine. It supports the old
@@ -52,7 +52,7 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
     methodCallHandler.startListening(registrar.context(), registrar.messenger());
     methodCallHandler.setActivity(registrar.activity());
 
-    StreamHandlerImpl streamHandler = new StreamHandlerImpl(geolocatorPlugin.geolocationManager);
+    StreamHandlerImpl streamHandler = new StreamHandlerImpl(geolocatorPlugin.geolocationManager, geolocatorPlugin.permissionManager);
     streamHandler.startListening(registrar.context(), registrar.messenger());
     streamHandler.setActivity(registrar.activity());
 
@@ -66,7 +66,7 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
     methodCallHandler = new MethodCallHandlerImpl(this.permissionManager, this.geolocationManager);
     methodCallHandler.startListening(
         flutterPluginBinding.getApplicationContext(), flutterPluginBinding.getBinaryMessenger());
-    streamHandler = new StreamHandlerImpl(this.geolocationManager);
+    streamHandler = new StreamHandlerImpl(this.geolocationManager, this.permissionManager);
     streamHandler.startListening(
         flutterPluginBinding.getApplicationContext(), flutterPluginBinding.getBinaryMessenger());
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -6,10 +6,13 @@ import android.location.Location;
 import android.util.Log;
 import androidx.annotation.Nullable;
 import com.baseflow.geolocator.errors.ErrorCodes;
+import com.baseflow.geolocator.errors.PermissionUndefinedException;
 import com.baseflow.geolocator.location.GeolocationManager;
 import com.baseflow.geolocator.location.LocationClient;
 import com.baseflow.geolocator.location.LocationMapper;
 import com.baseflow.geolocator.location.LocationOptions;
+import com.baseflow.geolocator.permission.PermissionManager;
+
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
 
@@ -19,14 +22,16 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
   private static final String TAG = "StreamHandlerImpl";
 
   private final GeolocationManager geolocationManager;
+  private final PermissionManager permissionManager;
 
   @Nullable private EventChannel channel;
   @Nullable private Context context;
   @Nullable private Activity activity;
   @Nullable private LocationClient locationClient;
 
-  public StreamHandlerImpl(GeolocationManager geolocationManager) {
+  public StreamHandlerImpl(GeolocationManager geolocationManager, PermissionManager permissionManager) {
     this.geolocationManager = geolocationManager;
+    this.permissionManager = permissionManager;
   }
 
   void setActivity(@Nullable Activity activity) {
@@ -68,6 +73,16 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
 
   @Override
   public void onListen(Object arguments, EventChannel.EventSink events) {
+    try {
+        if (!permissionManager.hasPermission(this.context)){
+            events.error(ErrorCodes.permissionDenied.toString(),ErrorCodes.permissionDenied.toDescription(),null);
+            return;
+        }
+    } catch (PermissionUndefinedException e) {
+        events.error(ErrorCodes.permissionDefinitionsNotFound.toString(), ErrorCodes.permissionDefinitionsNotFound.toDescription(), null);
+        return; 
+    }
+    
     @SuppressWarnings("unchecked")
     Map<String, Object> map = (Map<String, Object>) arguments;
 
@@ -79,9 +94,8 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
             this.context, forceLocationManager, locationOptions);
 
     geolocationManager.startPositionUpdates(
-        context,
-        activity,
         this.locationClient,
+        activity,
         (Location location) -> events.success(LocationMapper.toHashMap(location)),
         (ErrorCodes errorCodes) ->
             events.error(errorCodes.toString(), errorCodes.toDescription(), null));

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
@@ -21,29 +21,20 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class GeolocationManager
     implements io.flutter.plugin.common.PluginRegistry.ActivityResultListener {
 
-  @NonNull private final PermissionManager permissionManager;
   private final List<LocationClient> locationClients;
 
-  public GeolocationManager(@NonNull PermissionManager permissionManager) {
-    this.permissionManager = permissionManager;
+  public GeolocationManager() {
     this.locationClients = new CopyOnWriteArrayList<>();
   }
 
   public void getLastKnownPosition(
       Context context,
-      Activity activity,
       boolean forceLocationManager,
       PositionChangedCallback positionChangedCallback,
       ErrorCallback errorCallback) {
 
-    handlePermissions(
-        context,
-        activity,
-        () -> {
-          LocationClient locationClient = createLocationClient(context, forceLocationManager, null);
-          locationClient.getLastKnownPosition(positionChangedCallback, errorCallback);
-        },
-        errorCallback);
+      LocationClient locationClient = createLocationClient(context, forceLocationManager, null);
+      locationClient.getLastKnownPosition(positionChangedCallback, errorCallback);
   }
 
   public void isLocationServiceEnabled(
@@ -57,19 +48,13 @@ public class GeolocationManager
   }
 
   public void startPositionUpdates(
-      Context context,
-      Activity activity,
-      LocationClient locationClient,
-      PositionChangedCallback positionChangedCallback,
-      ErrorCallback errorCallback) {
+      @NonNull LocationClient locationClient,
+      @Nullable Activity activity,
+      @NonNull PositionChangedCallback positionChangedCallback,
+      @NonNull ErrorCallback errorCallback) {
 
     this.locationClients.add(locationClient);
-
-    handlePermissions(
-        context,
-        activity,
-        () -> locationClient.startPositionUpdates(activity, positionChangedCallback, errorCallback),
-        errorCallback);
+    locationClient.startPositionUpdates(activity, positionChangedCallback, errorCallback);
   }
 
   public void stopPositionUpdates(@NonNull LocationClient locationClient) {
@@ -94,46 +79,6 @@ public class GeolocationManager
     GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance();
     int resultCode = googleApiAvailability.isGooglePlayServicesAvailable(context);
     return resultCode == ConnectionResult.SUCCESS;
-  }
-
-  private void handlePermissions(
-      Context context,
-      @Nullable Activity activity,
-      Runnable hasPermissionCallback,
-      ErrorCallback errorCallback) {
-    try {
-      LocationPermission permissionStatus =
-          permissionManager.checkPermissionStatus(context, activity);
-
-      if (permissionStatus == LocationPermission.deniedForever) {
-        errorCallback.onError(ErrorCodes.permissionDenied);
-        return;
-      }
-
-      if (permissionStatus == LocationPermission.whileInUse
-          || permissionStatus == LocationPermission.always) {
-        hasPermissionCallback.run();
-        return;
-      }
-
-      if (permissionStatus == LocationPermission.denied && activity != null) {
-        permissionManager.requestPermission(
-            activity,
-            (permission) -> {
-              if (permission == LocationPermission.whileInUse
-                  || permission == LocationPermission.always) {
-                hasPermissionCallback.run();
-              } else {
-                errorCallback.onError(ErrorCodes.permissionDenied);
-              }
-            },
-            errorCallback);
-      } else {
-        errorCallback.onError(ErrorCodes.permissionDenied);
-      }
-    } catch (PermissionUndefinedException ex) {
-      errorCallback.onError(ErrorCodes.permissionDefinitionsNotFound);
-    }
   }
 
   @Override

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
@@ -27,7 +27,7 @@ public class PermissionManager
   @Nullable private ErrorCallback errorCallback;
   @Nullable private PermissionResultCallback resultCallback;
 
-  public LocationPermission checkPermissionStatus(Context context, Activity activity)
+  public LocationPermission checkPermissionStatus(Context context)
       throws PermissionUndefinedException {
     String permission = determineFineOrCoarse(context);
 
@@ -187,4 +187,10 @@ public class PermissionManager
         ? Manifest.permission.ACCESS_FINE_LOCATION
         : Manifest.permission.ACCESS_COARSE_LOCATION;
   }
+
+    public boolean hasPermission(Context context) throws PermissionUndefinedException {
+        LocationPermission locationPermission = this.checkPermissionStatus(context);
+
+        return locationPermission == LocationPermission.whileInUse || locationPermission == LocationPermission.always;
+    }
 }

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 1.1.0
+version: 1.2.0
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 1.2.0
+version: NEXT
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,7 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: NEXT
+# TODO: Change the version code when the final version of geolocator_android is published
+version: 1.0.1
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

As mentioned in proposal #775, the permission request that happened when requesting `getCurrentPosition` or `getPositionStream` is removed.

### :arrow_heading_down: What is the current behavior?

When requesting `getCurrentPosition` or `getPositionStream` the plugin will request for the location permission.

### :new: What is the new behavior (if this is a feature change)?

Per request (as mentioned in #775) this behavior is removed.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Proposal #775 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
