### PR TITLE
Fix "forceAndroidLocationManager" feature in android bindings

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+- Fix "forceAndroidLocationManager" feature in android bindings
+
 ## 3.0.0+4
 
 - Resolve merge conflict.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
@@ -175,7 +175,7 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
         return;
     }
 
-    Boolean forceLocationManager = call.argument("forceLocationManager");
+    Boolean forceLocationManager = call.argument("forceAndroidLocationManager");
 
     this.geolocationManager.getLastKnownPosition(
         this.context,
@@ -199,8 +199,8 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     @SuppressWarnings("unchecked")
     Map<String, Object> map = (Map<String, Object>) call.arguments;
     boolean forceLocationManager = false;
-    if (map != null && map.get("forceLocationManager") != null) {
-      forceLocationManager = (boolean) map.get("forceLocationManager");
+    if (map != null && map.get("forceAndroidLocationManager") != null) {
+      forceLocationManager = (boolean) map.get("forceAndroidLocationManager");
     }
     LocationOptions locationOptions = LocationOptions.parseArguments(map);
     final boolean[] replySubmitted = {false};

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -86,8 +86,8 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
     @SuppressWarnings("unchecked")
     Map<String, Object> map = (Map<String, Object>) arguments;
     boolean forceLocationManager = false;
-    if (map != null && map.get("forceLocationManager") != null) {
-      forceLocationManager = (boolean) map.get("forceLocationManager");
+    if (map != null && map.get("forceAndroidLocationManager") != null) {
+      forceLocationManager = (boolean) map.get("forceAndroidLocationManager");
     }
     LocationOptions locationOptions = LocationOptions.parseArguments(map);
 

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 3.0.0+4
+version: 3.0.1
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

On the dart side the parameter is still called "forceAndroidLocationManager". The native side expects it to be called "forceLocationManager"

### :arrow_heading_down: What is the current behavior?

The paramter can not be used anymore.

### :new: What is the new behavior (if this is a feature change)?

-

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

None

### :memo: Links to relevant issues/docs

None

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
