### PR TITLE
[geolocator_web] Fixes a bug where a timeout exception occurs when no timeout interval is specified.

### DIFF
--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.2
+
+- Fixes a bug where the `getCurrentPosition` and `getPositionStream` methods return a timeout exception when no timeout interval is specified.
+
 ## 2.1.1
 
 - Upgrade the `geolocator_platform_interface` dependency to version 3.0.1.

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -82,7 +82,7 @@ class GeolocatorPlugin extends GeolocatorPlatform {
   }) async {
     final result = await _geolocation.getCurrentPosition(
       enableHighAccuracy: _enableHighAccuracy(locationSettings?.accuracy),
-      timeout: locationSettings?.timeLimit ?? const Duration(seconds: 0),
+      timeout: locationSettings?.timeLimit,
     );
 
     return result;
@@ -97,7 +97,7 @@ class GeolocatorPlugin extends GeolocatorPlatform {
     return _geolocation
         .watchPosition(
       enableHighAccuracy: _enableHighAccuracy(locationSettings?.accuracy),
-      timeout: locationSettings?.timeLimit ?? const Duration(seconds: 0),
+      timeout: locationSettings?.timeLimit,
     )
         .skipWhile((geoposition) {
       if (locationSettings?.distanceFilter == 0 ||

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_web
 description: Official web implementation of the geolocator plugin.
 repository: https://github.com/Baseflow/flutter-geolocator/tree/geolocator_web
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.1.1
+version: 2.1.2
 
 flutter:
   plugin:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When calling the `getCurrentPosition` or `getPositionStream` methods on the web without specifying a value for the `timelimit` parameter a timeout exception is thrown. The default behaviour should be that when the `timelimit` value is not supplied the method should wait indefinitely for a position to be acquired.
 
### :new: What is the new behavior (if this is a feature change)?

Ensure the default behaviour is implemented. 

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

-

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
