### PR TITLE
Changed default value of intervalDuration

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 3.0.2
+
+- Added a default `intervalDuration` value of 500ms to prevent the `getCurrentPosition` method to return a cached Location.
+
 ## 3.0.1
 
-- Replace usage of unofficial GMS library
+- Replace usage of unofficial GMS library.
 
 ## 3.0.0+4
 

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.2
 
-- Added a default `intervalDuration` value of 500ms to prevent the `getCurrentPosition` method to return a cached Location.
+- Added a default `intervalDuration` value of 5000ms to prevent the `getCurrentPosition` method to return a cached Location.
 
 ## 3.0.1
 

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 3.0.2
+## 3.0.3
 
 - Added a default `intervalDuration` value of 5000ms to prevent the `getCurrentPosition` method to return a cached Location.
+
+## 3.0.2
+
+- Updated to the latest version of the `geolocator_platform_interface': `4.0.0`.
 
 ## 3.0.1
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationOptions.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationOptions.java
@@ -9,7 +9,7 @@ public class LocationOptions {
 
   public static LocationOptions parseArguments(Map<String, Object> arguments) {
     if (arguments == null) {
-      return new LocationOptions(LocationAccuracy.best, 0, 500);
+      return new LocationOptions(LocationAccuracy.best, 0, 5000);
     }
 
     final Integer accuracy = (Integer) arguments.get("accuracy");
@@ -44,7 +44,7 @@ public class LocationOptions {
     return new LocationOptions(
         locationAccuracy,
         distanceFilter != null ? distanceFilter : 0,
-        timeInterval != null ? timeInterval : 500);
+        timeInterval != null ? timeInterval : 5000);
   }
 
   private LocationOptions(LocationAccuracy accuracy, long distanceFilter, long timeInterval) {

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationOptions.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationOptions.java
@@ -9,7 +9,7 @@ public class LocationOptions {
 
   public static LocationOptions parseArguments(Map<String, Object> arguments) {
     if (arguments == null) {
-      return new LocationOptions(LocationAccuracy.best, 0, 0);
+      return new LocationOptions(LocationAccuracy.best, 0, 500);
     }
 
     final Integer accuracy = (Integer) arguments.get("accuracy");
@@ -44,7 +44,7 @@ public class LocationOptions {
     return new LocationOptions(
         locationAccuracy,
         distanceFilter != null ? distanceFilter : 0,
-        timeInterval != null ? timeInterval : 0);
+        timeInterval != null ? timeInterval : 500);
   }
 
   private LocationOptions(LocationAccuracy accuracy, long distanceFilter, long timeInterval) {

--- a/geolocator_android/lib/src/types/android_settings.dart
+++ b/geolocator_android/lib/src/types/android_settings.dart
@@ -31,7 +31,7 @@ class AndroidSettings extends LocationSettings {
 
   /// The desired interval for active location updates.
   ///
-  /// If this value is `null` no interval duration is applied.
+  /// If this value is `null` an interval duration of 500ms is applied.
   final Duration? intervalDuration;
 
   @override
@@ -39,7 +39,7 @@ class AndroidSettings extends LocationSettings {
     return super.toJson()
       ..addAll({
         'forceLocationManager': forceLocationManager,
-        'timeInterval': intervalDuration?.inMilliseconds ?? 0,
+        'timeInterval': intervalDuration?.inMilliseconds,
       });
   }
 }

--- a/geolocator_android/lib/src/types/android_settings.dart
+++ b/geolocator_android/lib/src/types/android_settings.dart
@@ -31,7 +31,7 @@ class AndroidSettings extends LocationSettings {
 
   /// The desired interval for active location updates.
   ///
-  /// If this value is `null` an interval duration of 500ms is applied.
+  /// If this value is `null` an interval duration of 5000ms is applied.
   final Duration? intervalDuration;
 
   @override

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 3.0.1
+version: 3.0.2
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 3.0.2
+version: 3.0.3
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Change

### :arrow_heading_down: What is the current behavior?
Currently the `intervalDuration` property is 0 on default which probably causes the `getCurrentPosition` method to return a cached Location instead of a fresh Location.

### :new: What is the new behavior (if this is a feature change)?
The `intervalDuration` property is set to 500 on default.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Does not apply

### :memo: Links to relevant issues/docs
Does not apply

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
