### PR TITLE
Update getServiceStatusStream method documentation

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.6
+
+- Updated API documentation on `GeolocatorPlatform.getServiceStream()` method, describing it is not supported on the web platform.
+
 ## 2.3.5
 
 - Changed the EventChannelMock and the MethodChannelMockd due to breaking changes in the platform channel test interface.

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -112,9 +112,12 @@ abstract class GeolocatorPlatform extends PlatformInterface {
     throw UnimplementedError('getCurrentPosition() has not been implemented.');
   }
 
-  /// Fires when the Location Service is manually disabled or enabled f.e.
-  /// when Location Service in Settings is disabled, a event will be fired which
-  /// returns a [LocationServiceStatus].
+  /// Fires when the location Service is manually disabled or enabled.
+  ///
+  /// An instance of [LocationServiceStatus] will be emitted each time the
+  /// location service is enabled or disabled.
+  /// Throws an [UnimplementedError] on the web as the concept of location
+  /// service doesn't exist on the web platform.
   Stream<ServiceStatus> getServiceStatusStream() {
     throw UnimplementedError(
         'getServiceStatusStream() has not been implemented.');

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.5
+version: 2.3.6
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Documentation update

### :arrow_heading_down: What is the current behavior?

On the web the `Geolocator.getServiceStatusStream()` method throws an `UnimplementedError` because the web platform doesn't support the concept of a separate location service. The documentation however doesn't mention this and this causes confusion for users working with the geolocator plugin.

### :new: What is the new behavior (if this is a feature change)?

Updated the API documentation for the `Geolocator.getServiceStatusStream()` method to explain that an `UnimplementedError` is thrown when calling this method on the web platform.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- Fixes #846 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
