### PR TITLE
Updated GeolocatorPlatform

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,7 +1,14 @@
+## 3.0.2
+
+- Made changes to the `GeolocatorPlatform` due to version locking issues.
+- Replaced soft-deprecated `PlatformInterface.verifyToken` method with `PlatformInterface.verify` method;
+- Updated `plugin_platform_interface` dependency;
+- 
+
 ## 3.0.1
 
-- Remove unnexessary import statements from several source files.
-- Fix "forceAndroidLocationManager" for getLastKnownPosition
+- Remove unnecessary import statements from several source files;
+- Fix "forceAndroidLocationManager" for getLastKnownPosition.
 
 ## 3.0.0+1
 

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,9 +1,8 @@
-## 3.0.2
+## 4.0.0
 
-- Made changes to the `GeolocatorPlatform` due to version locking issues;
+- **breaking** Updates the plugin platform interface to use a non`-const` token. This is marked as a breaking change because it can cause an assertion failure if implementations use `implements` rather than `extends`, but hopefully there aren't any of those;
 - Replaced soft-deprecated `PlatformInterface.verifyToken` method with `PlatformInterface.verify` method;
 - Updated `plugin_platform_interface` dependency.
-- 
 
 ## 3.0.1
 

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 3.0.2
 
-- Made changes to the `GeolocatorPlatform` due to version locking issues.
+- Made changes to the `GeolocatorPlatform` due to version locking issues;
 - Replaced soft-deprecated `PlatformInterface.verifyToken` method with `PlatformInterface.verify` method;
-- Updated `plugin_platform_interface` dependency;
+- Updated `plugin_platform_interface` dependency.
 - 
 
 ## 3.0.1

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -20,7 +20,7 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// Constructs a GeolocatorPlatform.
   GeolocatorPlatform() : super(token: _token);
 
-  static const Object _token = Object();
+  static final Object _token = Object();
 
   static GeolocatorPlatform _instance = MethodChannelGeolocator();
 
@@ -33,7 +33,7 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   /// platform-specific class that extends [GeolocatorPlatform] when they
   /// register themselves.
   static set instance(GeolocatorPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verify(instance, _token);
     _instance = instance;
   }
 

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,13 +3,13 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.0.1
+version: 3.0.2
 
 dependencies:
   flutter:
     sdk: flutter
   
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.1
   vector_math: ^2.1.0
   meta: ^1.3.0
 

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.0.2
+version: 4.0.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Currently the `_token` object in the `GeolocatorPlatform` is a const variable, which should be a final variable. Can cause version locking. Also replaced the `verifyToken` method with the `verify` method as mentioned in the issues in the `Links to relevant issues/docs` section.

### :new: What is the new behavior (if this is a feature change)?
Solved the issue mentioned above

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Does not apply

### :memo: Links to relevant issues/docs
https://github.com/flutter/flutter/issues/96178
https://github.com/Baseflow/flutter-geolocator/issues/937
https://github.com/flutter/plugins/pull/4640

### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [ ] I rebased onto current `master`.
