### PR TITLE
Approximate Location support for Android 12

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.7.0
+
+- Added Approximate Location support for Android 12.
+
 
 ## 7.6.2
 

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 7.6.2
+version: 7.7.0
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
@@ -44,7 +44,7 @@ public class PermissionManager
         if (permissions.length == 1) {
             permissionStatus = ContextCompat.checkSelfPermission(context, permissions[0]);
         } else {
-            if(ContextCompat.checkSelfPermission(context, permissions[0]) == 0
+            if (ContextCompat.checkSelfPermission(context, permissions[0]) == 0
                     || ContextCompat.checkSelfPermission(context, permissions[1]) == 0) {
                 permissionStatus = PackageManager.PERMISSION_GRANTED;
             }
@@ -155,7 +155,7 @@ public class PermissionManager
             return false;
         }
 
-        if(requestedPermissions.length == 1) {
+        if (requestedPermissions.length == 1) {
             if (grantResults[requestedPermissionIndex] == PackageManager.PERMISSION_GRANTED) {
                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
                     int backgroundPermissionIndex =
@@ -176,7 +176,7 @@ public class PermissionManager
             }
         } else {
             if (grantResults[requestedPermissionIndex] == PackageManager.PERMISSION_GRANTED
-                    || grantResults[requestedPermissionIndex+1] == PackageManager.PERMISSION_GRANTED) {
+                    || grantResults[requestedPermissionIndex + 1] == PackageManager.PERMISSION_GRANTED) {
                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
                     int backgroundPermissionIndex =
                             indexOf(permissions, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
@@ -191,7 +191,7 @@ public class PermissionManager
                 }
             } else {
                 if (activity != null && !ActivityCompat.shouldShowRequestPermissionRationale(activity, requestedPermissions[0])
-                    && !ActivityCompat.shouldShowRequestPermissionRationale(activity, requestedPermissions[1])) {
+                        && !ActivityCompat.shouldShowRequestPermissionRationale(activity, requestedPermissions[1])) {
                     permission = LocationPermission.deniedForever;
                 }
             }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
@@ -19,216 +19,221 @@ import java.util.*;
 
 @SuppressWarnings("deprecation")
 public class PermissionManager
-        implements io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener {
+    implements io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener {
 
-    private static final int PERMISSION_REQUEST_CODE = 109;
+  private static final int PERMISSION_REQUEST_CODE = 109;
 
-    @Nullable
-    private Activity activity;
-    @Nullable
-    private ErrorCallback errorCallback;
-    @Nullable
-    private PermissionResultCallback resultCallback;
+  @Nullable private Activity activity;
+  @Nullable private ErrorCallback errorCallback;
+  @Nullable private PermissionResultCallback resultCallback;
 
-    public LocationPermission checkPermissionStatus(Context context, Activity activity)
-            throws PermissionUndefinedException {
-        String[] permissions = determineFineOrCoarse(context);
+  public LocationPermission checkPermissionStatus(Context context, Activity activity)
+      throws PermissionUndefinedException {
+    String[] permissions = determineFineOrCoarse(context);
 
-        // If target is before Android M, permission is always granted
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return LocationPermission.always;
-        }
+    // If target is before Android M, permission is always granted
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return LocationPermission.always;
+    }
 
-        int permissionStatus = -1;
+    int permissionStatus = -1;
 
-        if (permissions.length == 1) {
-            permissionStatus = ContextCompat.checkSelfPermission(context, permissions[0]);
+    if (permissions.length == 1) {
+      permissionStatus = ContextCompat.checkSelfPermission(context, permissions[0]);
+    } else {
+      if (ContextCompat.checkSelfPermission(context, permissions[0])
+              == PackageManager.PERMISSION_GRANTED
+          || ContextCompat.checkSelfPermission(context, permissions[1])
+              == PackageManager.PERMISSION_GRANTED) {
+        permissionStatus = PackageManager.PERMISSION_GRANTED;
+      }
+    }
+
+    if (permissionStatus == PackageManager.PERMISSION_DENIED) {
+      return LocationPermission.denied;
+    }
+
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      return LocationPermission.always;
+    }
+
+    boolean wantsBackgroundLocation =
+        PermissionUtils.hasPermissionInManifest(
+            context, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+    if (!wantsBackgroundLocation) {
+      return LocationPermission.whileInUse;
+    }
+
+    final int permissionStatusBackground =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+    if (permissionStatusBackground == PackageManager.PERMISSION_GRANTED) {
+      return LocationPermission.always;
+    }
+
+    return LocationPermission.whileInUse;
+  }
+
+  public void requestPermission(
+      Activity activity, PermissionResultCallback resultCallback, ErrorCallback errorCallback)
+      throws PermissionUndefinedException {
+    final ArrayList<String> permissionsToRequest = new ArrayList<>();
+
+    if (activity == null) {
+      errorCallback.onError(ErrorCodes.activityMissing);
+      return;
+    }
+
+    // Before Android M, requesting permissions was not needed.
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      resultCallback.onResult(LocationPermission.always);
+      return;
+    }
+
+    String[] permissions = determineFineOrCoarse(activity);
+    Collections.addAll(permissionsToRequest, permissions);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+        && PermissionUtils.hasPermissionInManifest(
+            activity, Manifest.permission.ACCESS_BACKGROUND_LOCATION)) {
+      final int permissionStatus = ContextCompat.checkSelfPermission(activity, permissions[0]);
+      if (permissionStatus != PackageManager.PERMISSION_DENIED) {
+        permissionsToRequest.add(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+      }
+    }
+
+    this.errorCallback = errorCallback;
+    this.resultCallback = resultCallback;
+    this.activity = activity;
+
+    ActivityCompat.requestPermissions(
+        activity, permissionsToRequest.toArray(new String[0]), PERMISSION_REQUEST_CODE);
+  }
+
+  @Override
+  public boolean onRequestPermissionsResult(
+      int requestCode, String[] permissions, int[] grantResults) {
+    if (requestCode != PERMISSION_REQUEST_CODE) {
+      return false;
+    }
+
+    if (this.activity == null) {
+      Log.e("Geolocator", "Trying to process permission result without an valid Activity instance");
+      if (this.errorCallback != null) {
+        this.errorCallback.onError(ErrorCodes.activityMissing);
+      }
+      return false;
+    }
+
+    String[] requestedPermissions;
+
+    try {
+      requestedPermissions = determineFineOrCoarse(this.activity);
+    } catch (PermissionUndefinedException ex) {
+      if (this.errorCallback != null) {
+        this.errorCallback.onError(ErrorCodes.permissionDefinitionsNotFound);
+      }
+
+      return false;
+    }
+
+    LocationPermission permission = LocationPermission.denied;
+
+    int requestedPermissionIndex = indexOf(permissions, requestedPermissions[0]);
+
+    if (requestedPermissionIndex < 0) {
+      Log.w(
+          "Geolocator",
+          "Location permissions not part of permissions send to onRequestPermissionsResult method.");
+      return false;
+    }
+
+    if (grantResults.length == 0) {
+      Log.i(
+          "Geolocator",
+          "The grantResults array is empty. This can happen when the user cancels the permission request");
+      return false;
+    }
+
+    if (requestedPermissions.length == 1) {
+      if (grantResults[requestedPermissionIndex] == PackageManager.PERMISSION_GRANTED) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+          int backgroundPermissionIndex =
+              indexOf(permissions, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+          if (backgroundPermissionIndex >= 0
+              && grantResults[backgroundPermissionIndex] == PackageManager.PERMISSION_GRANTED) {
+            permission = LocationPermission.always;
+          } else {
+            permission = LocationPermission.whileInUse;
+          }
         } else {
-            if (ContextCompat.checkSelfPermission(context, permissions[0]) == 0
-                    || ContextCompat.checkSelfPermission(context, permissions[1]) == 0) {
-                permissionStatus = PackageManager.PERMISSION_GRANTED;
-            }
+          permission = LocationPermission.always;
         }
-
-        if (permissionStatus == PackageManager.PERMISSION_DENIED) {
-            return LocationPermission.denied;
+      } else {
+        if (activity != null
+            && !ActivityCompat.shouldShowRequestPermissionRationale(
+                activity, requestedPermissions[0])) {
+          permission = LocationPermission.deniedForever;
         }
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-            return LocationPermission.always;
-        }
-
-        boolean wantsBackgroundLocation =
-                PermissionUtils.hasPermissionInManifest(
-                        context, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
-        if (!wantsBackgroundLocation) {
-            return LocationPermission.whileInUse;
-        }
-
-        final int permissionStatusBackground =
-                ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
-        if (permissionStatusBackground == PackageManager.PERMISSION_GRANTED) {
-            return LocationPermission.always;
-        }
-
-        return LocationPermission.whileInUse;
-    }
-
-    public void requestPermission(
-            Activity activity, PermissionResultCallback resultCallback, ErrorCallback errorCallback)
-            throws PermissionUndefinedException {
-        final ArrayList<String> permissionsToRequest = new ArrayList<>();
-
-        if (activity == null) {
-            errorCallback.onError(ErrorCodes.activityMissing);
-            return;
-        }
-
-        // Before Android M, requesting permissions was not needed.
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            resultCallback.onResult(LocationPermission.always);
-            return;
-        }
-
-        String[] permissions = determineFineOrCoarse(activity);
-        Collections.addAll(permissionsToRequest, permissions);
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
-                && PermissionUtils.hasPermissionInManifest(
-                activity, Manifest.permission.ACCESS_BACKGROUND_LOCATION)) {
-            final int permissionStatus = ContextCompat.checkSelfPermission(activity, permissions[0]);
-            if (permissionStatus != PackageManager.PERMISSION_DENIED) {
-                permissionsToRequest.add(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
-            }
-        }
-
-        this.errorCallback = errorCallback;
-        this.resultCallback = resultCallback;
-        this.activity = activity;
-
-        ActivityCompat.requestPermissions(
-                activity, permissionsToRequest.toArray(new String[0]), PERMISSION_REQUEST_CODE);
-    }
-
-    @Override
-    public boolean onRequestPermissionsResult(
-            int requestCode, String[] permissions, int[] grantResults) {
-        if (requestCode != PERMISSION_REQUEST_CODE) {
-            return false;
-        }
-
-        if (this.activity == null) {
-            Log.e("Geolocator", "Trying to process permission result without an valid Activity instance");
-            if (this.errorCallback != null) {
-                this.errorCallback.onError(ErrorCodes.activityMissing);
-            }
-            return false;
-        }
-
-        String[] requestedPermissions;
-
-        try {
-            requestedPermissions = determineFineOrCoarse(this.activity);
-        } catch (PermissionUndefinedException ex) {
-            if (this.errorCallback != null) {
-                this.errorCallback.onError(ErrorCodes.permissionDefinitionsNotFound);
-            }
-
-            return false;
-        }
-
-        LocationPermission permission = LocationPermission.denied;
-
-        int requestedPermissionIndex = indexOf(permissions, requestedPermissions[0]);
-
-        if (requestedPermissionIndex < 0) {
-            Log.w(
-                    "Geolocator",
-                    "Location permissions not part of permissions send to onRequestPermissionsResult method.");
-            return false;
-        }
-
-        if (grantResults.length == 0) {
-            Log.i(
-                    "Geolocator",
-                    "The grantResults array is empty. This can happen when the user cancels the permission request");
-            return false;
-        }
-
-        if (requestedPermissions.length == 1) {
-            if (grantResults[requestedPermissionIndex] == PackageManager.PERMISSION_GRANTED) {
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-                    int backgroundPermissionIndex =
-                            indexOf(permissions, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
-                    if (backgroundPermissionIndex >= 0
-                            && grantResults[backgroundPermissionIndex] == PackageManager.PERMISSION_GRANTED) {
-                        permission = LocationPermission.always;
-                    } else {
-                        permission = LocationPermission.whileInUse;
-                    }
-                } else {
-                    permission = LocationPermission.always;
-                }
-            } else {
-                if (activity != null && !ActivityCompat.shouldShowRequestPermissionRationale(activity, requestedPermissions[0])) {
-                    permission = LocationPermission.deniedForever;
-                }
-            }
+      }
+    } else {
+      if (grantResults[requestedPermissionIndex] == PackageManager.PERMISSION_GRANTED
+          || grantResults[requestedPermissionIndex + 1] == PackageManager.PERMISSION_GRANTED) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+          int backgroundPermissionIndex =
+              indexOf(permissions, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+          if (backgroundPermissionIndex >= 0
+              && grantResults[backgroundPermissionIndex] == PackageManager.PERMISSION_GRANTED) {
+            permission = LocationPermission.always;
+          } else {
+            permission = LocationPermission.whileInUse;
+          }
         } else {
-            if (grantResults[requestedPermissionIndex] == PackageManager.PERMISSION_GRANTED
-                    || grantResults[requestedPermissionIndex + 1] == PackageManager.PERMISSION_GRANTED) {
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-                    int backgroundPermissionIndex =
-                            indexOf(permissions, Manifest.permission.ACCESS_BACKGROUND_LOCATION);
-                    if (backgroundPermissionIndex >= 0
-                            && grantResults[backgroundPermissionIndex] == PackageManager.PERMISSION_GRANTED) {
-                        permission = LocationPermission.always;
-                    } else {
-                        permission = LocationPermission.whileInUse;
-                    }
-                } else {
-                    permission = LocationPermission.always;
-                }
-            } else {
-                if (activity != null && !ActivityCompat.shouldShowRequestPermissionRationale(activity, requestedPermissions[0])
-                        && !ActivityCompat.shouldShowRequestPermissionRationale(activity, requestedPermissions[1])) {
-                    permission = LocationPermission.deniedForever;
-                }
-            }
+          permission = LocationPermission.always;
         }
-
-        if (this.resultCallback != null) {
-            this.resultCallback.onResult(permission);
+      } else {
+        if (activity != null
+            && !ActivityCompat.shouldShowRequestPermissionRationale(
+                activity, requestedPermissions[0])
+            && !ActivityCompat.shouldShowRequestPermissionRationale(
+                activity, requestedPermissions[1])) {
+          permission = LocationPermission.deniedForever;
         }
-
-        return true;
+      }
     }
 
-    private static <T> int indexOf(T[] arr, T val) {
-        return Arrays.asList(arr).indexOf(val);
+    if (this.resultCallback != null) {
+      this.resultCallback.onResult(permission);
     }
 
-    private static String[] determineFineOrCoarse(Context context) throws PermissionUndefinedException {
-        boolean wantsFineLocation =
-                PermissionUtils.hasPermissionInManifest(context, Manifest.permission.ACCESS_FINE_LOCATION);
-        boolean wantsCoarseLocation =
-                PermissionUtils.hasPermissionInManifest(
-                        context, Manifest.permission.ACCESS_COARSE_LOCATION);
+    return true;
+  }
 
-        if (!wantsCoarseLocation && !wantsFineLocation) {
-            throw new PermissionUndefinedException();
-        }
+  private static <T> int indexOf(T[] arr, T val) {
+    return Arrays.asList(arr).indexOf(val);
+  }
 
-        ArrayList<String> permissions = new ArrayList<>();
+  private static String[] determineFineOrCoarse(Context context)
+      throws PermissionUndefinedException {
+    boolean wantsFineLocation =
+        PermissionUtils.hasPermissionInManifest(context, Manifest.permission.ACCESS_FINE_LOCATION);
+    boolean wantsCoarseLocation =
+        PermissionUtils.hasPermissionInManifest(
+            context, Manifest.permission.ACCESS_COARSE_LOCATION);
 
-        if (wantsFineLocation) {
-            permissions.add(Manifest.permission.ACCESS_FINE_LOCATION);
-        }
-
-        if (wantsCoarseLocation) {
-            permissions.add(Manifest.permission.ACCESS_COARSE_LOCATION);
-        }
-
-        return permissions.toArray(new String[0]);
+    if (!wantsCoarseLocation && !wantsFineLocation) {
+      throw new PermissionUndefinedException();
     }
+
+    ArrayList<String> permissions = new ArrayList<>();
+
+    if (wantsFineLocation) {
+      permissions.add(Manifest.permission.ACCESS_FINE_LOCATION);
+    }
+
+    if (wantsCoarseLocation) {
+      permissions.add(Manifest.permission.ACCESS_COARSE_LOCATION);
+    }
+
+    return permissions.toArray(new String[0]);
+  }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature
### :arrow_heading_down: What is the current behavior?
Currently, the `geolocator` will mark Android 12 Approximate location requests as `Permission. denied`. This causes some apps running on Android to fail when trying to fetch the Location.

### :new: What is the new behavior (if this is a feature change)?
The issue mentioned above is resolved. Approximate location requests will now be marked as `Permission.granted`.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Use the example application

### :memo: Links to relevant issues/docs
Does not apply

### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [ ] I rebased onto current `master`.
