### PR TITLE
Web: Fix "forceAndroidLocationManager" feature for getLastKnownPosition

### DIFF
--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- Use "forceLocationManager" instead of "forceAndroidLocationManager"
+
 ## 2.1.0
 
 - Made changes to the implementation of the `getCurrentPosition` and `getPositionStream` method to match new platform interface. 

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -72,7 +72,7 @@ class GeolocatorPlugin extends GeolocatorPlatform {
 
   @override
   Future<Position> getLastKnownPosition({
-    bool forceAndroidLocationManager = false,
+    bool forceLocationManager = false,
   }) =>
       throw _unsupported('getLastKnownPosition');
 

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_web
 description: Official web implementation of the geolocator plugin.
 repository: https://github.com/Baseflow/flutter-geolocator/tree/geolocator_web
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.1.0
+version: 2.1.1
 
 flutter:
   plugin:
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  geolocator_platform_interface: ^3.0.0
+  geolocator_platform_interface: ^3.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
See https://github.com/Baseflow/flutter-geolocator/pull/918