### PR TITLE
Update stream cancelation callback

### DIFF
--- a/geolocator_apple/apple/Classes/Handlers/PositionStreamHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/PositionStreamHandler.m
@@ -76,7 +76,7 @@
   return nil;
 }
 
-- (FlutterError *_Nullable)onCancelWithArguments:(id _Nullable)arguments {
+- (FlutterError *)onCancelWithArguments:(id)arguments{
   [_geolocationHandler stopListening];
   _eventSink = nil;
   


### PR DESCRIPTION
It seems that the cancel method is not being called, autocompletion declared it differently.

### :sparkles: Bug fix


### :arrow_heading_down: What is the current behavior?

when canceling a stream created via `Geolocator.getPositionStream`, the cancel callback is not invoked on iOS

```dart
final stream = Geolocator.getPositionStream(
        desiredAccuracy: LocationAccuracy.best,
        intervalDuration: const Duration(seconds: 1),
      ).listen((event) { });
      stream.cancel();
```


### :new: What is the new behavior (if this is a feature change)?

the cancel callback is invoked on iOS

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
-Start a new `Geolocator.getPositionStream` and cancel the stream from a button
-Run from Xcode and  set a breakpoint inside cancelation callback
-debugger should stop at breakpoint, compare with master branch

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [ ] I rebased onto current `master`.
