### PR TITLE
Fix Code Coverage

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,6 +1,9 @@
+## 8.0.5
+- Fix code coverage issues by adding iOS specific test for getCurrentPosition
+
 ## 8.0.4
 - Export `ActivityType` at `geolocator.dart`
-- 
+
 ## 8.0.3
 
 - Upgraded the geolocator_platform_interface, geolocator_web, geolocator_apple and geolocator_android packages to the latest versions.

--- a/geolocator/lib/geolocator.dart
+++ b/geolocator/lib/geolocator.dart
@@ -5,11 +5,11 @@ import 'package:geolocator_android/geolocator_android.dart';
 import 'package:geolocator_apple/geolocator_apple.dart';
 import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 
-export 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 export 'package:geolocator_android/geolocator_android.dart'
     show AndroidSettings;
 export 'package:geolocator_apple/geolocator_apple.dart'
     show AppleSettings, ActivityType;
+export 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 
 /// Wraps CLLocationManager (on iOS) and FusedLocationProviderClient or
 /// LocationManager
@@ -87,9 +87,8 @@ class Geolocator {
       );
     }
 
-    return GeolocatorPlatform.instance.getCurrentPosition(
-      locationSettings: locationSettings,
-    );
+    return GeolocatorPlatform.instance
+        .getCurrentPosition(locationSettings: locationSettings);
   }
 
   /// Fires whenever the location changes inside the bounds of the

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 8.0.4
+version: 8.0.5
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 

--- a/geolocator/test/geolocator_test.dart
+++ b/geolocator/test/geolocator_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:mockito/mockito.dart';
@@ -51,6 +52,13 @@ void main() {
       final position = await Geolocator.getCurrentPosition();
 
       expect(position, mockPosition);
+    });
+
+    test('getCurrentPosition iOS', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      final position = await Geolocator.getCurrentPosition();
+      expect(position, mockPosition);
+      debugDefaultTargetPlatformOverride = null;
     });
 
     test('getLocationAccuracy', () async {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix: Branching from current master will have code coverage issues

### :arrow_heading_down: What is the current behavior?
Pull Requests are failing the coverage check 

### :new: What is the new behavior (if this is a feature change)?
I added an iOS specific test for getCurrentPosition to cover the other half of the else statement and reformatted the return statement

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Try merging in this branch to your PR and see if it passes the code coverage check

### :memo: Links to relevant issues/docs
#957 is an example of a PR failing the coverage check that will be fixed by this

### :thinking: Checklist before submitting

- [ x ] I made sure all projects build.
- [ x ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ x ] I updated CHANGELOG.md to add a description of the change.
- [ x ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ x ] I updated the relevant documentation.
- [ x ] I rebased onto current `master`.
