### PR TITLE
Use `requestAlwaysAuthorization` on macOS.

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+- Use `requestAlwaysAuthorization` instead of `requestWhenInUseAuthorization` on macOS as both result in the same behaviour but the former has better support on Catelina.
+
 ## 1.2.0
 
 - Make sure the `getCurrentPosition` method returns the current position and not a cached location which might be wrong (see issue [#629](https://github.com/Baseflow/flutter-geolocator/issues/629)).

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
@@ -55,9 +55,11 @@
   locationManager.desiredAccuracy = desiredAccuracy;
   locationManager.distanceFilter = distanceFilter;
   
-  if (@available(iOS 9.0, macOS 10.16, *)) {
+#if TARGET_OS_IOS
+  if (@available(iOS 9.0, macOS 11.0, *)) {
       locationManager.allowsBackgroundLocationUpdates = [GeolocationHandler shouldEnableBackgroundLocationUpdates];
   }
+#endif
   
   [locationManager startUpdatingLocation];
 }

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
@@ -54,9 +54,12 @@
   CLLocationManager *locationManager = self.locationManager;
   locationManager.desiredAccuracy = desiredAccuracy;
   locationManager.distanceFilter = distanceFilter;
+  
+#if TARGET_OS_IOS
   if (@available(iOS 9.0, macOS 10.15, *)) {
       locationManager.allowsBackgroundLocationUpdates = [GeolocationHandler shouldEnableBackgroundLocationUpdates];
   }
+#endif
   
   [locationManager startUpdatingLocation];
 }

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
@@ -55,11 +55,9 @@
   locationManager.desiredAccuracy = desiredAccuracy;
   locationManager.distanceFilter = distanceFilter;
   
-#if TARGET_OS_IOS
-  if (@available(iOS 9.0, macOS 10.15, *)) {
+  if (@available(iOS 9.0, macOS 10.16, *)) {
       locationManager.allowsBackgroundLocationUpdates = [GeolocationHandler shouldEnableBackgroundLocationUpdates];
   }
-#endif
   
   [locationManager startUpdatingLocation];
 }

--- a/geolocator_apple/apple/Classes/Handlers/LocationAccuracyHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/LocationAccuracyHandler.m
@@ -28,19 +28,18 @@
 }
 
 - (void) getLocationAccuracyWithResult:(FlutterResult)result {
-  if (@available(iOS 14, macOS 11, *)) {
+  if (@available(iOS 14, macOS 10.16, *)) {
     switch ([self.locationManager accuracyAuthorization]) {
       case CLAccuracyAuthorizationFullAccuracy:
         return result([NSNumber numberWithInt:(LocationAccuracy)precise]);
       case CLAccuracyAuthorizationReducedAccuracy:
         return result([NSNumber numberWithInt:(LocationAccuracy)reduced]);
       default:
-        // in iOS 14, reduced location accuracy is the default
+        // Reduced location accuracy is the default on iOS 14+ and macOS 11+.
         return result([NSNumber numberWithInt:(LocationAccuracy)reduced]);
     }
   } else {
-    // If the version of iOS is below version number 14, approximate location is not available, thus
-    // precise location is always returned
+    // Approximate location is not available, return precise location.
     return result([NSNumber numberWithInt:(LocationAccuracy)precise]);
   }
 }
@@ -52,7 +51,7 @@
                                       details:nil]);
   }
   
