### PR TITLE
Keep PositionStream alive when service status has been changed

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,4 +1,4 @@
-# NEXT
+## 2.0.0
 
 - iOS: Keep `PositionStream` alive when the `Location Services` has been turned off and on again in the settings.
 - Removed implicit request for permissions when getting a position.

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,5 +1,6 @@
 # NEXT
 
+- iOS: Keep `PositionStream` alive when the `Location Services` has been turned off and on again in the settings.
 - Removed implicit request for permissions when getting a position.
 - Added the [ActivityType] enum needed for the `pauseLocationUpdatesAutomatically` property.
 - Added the `pauseLocationUpdatesAutomatically` and `activityType` property to the iOS options class.

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
@@ -108,9 +108,7 @@
     if([error.domain isEqualToString:kCLErrorDomain] && error.code == kCLErrorLocationUnknown) {
         return;
     }
-    
-    
-    
+
     if (self.errorHandler) {
         self.errorHandler(GeolocatorErrorLocationUpdateFailure, error.localizedDescription);
     }

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
@@ -109,7 +109,7 @@
         return;
     }
     
-    [self stopListening];
+    
     
     if (self.errorHandler) {
         self.errorHandler(GeolocatorErrorLocationUpdateFailure, error.localizedDescription);

--- a/geolocator_apple/apple/Classes/Handlers/PositionStreamHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/PositionStreamHandler.m
@@ -84,7 +84,6 @@
   _eventSink([FlutterError errorWithCode:errorCode
                                  message:errorDescription
                                  details:nil]);
-  _eventSink = nil;
 }
 
 @end

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -1,7 +1,7 @@
 name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 # TODO: Change the version code when the final version of geolocator_apple is ready
-version: NEXT
+version: 2.0.0
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_apple
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -43,9 +43,9 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
       return permission.toLocationPermission();
     } on PlatformException catch (e) {
-      _handlePlatformException(e);
+      final error = _handlePlatformException(e);
 
-      rethrow;
+      throw error;
     }
   }
 
@@ -58,9 +58,9 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
       return permission.toLocationPermission();
     } on PlatformException catch (e) {
-      _handlePlatformException(e);
+      final error = _handlePlatformException(e);
 
-      rethrow;
+      throw error;
     }
   }
 
@@ -83,9 +83,9 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
       return positionMap != null ? Position.fromMap(positionMap) : null;
     } on PlatformException catch (e) {
-      _handlePlatformException(e);
+      final error = _handlePlatformException(e);
 
-      rethrow;
+      throw error;
     }
   }
 
@@ -122,9 +122,9 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
       final positionMap = await positionFuture;
       return Position.fromMap(positionMap);
     } on PlatformException catch (e) {
-      _handlePlatformException(e);
+      final error = _handlePlatformException(e);
 
-      rethrow;
+      throw error;
     }
   }
 
@@ -141,7 +141,7 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
         .handleError((error) {
       _serviceStatusStream = null;
       if (error is PlatformException) {
-        _handlePlatformException(error);
+        error = _handlePlatformException(error);
       }
       throw error;
     });
@@ -182,9 +182,8 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
             Position.fromMap(element.cast<String, dynamic>()))
         .handleError(
       (error) {
-        _positionStream = null;
         if (error is PlatformException) {
-          _handlePlatformException(error);
+          error = _handlePlatformException(error);
         }
         throw error;
       },
@@ -212,8 +211,8 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
       );
       return LocationAccuracyStatus.values[status];
     } on PlatformException catch (e) {
-      _handlePlatformException(e);
-      rethrow;
+      final error = _handlePlatformException(e);
+      throw error;
     }
   }
 
@@ -227,24 +226,24 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
       .invokeMethod<bool>('openLocationSettings')
       .then((value) => value ?? false);
 
