### PR TITLE
Avoid usage of unofficial API

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0+5
+
+- Replace usage of unofficial GMS library
+
 ## 3.0.0+4
 
 - Resolve merge conflict.

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.0+5
+## 3.0.1
 
 - Replace usage of unofficial GMS library
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -16,7 +16,6 @@ import androidx.annotation.Nullable;
 
 import com.baseflow.geolocator.errors.ErrorCallback;
 import com.baseflow.geolocator.errors.ErrorCodes;
-import com.google.android.gms.common.util.Strings;
 
 import java.util.List;
 
@@ -93,7 +92,7 @@ class LocationManagerClient implements LocationClient, LocationListener {
 
     this.currentLocationProvider = getBestProvider(this.locationManager, locationAccuracy);
 
-    if (Strings.isEmptyOrWhitespace(this.currentLocationProvider)) {
+    if (this.currentLocationProvider.trim().isEmpty()) {
       errorCallback.onError(ErrorCodes.locationServicesDisabled);
       return;
     }
@@ -227,7 +226,7 @@ class LocationManagerClient implements LocationClient, LocationListener {
 
     String provider = locationManager.getBestProvider(criteria, true);
 
-    if (Strings.isEmptyOrWhitespace(provider)) {
+    if (provider.trim().isEmpty()) {
       List<String> providers = locationManager.getProviders(true);
       if (providers.size() > 0) provider = providers.get(0);
     }

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 3.0.0+5
+version: 3.0.1
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 3.0.0+4
+version: 3.0.0+5
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This PR removes the usage `com.google.android.gms.common.util.Strings;`. I'm trying to publish an app to F-Droid. Therefore, I'm stripping away the GMS dependency before packaging the final result. This actually works very well if I'm forcing the usage of the legacy location manager.

The only issue with my approach is that geolocator is using the Strings API which in fact is not even listed here: https://developers.google.com/android/reference/com/google/android/gms/common/package-summary

### :new: What is the new behavior (if this is a feature change)?

The new check is done using plain Java.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

None

### :memo: Links to relevant issues/docs

None

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
