### PR TITLE
Update README.md for Android SDK 31

### DIFF
--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -42,11 +42,11 @@ The TL;DR version is:
 android.useAndroidX=true
 android.enableJetifier=true
 ```
-2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 30:
+2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 31:
 
 ```
 android {
-  compileSdkVersion 30
+  compileSdkVersion 31
 
   ...
 }


### PR DESCRIPTION
Reflect new Android 12 requirements to build

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Docs update


### :arrow_heading_down: What is the current behavior?

The reported minSDK doesn't make the newest lib to build on Android


### :new: What is the new behavior (if this is a feature change)?

Raising minSdk as suggested in issues makes geolocator to build correctly


### :boom: Does this PR introduce a breaking change?

Nope


### :bug: Recommendations for testing

Nope


### :memo: Links to relevant issues/docs

Nope


### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [ ] I rebased onto current `master`.
