### PR TITLE
Export `ActivityType` at `geolocator.dart`

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.0.4
+- Export `ActivityType` at `geolocator.dart`
+- 
 ## 8.0.3
 
 - Upgraded the geolocator_platform_interface, geolocator_web, geolocator_apple and geolocator_android packages to the latest versions.

--- a/geolocator/lib/geolocator.dart
+++ b/geolocator/lib/geolocator.dart
@@ -8,7 +8,8 @@ import 'package:geolocator_platform_interface/geolocator_platform_interface.dart
 export 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 export 'package:geolocator_android/geolocator_android.dart'
     show AndroidSettings;
-export 'package:geolocator_apple/geolocator_apple.dart' show AppleSettings;
+export 'package:geolocator_apple/geolocator_apple.dart'
+    show AppleSettings, ActivityType;
 
 /// Wraps CLLocationManager (on iOS) and FusedLocationProviderClient or
 /// LocationManager

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 8.0.3
+version: 8.0.4
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
enhancement

### :arrow_heading_down: What is the current behavior?
When I use `AppleSettings` with `activityType` property. `AppleSettings` has exported, but the type of the property itself is not.
 Must import: 
`import 'package:geolocator_apple/geolocator_apple.dart';`

On the opposite side, unnecessary below import for `AndroidSettings`:
`import 'package:geolocator_android/geolocator_android.dart';`


### :new: What is the new behavior (if this is a feature change)?
Export `ActivityType` at `geolocator.dart`

Then all need to do:
`import 'package:geolocator/geolocator.dart';`

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