-  void _handlePlatformException(PlatformException exception) {
+  Exception _handlePlatformException(PlatformException exception) {
     switch (exception.code) {
       case 'ACTIVITY_MISSING':
-        throw ActivityMissingException(exception.message);
+        return ActivityMissingException(exception.message);
       case 'LOCATION_SERVICES_DISABLED':
-        throw const LocationServiceDisabledException();
+        return const LocationServiceDisabledException();
       case 'LOCATION_SUBSCRIPTION_ACTIVE':
-        throw const AlreadySubscribedException();
+        return const AlreadySubscribedException();
       case 'PERMISSION_DEFINITIONS_NOT_FOUND':
-        throw PermissionDefinitionsNotFoundException(exception.message);
+        return PermissionDefinitionsNotFoundException(exception.message);
       case 'PERMISSION_DENIED':
-        throw PermissionDeniedException(exception.message);
+        return PermissionDeniedException(exception.message);
       case 'PERMISSION_REQUEST_IN_PROGRESS':
-        throw PermissionRequestInProgressException(exception.message);
+        return PermissionRequestInProgressException(exception.message);
       case 'LOCATION_UPDATE_FAILURE':
-        throw PositionUpdateException(exception.message);
+        return PositionUpdateException(exception.message);
       default:
-        throw exception;
+        return exception;
     }
   }
 }

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -787,46 +787,46 @@ void main() {
       });
 
       test(
-        // ignore: lines_longer_than_80_chars
+          // ignore: lines_longer_than_80_chars
           'Should continue listening to the stream when exception is thrown ',
-              () async {
-            // Arrange
-            final streamController =
+          () async {
+        // Arrange
+        final streamController =
             StreamController<Map<String, dynamic>>.broadcast();
-            EventChannelMock(
-              channelName: 'flutter.baseflow.com/geolocator_updates',
-              stream: streamController.stream,
-            );
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_updates',
+          stream: streamController.stream,
+        );
 
-            // Act
-            final positionStream = MethodChannelGeolocator().getPositionStream();
-            final streamQueue = StreamQueue(positionStream);
+        // Act
+        final positionStream = MethodChannelGeolocator().getPositionStream();
+        final streamQueue = StreamQueue(positionStream);
 
-            // Emit test events
-            streamController.add(mockPosition.toJson());
-            streamController.addError(PlatformException(
-                code: 'PERMISSION_DENIED',
-                message: 'Permission denied',
-                details: null));
-            streamController.add(mockPosition.toJson());
+        // Emit test events
+        streamController.add(mockPosition.toJson());
+        streamController.addError(PlatformException(
+            code: 'PERMISSION_DENIED',
+            message: 'Permission denied',
+            details: null));
+        streamController.add(mockPosition.toJson());
 
-            // Assert
-            expect(await streamQueue.next, mockPosition);
-            expect(
-                streamQueue.next,
-                throwsA(
-                  isA<PermissionDeniedException>().having(
-                        (e) => e.message,
-                    'message',
-                    'Permission denied',
-                  ),
-                ));
-            expect(await streamQueue.next, mockPosition);
+        // Assert
+        expect(await streamQueue.next, mockPosition);
+        expect(
+            streamQueue.next,
+            throwsA(
+              isA<PermissionDeniedException>().having(
+                (e) => e.message,
+                'message',
+                'Permission denied',
+              ),
+            ));
+        expect(await streamQueue.next, mockPosition);
 
-            // Clean up
-            await streamQueue.cancel();
-            await streamController.close();
-          });
+        // Clean up
+        await streamQueue.cancel();
+        await streamController.close();
+      });
 
       test(
           // ignore: lines_longer_than_80_chars


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Current behavior is that the PositionStream is cancelled when the `Location Service` or permission iOS devices is turned off. The behavior in this PR keeps the stream alive when the location service has been turned off and on again in the settings. 

### :arrow_heading_down: What is the current behavior?

Stops giving location updates when the location service has been turned off and on again in the settings.
### :new: What is the new behavior (if this is a feature change)?

Keeps the PositionStream alive when the location service has been turned off and on again in the settings.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing



### :memo: Links to relevant issues/docs

Issue #821

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.