### PR TITLE
Fix geolocator_web

### DIFF
--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- Upgrade the `geolocator_platform_interface` dependency to version 3.0.1.
+
 ## 2.1.0
 
 - Made changes to the implementation of the `getCurrentPosition` and `getPositionStream` method to match new platform interface. 

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -72,7 +72,7 @@ class GeolocatorPlugin extends GeolocatorPlatform {
 
   @override
   Future<Position> getLastKnownPosition({
-    bool forceAndroidLocationManager = false,
+    bool forceLocationManager = false,
   }) =>
       throw _unsupported('getLastKnownPosition');
 

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_web
 description: Official web implementation of the geolocator plugin.
 repository: https://github.com/Baseflow/flutter-geolocator/tree/geolocator_web
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.1.0
+version: 2.1.1
 
 flutter:
   plugin:
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  geolocator_platform_interface: ^3.0.0
+  geolocator_platform_interface: ^3.0.1
 
 dev_dependencies:
   flutter_test:

--- a/geolocator_web/test/geolocator_web_test.dart
+++ b/geolocator_web/test/geolocator_web_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 import 'package:geolocator_web/geolocator_web.dart';
 import 'package:geolocator_web/src/geolocation_manager.dart';
 import 'package:geolocator_web/src/permissions_manager.dart';


### PR DESCRIPTION
Related PR: https://github.com/Baseflow/flutter-geolocator/pull/918

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

The `forceAndroidLocationManager` parameter on the `getLastKnownPosition` method in the platoform interface has been renamed since version 3.0.0. Unfortunately this has not been updated in the `geolocator_web` package.

### :arrow_heading_down: What is the current behavior?

Renamed the parameter so geoloator_web compiles correcty.

### :new: What is the new behavior (if this is a feature change)?

-

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

None

### :memo: Links to relevant issues/docs

None

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.