### PR TITLE
Adds the `LocationPermission.unableToDetermine` value.

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+- Adds the `LocationPermission.unknown` status used on the web platform when the permission API is not implemented by the browser.
+
 ## 4.0.0
 
 - **breaking** Updates the plugin platform interface to use a non`-const` token. This is marked as a breaking change because it can cause an assertion failure if implementations use `implements` rather than `extends`, but hopefully there aren't any of those;

--- a/geolocator_platform_interface/lib/src/enums/location_permission.dart
+++ b/geolocator_platform_interface/lib/src/enums/location_permission.dart
@@ -1,8 +1,7 @@
 /// Represent the possible location permissions.
 enum LocationPermission {
-  /// This is the initial state on both Android and iOS, but on Android the
-  /// user can still choose to deny permissions, meaning the App can still
-  /// request for permission another time.
+  /// Permission to access the device's location is denied, the App should try
+  /// to request permission using the `Geolocator.requestPermission()` method.
   denied,
 
   /// Permission to access the device's location is permenantly denied. When
@@ -16,5 +15,10 @@ enum LocationPermission {
 
   /// Permission to access the device's location is allowed even when the
   /// App is running in the background.
-  always
+  always,
+
+  /// Permission status is cannot be determined. This permission is only
+  /// returned by the `Geolocator.checkPermission()` method on the web platform
+  /// for browsers that do not implement the Permission API (see https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API).
+  unableToDetermine
 }

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -39,6 +39,10 @@ abstract class GeolocatorPlatform extends PlatformInterface {
 
   /// Returns a [Future] indicating if the user allows the App to access
   /// the device's location.
+  ///
+  /// Note: on the web platform not all browsers implement the [Permission API](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API)
+  /// if this is the case the `LocationPermission.unableToDetermine` is returned
+  /// as the plugin cannot determine the if permissions are granted or denied.
   Future<LocationPermission> checkPermission() {
     throw UnimplementedError(
       'checkPermission() has not been implemented.',

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.0.0
+version: 4.0.1
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/test/src/enums/location_permission_test.dart
+++ b/geolocator_platform_interface/test/src/enums/location_permission_test.dart
@@ -5,7 +5,7 @@ void main() {
   test('LocationPermission should contain 4 options', () {
     const values = LocationPermission.values;
 
-    expect(values.length, 4);
+    expect(values.length, 5);
   });
 
   test('LocationPermission enum should have items in correct index', () {
@@ -15,5 +15,6 @@ void main() {
     expect(values[1], LocationPermission.deniedForever);
     expect(values[2], LocationPermission.whileInUse);
     expect(values[3], LocationPermission.always);
+    expect(values[4], LocationPermission.unableToDetermine);
   });
 }

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -48,13 +48,6 @@ class GeolocatorPlugin extends GeolocatorPlatform {
 
   @override
   Future<LocationPermission> checkPermission() async {
-    if (!_permissions.permissionsSupported) {
-      throw PlatformException(
-        code: 'LOCATION_SERVICES_NOT_SUPPORTED',
-        message: 'Location services are not supported on this browser.',
-      );
-    }
-
     return await _permissions.query(
       _permissionQuery,
     );


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

Currently Safari does not support the permission API which causes the Geolocator to crash when calling the `Geolocator.checkPermission()` method. 

### :new: What is the new behavior (if this is a feature change)?

Adds a new `LocationPermission.unableToDetermine` status which can be returned in those cases where the permission API is not supported. 

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- #774 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
