### PR TITLE
Update geolocator_android dependency

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.7.0
+
+> **IMPORTANT:** when updating to version 7.7.0 make sure to also set the compileSdkVersion in the android/app/build.gradle file to 31.
+
+- Updated dependency on geolocator_android to version 2.0.0;
+- Make sure the Android example App compiles against Android SDK 31.
 
 ## 7.6.2
 

--- a/geolocator/example/android/app/build.gradle
+++ b/geolocator/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     lintOptions {
         disable 'InvalidPackage'

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 7.6.2
+version: 7.7.0
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 
@@ -25,7 +25,7 @@ dependencies:
     sdk: flutter
   
   geolocator_platform_interface: ^2.3.4
-  geolocator_android: ^1.0.1
+  geolocator_android: ^2.0.0
   geolocator_apple: ^1.2.0
   geolocator_web: ^2.0.1
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Maintenance

### :arrow_heading_down: What is the current behavior?

Currently the geolocator app-facing packages depends on version `>1.0.1` of the geolocator_android package which doesn't provide support for Android SDK 31.

### :new: What is the new behavior (if this is a feature change)?

Update the `geolocator_android` dependency to version 2.0.0, which provides support for Android SDK 31.

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
