### PR TITLE
Removed the permission API query in the geolocator_web package and updated the README.md

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.8.1
+
+- Updated README.md to clarify the use of the `Geolocator.checkPermission()` method.
+
 ## 7.8.0
 
 - Added Approximate Location support for Android 12;

--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -270,6 +270,10 @@ bool isLocationServiceEnabled  = await Geolocator.isLocationServiceEnabled();
 
 The geolocator will automatically try to request permissions when you try to acquire a location through the `getCurrentPosition` or `getPositionStream` methods. We do however provide methods that will allow you to manually handle requesting permissions.
 
+**NOTE**
+
+When using the web platform, the `checkPermission` method will always return the `LocationPermission.denied` status, since not every browser is supporting the JavaScript Permissions API. Nevertheless, the `getCurrentPosition` and `getPositionStream` methods can still be used on the web platform.
+
 If you want to check if the user already granted permissions to acquire the device's location you can make a call to the `checkPermission` method:
 
 ``` dart

--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -272,7 +272,7 @@ The geolocator will automatically try to request permissions when you try to acq
 
 **NOTE**
 
-When using the web platform, the `checkPermission` method will always return the `LocationPermission.denied` status, since not every browser is supporting the JavaScript Permissions API. Nevertheless, the `getCurrentPosition` and `getPositionStream` methods can still be used on the web platform.
+When using the web platform, the `checkPermission` method will return the `LocationPermission.denied` status, when the browser doesn't support the JavaScript Permissions API. Nevertheless, the `getCurrentPosition` and `getPositionStream` methods can still be used on the web platform.
 
 If you want to check if the user already granted permissions to acquire the device's location you can make a call to the `checkPermission` method:
 

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 7.8.0
+version: 7.8.1
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 

--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.7
+
+- Removed Permissions query in the `requestPermission` method.
+
 ## 2.0.6
 
 - Fixes a bug where the `LocationAccuracy.reduced` accuracy value is treated as high accuracy on web.

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -15,7 +15,6 @@ export 'package:geolocator_platform_interface/geolocator_platform_interface.dart
 ///
 /// This class implements the `package:geolocator` functionality for the web.
 class GeolocatorPlugin extends GeolocatorPlatform {
-  static const _permissionQuery = {'name': 'geolocation'};
 
   final GeolocationManager _geolocation;
   final PermissionsManager _permissions;

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -15,7 +15,6 @@ export 'package:geolocator_platform_interface/geolocator_platform_interface.dart
 ///
 /// This class implements the `package:geolocator` functionality for the web.
 class GeolocatorPlugin extends GeolocatorPlatform {
-
   final GeolocationManager _geolocation;
   final PermissionsManager _permissions;
 

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -15,6 +15,8 @@ export 'package:geolocator_platform_interface/geolocator_platform_interface.dart
 ///
 /// This class implements the `package:geolocator` functionality for the web.
 class GeolocatorPlugin extends GeolocatorPlatform {
+  static const _permissionQuery = {'name': 'geolocation'};
+
   final GeolocationManager _geolocation;
   final PermissionsManager _permissions;
 
@@ -53,7 +55,9 @@ class GeolocatorPlugin extends GeolocatorPlatform {
       );
     }
 
-    return LocationPermission.denied;
+    return await _permissions.query(
+      _permissionQuery,
+    );
   }
 
   @override

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -55,9 +55,7 @@ class GeolocatorPlugin extends GeolocatorPlatform {
       );
     }
 
-    return await _permissions.query(
-      _permissionQuery,
-    );
+    return LocationPermission.denied;
   }
 
   @override

--- a/geolocator_web/lib/src/html_permissions_manager.dart
+++ b/geolocator_web/lib/src/html_permissions_manager.dart
@@ -16,10 +16,17 @@ class HtmlPermissionsManager implements PermissionsManager {
 
   @override
   Future<LocationPermission> query(Map permission) async {
-    final html.PermissionStatus result = await _permissions!.query(
+    final permissions = _permissions;
+    if (permissions == null) {
+      return LocationPermission.denied;
+    }
+
+    final status = await permissions.query(
       _permissionQuery,
     );
 
-    return toLocationPermission(result.state);
+    return status.state != null
+        ? toLocationPermission(status.state)
+        : LocationPermission.denied;
   }
 }

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_web
 description: Official web implementation of the geolocator plugin.
 repository: https://github.com/Baseflow/flutter-geolocator/tree/geolocator_web
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.0.6
+version: 2.0.7
 
 flutter:
   plugin:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Removed the Permission API query in the geolocator_web package, to be found in the `checkPermission` method.

### :arrow_heading_down: What is the current behavior?
Currently, apps running in browsers that don't support the JavaScript Permissions API, will stop working when using the `checkPermission` method.

### :new: What is the new behavior (if this is a feature change)?
The `checkPermission` method will always return the `LocationPermission.denied` status.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Does not apply.

### :memo: Links to relevant issues/docs
Does not apply

### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [ ] I rebased onto current `master`.
