### PR TITLE
#915 Android: Unregister receiver in when detaching from activity.

### DIFF
--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -137,7 +137,7 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
       streamHandler.setActivity(null);
     }
     if (locationServiceHandler != null) {
-      streamHandler.setActivity(null);
+      locationServiceHandler.setActivity(null);
     }
 
     deregisterListeners();

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
@@ -42,7 +42,14 @@ public class LocationServiceHandlerImpl implements EventChannel.StreamHandler{
         channel = null;
     }
 
-    void setActivity(@Nullable Activity activity) { this.activity = activity;}
+    void setActivity(@Nullable Activity activity) {
+        if (this.activity == activity) return;
+
+        if (this.activity != null) {
+            this.activity.unregisterReceiver(this.receiver);
+        }
+        this.activity = activity;
+    }
 
     @Override
     public void onListen(Object arguments, EventChannel.EventSink events) {
@@ -59,6 +66,7 @@ public class LocationServiceHandlerImpl implements EventChannel.StreamHandler{
 
     @Override
     public void onCancel(Object arguments) {
+        if(activity == null) return;
         activity.unregisterReceiver(this.receiver);
     }
 


### PR DESCRIPTION

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
fixes bug with activity not being removed from locationServiceHandler

### :arrow_heading_down: What is the current behavior?
MainActivity leaks IntentReceiver 

### :new: What is the new behavior (if this is a feature change)?
unregister Receiver if activity change 

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Keep background task running without 

### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter-geolocator/issues/915

### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [ ] I rebased onto current `master`.
