### PR TITLE
Platform: Fix "forceAndroidLocationManager" feature for getLastKnownPosition

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Remove unnexessary import statements from several source files.
 
+## 3.1.0
+
+- Fix "forceAndroidLocationManager" for getLastKnownPosition
+
 ## 3.0.0+1
 
 - Removed Android specific `LocationSettings.intervalDuration` field.

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Remove unnexessary import statements from several source files.
 
-## 3.1.0
+## 3.0.1
 
 - Fix "forceAndroidLocationManager" for getLastKnownPosition
 

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,9 +1,6 @@
-## NEXT
-
-- Remove unnexessary import statements from several source files.
-
 ## 3.0.1
 
+- Remove unnexessary import statements from several source files.
 - Fix "forceAndroidLocationManager" for getLastKnownPosition
 
 ## 3.0.0+1

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -76,7 +76,7 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// Throws a [PermissionDeniedException] when trying to request the device's
   /// location when the user denied access.
   Future<Position?> getLastKnownPosition({
-    bool forceAndroidLocationManager = false,
+    bool forceLocationManager = false,
   }) {
     throw UnimplementedError(
       'getLastKnownPosition() has not been implemented.',

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -94,7 +94,7 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   ///
   /// On Android you can force the use of the Android LocationManager instead of
   /// the FusedLocationProvider by setting the [forceLocationManager]
-  /// parameter of [LocationSettings] to true. The [timeLimit] parameter of 
+  /// parameter of [LocationSettings] to true. The [timeLimit] parameter of
   /// [LocationSettings] allows you to specify a timeout interval (by default no
   /// time limit is configured).
   ///
@@ -144,8 +144,8 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// the update is emitted (default value is 0 indicator no filter is used).
   /// On Android you can force the use of the Android LocationManager instead
   /// of the FusedLocationProvider by setting the [forceLocationManager]
-  /// parameter of [LocationSettings] to true. Using the [timeInterval] 
-  /// of [LocationSettings] you can control the amount of time that needs to 
+  /// parameter of [LocationSettings] to true. Using the [timeInterval]
+  /// of [LocationSettings] you can control the amount of time that needs to
   /// pass before the next position update is send.
   ///
   /// Throws a [PermissionDeniedException] when trying to request the device's

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -70,7 +70,7 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   ///
   /// On Android you can force the plugin to use the old Android
   /// LocationManager implementation over the newer FusedLocationProvider by
-  /// passing true to the [forceAndroidLocationManager] parameter. On iOS
+  /// passing true to the [forceLocationManager] parameter. On iOS
   /// this parameter is ignored.
   /// When no position is available, null is returned.
   /// Throws a [PermissionDeniedException] when trying to request the device's
@@ -93,9 +93,10 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// update it with the result of the `getCurrentPosition` method.
   ///
   /// On Android you can force the use of the Android LocationManager instead of
-  /// the FusedLocationProvider by setting the [forceAndroidLocationManager]
-  /// parameter to true. The [timeLimit] parameter allows you to specify a
-  /// timeout interval (by default no time limit is configured).
+  /// the FusedLocationProvider by setting the [forceLocationManager]
+  /// parameter of [LocationSettings] to true. The [timeLimit] parameter of 
+  /// [LocationSettings] allows you to specify a timeout interval (by default no
+  /// time limit is configured).
   ///
   /// Throws a [TimeoutException] when no location is received within the
   /// supplied [timeLimit] duration.
@@ -142,9 +143,10 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// parameter controls the minimum distance the device needs to move before
   /// the update is emitted (default value is 0 indicator no filter is used).
   /// On Android you can force the use of the Android LocationManager instead
-  /// of the FusedLocationProvider by setting the [forceAndroidLocationManager]
-  /// parameter to true. Using the [timeInterval] you can control the amount of
-  /// time that needs to pass before the next position update is send.
+  /// of the FusedLocationProvider by setting the [forceLocationManager]
+  /// parameter of [LocationSettings] to true. Using the [timeInterval] 
+  /// of [LocationSettings] you can control the amount of time that needs to 
+  /// pass before the next position update is send.
   ///
   /// Throws a [PermissionDeniedException] when trying to request the device's
   /// location when the user denied access.

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -71,11 +71,11 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
 
   @override
   Future<Position?> getLastKnownPosition({
-    bool forceAndroidLocationManager = false,
+    bool forceLocationManager = false,
   }) async {
     try {
       final parameters = <String, dynamic>{
-        'forceAndroidLocationManager': forceAndroidLocationManager,
+        'forceLocationManager': forceLocationManager,
       };
 
       final positionMap =

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -25,11 +25,11 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
   static const _serviceStatusEventChannel =
       EventChannel('flutter.baseflow.com/geolocator_service_updates');
 
-  /// On Android devices you can set [forceAndroidLocationManager]
+  /// On Android devices you can set [forcedLocationManager]
   /// to true to force the plugin to use the [LocationManager] to determine the
   /// position instead of the [FusedLocationProviderClient]. On iOS this is
   /// ignored.
-  bool forceAndroidLocationManager = false;
+  bool forcedLocationManager = false;
 
   Stream<Position>? _positionStream;
   Stream<ServiceStatus>? _serviceStatusStream;

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.1.0
+version: 3.0.1
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.0.0+1
+version: 3.1.0
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -464,7 +464,7 @@ void main() {
         );
 
         final expectedArguments = <String, dynamic>{
-          "forceAndroidLocationManager": false,
+          "forceLocationManager": false,
         };
 
         // Act

--- a/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_geolocator_test.dart
@@ -469,7 +469,7 @@ void main() {
 
         // Act
         final position = await MethodChannelGeolocator().getLastKnownPosition(
-          forceAndroidLocationManager: false,
+          forceLocationManager: false,
         );
 
         // Arrange
@@ -496,7 +496,7 @@ void main() {
 
         // Act
         final future = MethodChannelGeolocator().getLastKnownPosition(
-          forceAndroidLocationManager: false,
+          forceLocationManager: false,
         );
 
         // Assert


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

On the dart side the parameter is still called "forceAndroidLocationManager". The native side expects it to be called "forceLocationManager"

### :arrow_heading_down: What is the current behavior?

The paramter can not be used anymore.

### :new: What is the new behavior (if this is a feature change)?

-

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

None

### :memo: Links to relevant issues/docs

None

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