-  if (@available(iOS 14.0, macOS 11.0, *)) {
+  if (@available(iOS 14.0, macOS 10.16, *)) {
     [self.locationManager requestTemporaryFullAccuracyAuthorizationWithPurposeKey:purposeKey
                                                                        completion:^(NSError *_Nullable error) {
       if ([self.locationManager accuracyAuthorization] == CLAccuracyAuthorizationFullAccuracy) {

--- a/geolocator_apple/apple/Classes/Handlers/LocationAccuracyHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/LocationAccuracyHandler.m
@@ -28,6 +28,9 @@
 }
 
 - (void) getLocationAccuracyWithResult:(FlutterResult)result {
+#if TARGET_OS_OSX
+  return result([NSNumber numberWithInt:(LocationAccuracy)precise]);
+#else
   if (@available(iOS 14, macOS 10.16, *)) {
     switch ([self.locationManager accuracyAuthorization]) {
       case CLAccuracyAuthorizationFullAccuracy:
@@ -42,6 +45,7 @@
     // Approximate location is not available, return precise location.
     return result([NSNumber numberWithInt:(LocationAccuracy)precise]);
   }
+#endif
 }
 
 - (void) requestTemporaryFullAccuracyWithResult:(FlutterResult)result purposeKey:(NSString * _Nullable)purposeKey {
@@ -51,6 +55,9 @@
                                       details:nil]);
   }
   
+#if TARGET_OS_OSX
+  return result([NSNumber numberWithInt:(LocationAccuracy)precise]);
+#else
   if (@available(iOS 14.0, macOS 10.16, *)) {
     [self.locationManager requestTemporaryFullAccuracyAuthorizationWithPurposeKey:purposeKey
                                                                        completion:^(NSError *_Nullable error) {
@@ -63,6 +70,7 @@
   } else {
     return result([NSNumber numberWithInt:(LocationAccuracy)precise]);
   }
+#endif
 }
 
 @end

--- a/geolocator_apple/apple/Classes/Handlers/PermissionHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/PermissionHandler.m
@@ -49,7 +49,7 @@
 #if TARGET_OS_OSX
   if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationUsageDescription"] != nil) {
     if (@available(macOS 10.15, *)) {
-      [self.locationManager requestWhenInUseAuthorization];
+      [self.locationManager requestAlwaysAuthorization];
     }
   }
 #else

--- a/geolocator_apple/apple/Classes/Utils/LocationAccuracyMapper.m
+++ b/geolocator_apple/apple/Classes/Utils/LocationAccuracyMapper.m
@@ -24,11 +24,15 @@
         case 5:
             return kCLLocationAccuracyBestForNavigation;
         case 6:
+#if TARGET_OS_OSX
+        return kCLLocationAccuracyThreeKilometers;
+#else
             if (@available(iOS 14.0, macOS 10.16, *)) {
                 return kCLLocationAccuracyReduced;
             } else {
                 return kCLLocationAccuracyThreeKilometers;
             }
+#endif
         case 4:
         default:
             return kCLLocationAccuracyBest;

--- a/geolocator_apple/apple/Classes/Utils/LocationAccuracyMapper.m
+++ b/geolocator_apple/apple/Classes/Utils/LocationAccuracyMapper.m
@@ -24,15 +24,11 @@
         case 5:
             return kCLLocationAccuracyBestForNavigation;
         case 6:
-#if TARGET_OS_OSX
-            return kCLLocationAccuracyThreeKilometers;
-#else
-            if (@available(iOS 14.0, macOS 11.0, *)) {
+            if (@available(iOS 14.0, macOS 10.16, *)) {
                 return kCLLocationAccuracyReduced;
             } else {
                 return kCLLocationAccuracyThreeKilometers;
             }
-#endif
         case 4:
         default:
             return kCLLocationAccuracyBest;

--- a/geolocator_apple/apple/Classes/Utils/LocationAccuracyMapper.m
+++ b/geolocator_apple/apple/Classes/Utils/LocationAccuracyMapper.m
@@ -24,11 +24,15 @@
         case 5:
             return kCLLocationAccuracyBestForNavigation;
         case 6:
+#if TARGET_OS_OSX
+            return kCLLocationAccuracyThreeKilometers;
+#else
             if (@available(iOS 14.0, macOS 11.0, *)) {
                 return kCLLocationAccuracyReduced;
             } else {
                 return kCLLocationAccuracyThreeKilometers;
             }
+#endif
         case 4:
         default:
             return kCLLocationAccuracyBest;

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
-version: 1.2.0
+version: 1.2.1
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_apple
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

On macOS Catelina requesting permissions result in a compile time error explaining the `requestWhenInUseAuthorization` is not supported.

### :new: What is the new behavior (if this is a feature change)?

Use `requestAlwaysAuthorization` instead of `requestWhenInUseAuthorization` on macOS as both result in the same behaviour but the former has better support on Catelina.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Resolves #835

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
