### PR TITLE
Adds Android foreground location support

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.4
+
+- Fixes Android embedding v2 warning when compiling the example App.
+
 ## 3.0.3
 
 - Added a default `intervalDuration` value of 5000ms to prevent the `getCurrentPosition` method to return a cached Location.

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.0
+
+- Added a new option to Android settings that will allow us to configure the foreground service notification settings
+- Added wake lock and WiFI lock capabilities to the Android service
+- Added an Android service to retrieve location updates. This allows us to make the service a foreground service which will stay alive and continue processing location updates if if the application is moved into the background.
+
 ## 3.0.4
 
 - Fixes Android embedding v2 warning when compiling the example App.
@@ -61,4 +67,3 @@
 ## 1.0.0
 
 - Initial open source release.
-

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## 3.1.0
 
-- Added a new option to Android settings that will allow us to configure the foreground service notification settings
-- Added wake lock and WiFI lock capabilities to the Android service
-- Added an Android service to retrieve location updates. This allows us to make the service a foreground service which will stay alive and continue processing location updates if if the application is moved into the background.
+- Adds support to make a foreground service and continue processing location updates when the application is moved into the background.
 
 ## 3.0.4
 

--- a/geolocator_android/android/build.gradle
+++ b/geolocator_android/android/build.gradle
@@ -43,4 +43,5 @@ android {
 
 dependencies {
     implementation 'com.google.android.gms:play-services-location:17.0.0'
+    implementation 'androidx.core:core:1.2.0'
 }

--- a/geolocator_android/android/src/main/AndroidManifest.xml
+++ b/geolocator_android/android/src/main/AndroidManifest.xml
@@ -1,3 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.baseflow.geolocator">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+
+    <application>
+        <service
+                android:enabled="true"
+                android:exported="false"
+                android:foregroundServiceType="location"
+                android:name=".GeolocatorLocationService"/>
+    </application>
 </manifest>

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -1,0 +1,185 @@
+package com.baseflow.geolocator;
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.app.Notification;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.location.Location;
+import android.net.wifi.WifiManager;
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.PowerManager;
+import android.util.Log;
+import androidx.annotation.Nullable;
+
+import com.baseflow.geolocator.errors.ErrorCodes;
+import com.baseflow.geolocator.location.BackgroundNotification;
+import com.baseflow.geolocator.location.ForegroundNotificationOptions;
+import com.baseflow.geolocator.location.GeolocationManager;
+import com.baseflow.geolocator.location.LocationClient;
+import com.baseflow.geolocator.location.LocationMapper;
+import com.baseflow.geolocator.location.LocationOptions;
+
+import io.flutter.plugin.common.EventChannel;
+
+public class GeolocatorLocationService extends Service {
+    private static final String TAG = "FlutterGeolocator";
+    private static final int ONGOING_NOTIFICATION_ID = 75415;
+    private static final String CHANNEL_ID = "geolocator_channel_01";
+    private final String WAKELOCK_TAG = "GeolocatorLocationService:Wakelock";
+    private final String WIFILOCK_TAG = "GeolocatorLocationService:WifiLock";
+
+    // Service is foreground
+    private boolean isForeground = false;
+
+    @Nullable private final LocalBinder binder = new LocalBinder(this);
+    @Nullable private Activity activity = null;
+    @Nullable private GeolocationManager geolocationManager = null;
+    @Nullable private LocationClient locationClient;
+
+    @Nullable private PowerManager.WakeLock wakeLock = null;
+    @Nullable private WifiManager.WifiLock wifiLock = null;
+
+    @Nullable private BackgroundNotification backgroundNotification = null;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        Log.d(TAG, "Creating service.");
+        geolocationManager = new GeolocationManager();
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+
+        Log.d(TAG, "Binding to location service.");
+        return binder;
+    }
+
+    @Override
+    public boolean onUnbind(Intent intent) {
+        Log.d(TAG, "Binding to location service.");
+        return super.onUnbind(intent);
+    }
+
+    @Override
+    public void onDestroy() {
+        Log.d(TAG, "Destroying location service.");
+
+        disableBackgroundMode();
+        geolocationManager = null;
+        backgroundNotification = null;
+
+        super.onDestroy();
+    }
+
+    public void startLocationService(boolean forceLocationManager, LocationOptions locationOptions, EventChannel.EventSink events) {
+
+        if (geolocationManager != null) {
+            this.locationClient =
+                    geolocationManager.createLocationClient(
+                            this.getApplicationContext(), Boolean.TRUE.equals(forceLocationManager), locationOptions);
+
+            geolocationManager.startPositionUpdates(
+                    this.locationClient,
+                    activity,
+                    (Location location) -> events.success(LocationMapper.toHashMap(location)),
+                    (ErrorCodes errorCodes) ->
+                            events.error(errorCodes.toString(), errorCodes.toDescription(), null));
+        }
+    }
+
+    public void stopLocationService() {
+        if (this.locationClient != null && geolocationManager != null) {
+            geolocationManager.stopPositionUpdates(this.locationClient);
+        }
+    }
+
+    public void enableBackgroundMode(ForegroundNotificationOptions options) {
+        if (backgroundNotification != null) {
+            Log.d(TAG, "Service already in foreground mode.");
+            changeNotificationOptions(options);
+        } else {
+            Log.d(TAG, "Start service in foreground mode.");
+
+            backgroundNotification = new BackgroundNotification(
+                    this.getApplicationContext(),
+                    CHANNEL_ID,
+                    ONGOING_NOTIFICATION_ID,
+                    options
+            );
+            backgroundNotification.updateChannel("Background Location");
+            Notification notification = backgroundNotification.build();
+            startForeground(ONGOING_NOTIFICATION_ID, notification);
+            isForeground = true;
+        }
+        obtainWakeLocks(options);
+    }
+
+    public void disableBackgroundMode() {
+        Log.d(TAG, "Stop service in foreground.");
+        stopForeground(true);
+        releaseWakeLocks();
+        isForeground = false;
+        backgroundNotification = null;
+    }
+
+    public void changeNotificationOptions(ForegroundNotificationOptions options){
+        if(backgroundNotification != null) {
+            backgroundNotification.updateOptions(options, isForeground);
+            obtainWakeLocks(options);
+        }
+    }
+
+    public void setActivity(@Nullable Activity activity) {
+        this.activity = activity;
+    }
+
+    private void releaseWakeLocks() {
+        if(wakeLock != null && wakeLock.isHeld()) {
+            wakeLock.release();
+            wakeLock = null;
+        }
+        if(wifiLock != null && wifiLock.isHeld()) {
+            wifiLock.release();
+            wifiLock = null;
+        }
+    }
+
+    @SuppressLint("WakelockTimeout")
+    private void obtainWakeLocks(ForegroundNotificationOptions options) {
+        releaseWakeLocks();
+        if(options.isEnableWakeLock()){
+            PowerManager powerManager = (PowerManager) getApplicationContext().getSystemService(Context.POWER_SERVICE);
+            if (powerManager != null) {
+                wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKELOCK_TAG);
+                wakeLock.setReferenceCounted(false);
+                wakeLock.acquire();
+            }
+        }
+        if(options.isEnableWifiLock()) {
+            WifiManager wifiManager = (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+            if (wifiManager != null) {
+                wifiLock = wifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, WIFILOCK_TAG);
+                wifiLock.setReferenceCounted(false);
+                wifiLock.acquire();
+            }
+        }
+    }
+
+    class LocalBinder extends Binder {
+        private final GeolocatorLocationService locationService;
+
+        LocalBinder(GeolocatorLocationService locationService) {
+            this.locationService = locationService;
+        }
+
+        public GeolocatorLocationService getLocationService() {
+            return locationService;
+        }
+    }
+}
+
+

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -78,12 +78,12 @@ public class GeolocatorLocationService extends Service {
     public void startLocationService(boolean forceLocationManager, LocationOptions locationOptions, EventChannel.EventSink events) {
 
         if (geolocationManager != null) {
-            this.locationClient =
+            locationClient =
                     geolocationManager.createLocationClient(
                             this.getApplicationContext(), Boolean.TRUE.equals(forceLocationManager), locationOptions);
 
             geolocationManager.startPositionUpdates(
-                    this.locationClient,
+                    locationClient,
                     activity,
                     (Location location) -> events.success(LocationMapper.toHashMap(location)),
                     (ErrorCodes errorCodes) ->
@@ -92,8 +92,8 @@ public class GeolocatorLocationService extends Service {
     }
 
     public void stopLocationService() {
-        if (this.locationClient != null && geolocationManager != null) {
-            geolocationManager.stopPositionUpdates(this.locationClient);
+        if (locationClient != null && geolocationManager != null) {
+            geolocationManager.stopPositionUpdates(locationClient);
         }
     }
 
@@ -181,5 +181,3 @@ public class GeolocatorLocationService extends Service {
         }
     }
 }
-
-

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -1,4 +1,5 @@
 package com.baseflow.geolocator;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Notification;
@@ -24,160 +25,164 @@ import com.baseflow.geolocator.location.LocationOptions;
 import io.flutter.plugin.common.EventChannel;
 
 public class GeolocatorLocationService extends Service {
-    private static final String TAG = "FlutterGeolocator";
-    private static final int ONGOING_NOTIFICATION_ID = 75415;
-    private static final String CHANNEL_ID = "geolocator_channel_01";
-    private final String WAKELOCK_TAG = "GeolocatorLocationService:Wakelock";
-    private final String WIFILOCK_TAG = "GeolocatorLocationService:WifiLock";
+  private static final String TAG = "FlutterGeolocator";
+  private static final int ONGOING_NOTIFICATION_ID = 75415;
+  private static final String CHANNEL_ID = "geolocator_channel_01";
+  private final String WAKELOCK_TAG = "GeolocatorLocationService:Wakelock";
+  private final String WIFILOCK_TAG = "GeolocatorLocationService:WifiLock";
 
-    // Service is foreground
-    private boolean isForeground = false;
+  // Service is foreground
+  private boolean isForeground = false;
 
-    @Nullable private final LocalBinder binder = new LocalBinder(this);
-    @Nullable private Activity activity = null;
-    @Nullable private GeolocationManager geolocationManager = null;
-    @Nullable private LocationClient locationClient;
+  @Nullable private final LocalBinder binder = new LocalBinder(this);
+  @Nullable private Activity activity = null;
+  @Nullable private GeolocationManager geolocationManager = null;
+  @Nullable private LocationClient locationClient;
 
-    @Nullable private PowerManager.WakeLock wakeLock = null;
-    @Nullable private WifiManager.WifiLock wifiLock = null;
+  @Nullable private PowerManager.WakeLock wakeLock = null;
+  @Nullable private WifiManager.WifiLock wifiLock = null;
 
-    @Nullable private BackgroundNotification backgroundNotification = null;
+  @Nullable private BackgroundNotification backgroundNotification = null;
 
-    @Override
-    public void onCreate() {
-        super.onCreate();
-        Log.d(TAG, "Creating service.");
-        geolocationManager = new GeolocationManager();
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    Log.d(TAG, "Creating service.");
+    geolocationManager = new GeolocationManager();
+  }
+
+  @Nullable
+  @Override
+  public IBinder onBind(Intent intent) {
+
+    Log.d(TAG, "Binding to location service.");
+    return binder;
+  }
+
+  @Override
+  public boolean onUnbind(Intent intent) {
+    Log.d(TAG, "Binding to location service.");
+    return super.onUnbind(intent);
+  }
+
+  @Override
+  public void onDestroy() {
+    Log.d(TAG, "Destroying location service.");
+
+    disableBackgroundMode();
+    geolocationManager = null;
+    backgroundNotification = null;
+
+    super.onDestroy();
+  }
+
+  public void startLocationService(
+      boolean forceLocationManager,
+      LocationOptions locationOptions,
+      EventChannel.EventSink events) {
+
+    if (geolocationManager != null) {
+      locationClient =
+          geolocationManager.createLocationClient(
+              this.getApplicationContext(),
+              Boolean.TRUE.equals(forceLocationManager),
+              locationOptions);
+
+      geolocationManager.startPositionUpdates(
+          locationClient,
+          activity,
+          (Location location) -> events.success(LocationMapper.toHashMap(location)),
+          (ErrorCodes errorCodes) ->
+              events.error(errorCodes.toString(), errorCodes.toDescription(), null));
+    }
+  }
+
+  public void stopLocationService() {
+    if (locationClient != null && geolocationManager != null) {
+      geolocationManager.stopPositionUpdates(locationClient);
+    }
+  }
+
+  public void enableBackgroundMode(ForegroundNotificationOptions options) {
+    if (backgroundNotification != null) {
+      Log.d(TAG, "Service already in foreground mode.");
+      changeNotificationOptions(options);
+    } else {
+      Log.d(TAG, "Start service in foreground mode.");
+
+      backgroundNotification =
+          new BackgroundNotification(
+              this.getApplicationContext(), CHANNEL_ID, ONGOING_NOTIFICATION_ID, options);
+      backgroundNotification.updateChannel("Background Location");
+      Notification notification = backgroundNotification.build();
+      startForeground(ONGOING_NOTIFICATION_ID, notification);
+      isForeground = true;
+    }
+    obtainWakeLocks(options);
+  }
+
+  public void disableBackgroundMode() {
+    Log.d(TAG, "Stop service in foreground.");
+    stopForeground(true);
+    releaseWakeLocks();
+    isForeground = false;
+    backgroundNotification = null;
+  }
+
+  public void changeNotificationOptions(ForegroundNotificationOptions options) {
+    if (backgroundNotification != null) {
+      backgroundNotification.updateOptions(options, isForeground);
+      obtainWakeLocks(options);
+    }
+  }
+
+  public void setActivity(@Nullable Activity activity) {
+    this.activity = activity;
+  }
+
+  private void releaseWakeLocks() {
+    if (wakeLock != null && wakeLock.isHeld()) {
+      wakeLock.release();
+      wakeLock = null;
+    }
+    if (wifiLock != null && wifiLock.isHeld()) {
+      wifiLock.release();
+      wifiLock = null;
+    }
+  }
+
+  @SuppressLint("WakelockTimeout")
+  private void obtainWakeLocks(ForegroundNotificationOptions options) {
+    releaseWakeLocks();
+    if (options.isEnableWakeLock()) {
+      PowerManager powerManager =
+          (PowerManager) getApplicationContext().getSystemService(Context.POWER_SERVICE);
+      if (powerManager != null) {
+        wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKELOCK_TAG);
+        wakeLock.setReferenceCounted(false);
+        wakeLock.acquire();
+      }
+    }
+    if (options.isEnableWifiLock()) {
+      WifiManager wifiManager =
+          (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+      if (wifiManager != null) {
+        wifiLock = wifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, WIFILOCK_TAG);
+        wifiLock.setReferenceCounted(false);
+        wifiLock.acquire();
+      }
+    }
+  }
+
+  class LocalBinder extends Binder {
+    private final GeolocatorLocationService locationService;
+
+    LocalBinder(GeolocatorLocationService locationService) {
+      this.locationService = locationService;
     }
 
-    @Nullable
-    @Override
-    public IBinder onBind(Intent intent) {
-
-        Log.d(TAG, "Binding to location service.");
-        return binder;
+    public GeolocatorLocationService getLocationService() {
+      return locationService;
     }
-
-    @Override
-    public boolean onUnbind(Intent intent) {
-        Log.d(TAG, "Binding to location service.");
-        return super.onUnbind(intent);
-    }
-
-    @Override
-    public void onDestroy() {
-        Log.d(TAG, "Destroying location service.");
-
-        disableBackgroundMode();
-        geolocationManager = null;
-        backgroundNotification = null;
-
-        super.onDestroy();
-    }
-
-    public void startLocationService(boolean forceLocationManager, LocationOptions locationOptions, EventChannel.EventSink events) {
-
-        if (geolocationManager != null) {
-            locationClient =
-                    geolocationManager.createLocationClient(
-                            this.getApplicationContext(), Boolean.TRUE.equals(forceLocationManager), locationOptions);
-
-            geolocationManager.startPositionUpdates(
-                    locationClient,
-                    activity,
-                    (Location location) -> events.success(LocationMapper.toHashMap(location)),
-                    (ErrorCodes errorCodes) ->
-                            events.error(errorCodes.toString(), errorCodes.toDescription(), null));
-        }
-    }
-
-    public void stopLocationService() {
-        if (locationClient != null && geolocationManager != null) {
-            geolocationManager.stopPositionUpdates(locationClient);
-        }
-    }
-
-    public void enableBackgroundMode(ForegroundNotificationOptions options) {
-        if (backgroundNotification != null) {
-            Log.d(TAG, "Service already in foreground mode.");
-            changeNotificationOptions(options);
-        } else {
-            Log.d(TAG, "Start service in foreground mode.");
-
-            backgroundNotification = new BackgroundNotification(
-                    this.getApplicationContext(),
-                    CHANNEL_ID,
-                    ONGOING_NOTIFICATION_ID,
-                    options
-            );
-            backgroundNotification.updateChannel("Background Location");
-            Notification notification = backgroundNotification.build();
-            startForeground(ONGOING_NOTIFICATION_ID, notification);
-            isForeground = true;
-        }
-        obtainWakeLocks(options);
-    }
-
-    public void disableBackgroundMode() {
-        Log.d(TAG, "Stop service in foreground.");
-        stopForeground(true);
-        releaseWakeLocks();
-        isForeground = false;
-        backgroundNotification = null;
-    }
-
-    public void changeNotificationOptions(ForegroundNotificationOptions options){
-        if(backgroundNotification != null) {
-            backgroundNotification.updateOptions(options, isForeground);
-            obtainWakeLocks(options);
-        }
-    }
-
-    public void setActivity(@Nullable Activity activity) {
-        this.activity = activity;
-    }
-
-    private void releaseWakeLocks() {
-        if(wakeLock != null && wakeLock.isHeld()) {
-            wakeLock.release();
-            wakeLock = null;
-        }
-        if(wifiLock != null && wifiLock.isHeld()) {
-            wifiLock.release();
-            wifiLock = null;
-        }
-    }
-
-    @SuppressLint("WakelockTimeout")
-    private void obtainWakeLocks(ForegroundNotificationOptions options) {
-        releaseWakeLocks();
-        if(options.isEnableWakeLock()){
-            PowerManager powerManager = (PowerManager) getApplicationContext().getSystemService(Context.POWER_SERVICE);
-            if (powerManager != null) {
-                wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKELOCK_TAG);
-                wakeLock.setReferenceCounted(false);
-                wakeLock.acquire();
-            }
-        }
-        if(options.isEnableWifiLock()) {
-            WifiManager wifiManager = (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-            if (wifiManager != null) {
-                wifiLock = wifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, WIFILOCK_TAG);
-                wifiLock.setReferenceCounted(false);
-                wifiLock.acquire();
-            }
-        }
-    }
-
-    class LocalBinder extends Binder {
-        private final GeolocatorLocationService locationService;
-
-        LocalBinder(GeolocatorLocationService locationService) {
-            this.locationService = locationService;
-        }
-
-        public GeolocatorLocationService getLocationService() {
-            return locationService;
-        }
-    }
+  }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -25,7 +25,7 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
   private final GeolocationManager geolocationManager;
   private final LocationAccuracyManager locationAccuracyManager;
 
-  @Nullable private GeolocatorLocationService backgroundLocationService;
+  @Nullable private GeolocatorLocationService foregroundLocationService;
 
   @Nullable private MethodCallHandlerImpl methodCallHandler;
 
@@ -180,16 +180,16 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
 
   private void initialize(GeolocatorLocationService service) {
     Log.d(TAG, "Initializing Geolocator foreground service");
-    backgroundLocationService = service;
+    foregroundLocationService = service;
 
     if (pluginBinding != null) {
-      backgroundLocationService.setActivity(pluginBinding.getActivity());
+      foregroundLocationService.setActivity(pluginBinding.getActivity());
     }
     if (methodCallHandler != null) {
-      methodCallHandler.setBackgroundLocationService(service);
+      methodCallHandler.setForegroundLocationService(service);
     }
     if (streamHandler != null) {
-      streamHandler.setBackgroundLocationService(service);
+      streamHandler.setForegroundLocationService(service);
     }
   }
 
@@ -198,11 +198,11 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
       methodCallHandler.setActivity(null);
     }
     if (streamHandler != null) {
-      streamHandler.setBackgroundLocationService(null);
+      streamHandler.setForegroundLocationService(null);
     }
-    if (backgroundLocationService != null) {
-      backgroundLocationService.setActivity(null);
-      backgroundLocationService = null;
+    if (foregroundLocationService != null) {
+      foregroundLocationService.setActivity(null);
+      foregroundLocationService = null;
     }
   }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -121,7 +121,12 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
     }
 
     this.pluginBinding = binding;
-    pluginBinding.getActivity().bindService(new Intent(binding.getActivity(), GeolocatorLocationService.class), serviceConnection, Context.BIND_AUTO_CREATE);
+    pluginBinding
+        .getActivity()
+        .bindService(
+            new Intent(binding.getActivity(), GeolocatorLocationService.class),
+            serviceConnection,
+            Context.BIND_AUTO_CREATE);
     registerListeners();
   }
 
@@ -137,8 +142,8 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
 
   @Override
   public void onDetachedFromActivity() {
-      dispose();
-      deregisterListeners();
+    dispose();
+    deregisterListeners();
   }
 
   private void registerListeners() {
@@ -158,45 +163,46 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
     }
   }
 
-    private final ServiceConnection serviceConnection = new ServiceConnection() {
+  private final ServiceConnection serviceConnection =
+      new ServiceConnection() {
 
         @Override
         public void onServiceConnected(ComponentName name, IBinder service) {
-            Log.d(TAG, "Service connected: " + name);
-            initialize(((GeolocatorLocationService.LocalBinder) service).getLocationService());
+          Log.d(TAG, "Service connected: " + name);
+          initialize(((GeolocatorLocationService.LocalBinder) service).getLocationService());
         }
 
         @Override
         public void onServiceDisconnected(ComponentName name) {
-            Log.d(TAG, "Service disconnected:" + name);
+          Log.d(TAG, "Service disconnected:" + name);
         }
-    };
+      };
 
-    private void initialize(GeolocatorLocationService service) {
-        Log.d(TAG, "Initializing Geolocator foreground service");
-        backgroundLocationService = service;
+  private void initialize(GeolocatorLocationService service) {
+    Log.d(TAG, "Initializing Geolocator foreground service");
+    backgroundLocationService = service;
 
-        if (pluginBinding != null) {
-            backgroundLocationService.setActivity(pluginBinding.getActivity());
-        }
-        if(methodCallHandler != null){
-            methodCallHandler.setBackgroundLocationService(service);
-        }
-        if(streamHandler != null){
-            streamHandler.setBackgroundLocationService(service);
-        }
+    if (pluginBinding != null) {
+      backgroundLocationService.setActivity(pluginBinding.getActivity());
     }
-
-    private void dispose() {
-        if (methodCallHandler != null) {
-            methodCallHandler.setActivity(null);
-        }
-        if(streamHandler != null){
-            streamHandler.setBackgroundLocationService(null);
-        }
-        if(backgroundLocationService != null){
-            backgroundLocationService.setActivity(null);
-            backgroundLocationService = null;
-        }
+    if (methodCallHandler != null) {
+      methodCallHandler.setBackgroundLocationService(service);
     }
+    if (streamHandler != null) {
+      streamHandler.setBackgroundLocationService(service);
+    }
+  }
+
+  private void dispose() {
+    if (methodCallHandler != null) {
+      methodCallHandler.setActivity(null);
+    }
+    if (streamHandler != null) {
+      streamHandler.setBackgroundLocationService(null);
+    }
+    if (backgroundLocationService != null) {
+      backgroundLocationService.setActivity(null);
+      backgroundLocationService = null;
+    }
+  }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -1,10 +1,18 @@
 package com.baseflow.geolocator;
 
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.baseflow.geolocator.location.GeolocationManager;
 import com.baseflow.geolocator.location.LocationAccuracyManager;
 import com.baseflow.geolocator.permission.PermissionManager;
+
+import io.flutter.Log;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
@@ -16,6 +24,8 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
   private final PermissionManager permissionManager;
   private final GeolocationManager geolocationManager;
   private final LocationAccuracyManager locationAccuracyManager;
+
+  @Nullable private GeolocatorLocationService backgroundLocationService;
 
   @Nullable private MethodCallHandlerImpl methodCallHandler;
 
@@ -58,9 +68,8 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
     methodCallHandler.startListening(registrar.context(), registrar.messenger());
     methodCallHandler.setActivity(registrar.activity());
 
-    StreamHandlerImpl streamHandler = new StreamHandlerImpl(geolocatorPlugin.geolocationManager, geolocatorPlugin.permissionManager);
+    StreamHandlerImpl streamHandler = new StreamHandlerImpl(geolocatorPlugin.permissionManager);
     streamHandler.startListening(registrar.context(), registrar.messenger());
-    streamHandler.setActivity(registrar.activity());
 
     LocationServiceHandlerImpl locationServiceHandler = new LocationServiceHandlerImpl();
     locationServiceHandler.startListening(registrar.context(), registrar.messenger());
@@ -74,7 +83,7 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
             this.permissionManager, this.geolocationManager, this.locationAccuracyManager);
     methodCallHandler.startListening(
         flutterPluginBinding.getApplicationContext(), flutterPluginBinding.getBinaryMessenger());
-    streamHandler = new StreamHandlerImpl(this.geolocationManager, this.permissionManager);
+    streamHandler = new StreamHandlerImpl(this.permissionManager);
     streamHandler.startListening(
         flutterPluginBinding.getApplicationContext(), flutterPluginBinding.getBinaryMessenger());
 
@@ -106,15 +115,13 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
     if (methodCallHandler != null) {
       methodCallHandler.setActivity(binding.getActivity());
     }
-    if (streamHandler != null) {
-      streamHandler.setActivity(binding.getActivity());
-    }
 
     if (locationServiceHandler != null) {
       locationServiceHandler.setActivity(binding.getActivity());
     }
 
     this.pluginBinding = binding;
+    pluginBinding.getActivity().bindService(new Intent(binding.getActivity(), GeolocatorLocationService.class), serviceConnection, Context.BIND_AUTO_CREATE);
     registerListeners();
   }
 
@@ -130,17 +137,8 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
 
   @Override
   public void onDetachedFromActivity() {
-    if (methodCallHandler != null) {
-      methodCallHandler.setActivity(null);
-    }
-    if (streamHandler != null) {
-      streamHandler.setActivity(null);
-    }
-    if (locationServiceHandler != null) {
-      streamHandler.setActivity(null);
-    }
-
-    deregisterListeners();
+      dispose();
+      deregisterListeners();
   }
 
   private void registerListeners() {
@@ -159,4 +157,46 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
       this.pluginBinding.removeRequestPermissionsResultListener(this.permissionManager);
     }
   }
+
+    private final ServiceConnection serviceConnection = new ServiceConnection() {
+
+        @Override
+        public void onServiceConnected(ComponentName name, IBinder service) {
+            Log.d(TAG, "Service connected: " + name);
+            initialize(((GeolocatorLocationService.LocalBinder) service).getLocationService());
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName name) {
+            Log.d(TAG, "Service disconnected:" + name);
+        }
+    };
+
+    private void initialize(GeolocatorLocationService service) {
+        Log.d(TAG, "Initializing Geolocator foreground service");
+        backgroundLocationService = service;
+
+        if (pluginBinding != null) {
+            backgroundLocationService.setActivity(pluginBinding.getActivity());
+        }
+        if(methodCallHandler != null){
+            methodCallHandler.setBackgroundLocationService(service);
+        }
+        if(streamHandler != null){
+            streamHandler.setBackgroundLocationService(service);
+        }
+    }
+
+    private void dispose() {
+        if (methodCallHandler != null) {
+            methodCallHandler.setActivity(null);
+        }
+        if(streamHandler != null){
+            streamHandler.setBackgroundLocationService(null);
+        }
+        if(backgroundLocationService != null){
+            backgroundLocationService.setActivity(null);
+            backgroundLocationService = null;
+        }
+    }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -40,9 +40,9 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
   @Nullable private ActivityPluginBinding pluginBinding;
 
   public GeolocatorPlugin() {
-    this.permissionManager = new PermissionManager();
-    this.geolocationManager = new GeolocationManager();
-    this.locationAccuracyManager = new LocationAccuracyManager();
+    permissionManager = new PermissionManager();
+    geolocationManager = new GeolocationManager();
+    locationAccuracyManager = new LocationAccuracyManager();
   }
 
   // This static function is optional and equivalent to onAttachedToEngine. It supports the old
@@ -142,19 +142,19 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
   }
 
   private void registerListeners() {
-    if (this.pluginRegistrar != null) {
-      this.pluginRegistrar.addActivityResultListener(this.geolocationManager);
-      this.pluginRegistrar.addRequestPermissionsResultListener(this.permissionManager);
+    if (pluginRegistrar != null) {
+      pluginRegistrar.addActivityResultListener(this.geolocationManager);
+      pluginRegistrar.addRequestPermissionsResultListener(this.permissionManager);
     } else if (pluginBinding != null) {
-      this.pluginBinding.addActivityResultListener(this.geolocationManager);
-      this.pluginBinding.addRequestPermissionsResultListener(this.permissionManager);
+      pluginBinding.addActivityResultListener(this.geolocationManager);
+      pluginBinding.addRequestPermissionsResultListener(this.permissionManager);
     }
   }
 
   private void deregisterListeners() {
-    if (this.pluginBinding != null) {
-      this.pluginBinding.removeActivityResultListener(this.geolocationManager);
-      this.pluginBinding.removeRequestPermissionsResultListener(this.permissionManager);
+    if (pluginBinding != null) {
+      pluginBinding.removeActivityResultListener(this.geolocationManager);
+      pluginBinding.removeRequestPermissionsResultListener(this.permissionManager);
     }
   }
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
@@ -52,14 +52,14 @@ public class LocationServiceHandlerImpl implements EventChannel.StreamHandler{
 
         IntentFilter filter = new IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION);
         filter.addAction(Intent.ACTION_PROVIDER_CHANGED);
-        this.receiver = new LocationServiceStatusReceiver(events);
+        receiver = new LocationServiceStatusReceiver(events);
         if(activity == null) return;
-        activity.registerReceiver(this.receiver, filter);
+        activity.registerReceiver(receiver, filter);
     }
 
     @Override
     public void onCancel(Object arguments) {
-        activity.unregisterReceiver(this.receiver);
+        activity.unregisterReceiver(receiver);
     }
 
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
@@ -14,52 +14,52 @@ import com.baseflow.geolocator.location.LocationServiceStatusReceiver;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
 
-public class LocationServiceHandlerImpl implements EventChannel.StreamHandler{
+public class LocationServiceHandlerImpl implements EventChannel.StreamHandler {
 
-    private static final String TAG = "LocationServiceHandler";
+  private static final String TAG = "LocationServiceHandler";
 
-    @Nullable private EventChannel channel;
-    @Nullable private Activity activity;
-    @Nullable private Context context;
-    @Nullable private LocationServiceStatusReceiver receiver;
+  @Nullable private EventChannel channel;
+  @Nullable private Activity activity;
+  @Nullable private Context context;
+  @Nullable private LocationServiceStatusReceiver receiver;
 
+  void startListening(Context context, BinaryMessenger messenger) {
+    if (channel != null) {
+      Log.w(TAG, "Setting a event call handler before the last was disposed.");
+      stopListening();
+    }
+    channel = new EventChannel(messenger, "flutter.baseflow.com/geolocator_service_updates");
+    channel.setStreamHandler(this);
+    this.context = context;
+  }
 
-    void startListening(Context context, BinaryMessenger messenger){
-        if(channel != null){
-            Log.w(TAG, "Setting a event call handler before the last was disposed.");
-            stopListening();
-        }
-        channel = new EventChannel(messenger, "flutter.baseflow.com/geolocator_service_updates");
-        channel.setStreamHandler(this);
-        this.context = context;
+  void stopListening() {
+    if (channel == null) {
+      return;
+    }
+    channel.setStreamHandler(null);
+    channel = null;
+  }
+
+  void setActivity(@Nullable Activity activity) {
+    this.activity = activity;
+  }
+
+  @Override
+  public void onListen(Object arguments, EventChannel.EventSink events) {
+    if (activity == null) {
+      return;
     }
 
-    void stopListening(){
-        if(channel == null){
-            return;
-        }
-        channel.setStreamHandler(null);
-        channel = null;
-    }
+    IntentFilter filter = new IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION);
+    filter.addAction(Intent.ACTION_PROVIDER_CHANGED);
+    receiver = new LocationServiceStatusReceiver(events);
+    if (activity == null) return;
+    activity.registerReceiver(receiver, filter);
+  }
 
-    void setActivity(@Nullable Activity activity) { this.activity = activity;}
-
-    @Override
-    public void onListen(Object arguments, EventChannel.EventSink events) {
-        if (activity == null) {
-            return;
-        }
-
-        IntentFilter filter = new IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION);
-        filter.addAction(Intent.ACTION_PROVIDER_CHANGED);
-        receiver = new LocationServiceStatusReceiver(events);
-        if(activity == null) return;
-        activity.registerReceiver(receiver, filter);
-    }
-
-    @Override
-    public void onCancel(Object arguments) {
-        activity.unregisterReceiver(receiver);
-    }
-
+  @Override
+  public void onCancel(Object arguments) {
+    activity.unregisterReceiver(receiver);
+  }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
@@ -133,7 +133,7 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     private void onCheckPermission(MethodChannel.Result result) {
     try {
       LocationPermission permission =
-          this.permissionManager.checkPermissionStatus(context);
+          permissionManager.checkPermissionStatus(context);
       result.success(permission.toInt());
     } catch (PermissionUndefinedException e) {
       ErrorCodes errorCode = ErrorCodes.permissionDefinitionsNotFound;
@@ -148,8 +148,8 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
   private void onRequestPermission(MethodChannel.Result result) {
     try {
-      this.permissionManager.requestPermission(
-          this.activity,
+      permissionManager.requestPermission(
+          activity,
           (LocationPermission permission) -> result.success(permission.toInt()),
           (ErrorCodes errorCode) ->
               result.error(errorCode.toString(), errorCode.toDescription(), null));
@@ -161,7 +161,7 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
   private void getLocationAccuracy(MethodChannel.Result result, Context context) {
     final LocationAccuracyStatus status =
-        this.locationAccuracyManager.getLocationAccuracy(
+        locationAccuracyManager.getLocationAccuracy(
             context,
             (ErrorCodes errorCode) ->
                 result.error(errorCode.toString(), errorCode.toDescription(), null));
@@ -172,7 +172,7 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
   private void onGetLastKnownPosition(MethodCall call, MethodChannel.Result result) {
     try{
-        if (!permissionManager.hasPermission(this.context)){
+        if (!permissionManager.hasPermission(context)){
             result.error(ErrorCodes.permissionDenied.toString(),ErrorCodes.permissionDenied.toDescription(),null);
             return;
         }
@@ -183,8 +183,8 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
     Boolean forceLocationManager = call.argument("forceLocationManager");
 
-    this.geolocationManager.getLastKnownPosition(
-        this.context,
+    geolocationManager.getLastKnownPosition(
+        context,
         forceLocationManager != null && forceLocationManager,
         (Location location) -> result.success(LocationMapper.toHashMap(location)),
         (ErrorCodes errorCode) ->
@@ -193,7 +193,7 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
   private void onGetCurrentPosition(MethodCall call, MethodChannel.Result result) {
     try{
-      if (!permissionManager.hasPermission(this.context)){
+      if (!permissionManager.hasPermission(context)){
         result.error(ErrorCodes.permissionDenied.toString(),ErrorCodes.permissionDenied.toDescription(),null);
         return;
       }
@@ -213,11 +213,11 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
     LocationClient locationClient =
         geolocationManager.createLocationClient(
-            this.context, forceLocationManager, locationOptions);
+            context, forceLocationManager, locationOptions);
 
     geolocationManager.startPositionUpdates(
         locationClient,
-        this.activity,
+        activity,
         (Location location) -> {
           if (replySubmitted[0]) {
             return;

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
@@ -126,14 +126,13 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     this.activity = activity;
   }
 
-    void setBackgroundLocationService(@Nullable GeolocatorLocationService backgroundLocationService) {
-        this.backgroundLocationService = backgroundLocationService;
-    }
+  void setBackgroundLocationService(@Nullable GeolocatorLocationService backgroundLocationService) {
+    this.backgroundLocationService = backgroundLocationService;
+  }
 
-    private void onCheckPermission(MethodChannel.Result result) {
+  private void onCheckPermission(MethodChannel.Result result) {
     try {
-      LocationPermission permission =
-          permissionManager.checkPermissionStatus(context);
+      LocationPermission permission = permissionManager.checkPermissionStatus(context);
       result.success(permission.toInt());
     } catch (PermissionUndefinedException e) {
       ErrorCodes errorCode = ErrorCodes.permissionDefinitionsNotFound;
@@ -171,14 +170,20 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
   }
 
   private void onGetLastKnownPosition(MethodCall call, MethodChannel.Result result) {
-    try{
-        if (!permissionManager.hasPermission(context)){
-            result.error(ErrorCodes.permissionDenied.toString(),ErrorCodes.permissionDenied.toDescription(),null);
-            return;
-        }
-    } catch (PermissionUndefinedException e) {
-        result.error(ErrorCodes.permissionDefinitionsNotFound.toString(), ErrorCodes.permissionDefinitionsNotFound.toDescription(), null);
+    try {
+      if (!permissionManager.hasPermission(context)) {
+        result.error(
+            ErrorCodes.permissionDenied.toString(),
+            ErrorCodes.permissionDenied.toDescription(),
+            null);
         return;
+      }
+    } catch (PermissionUndefinedException e) {
+      result.error(
+          ErrorCodes.permissionDefinitionsNotFound.toString(),
+          ErrorCodes.permissionDefinitionsNotFound.toDescription(),
+          null);
+      return;
     }
 
     Boolean forceLocationManager = call.argument("forceLocationManager");
@@ -192,14 +197,20 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
   }
 
   private void onGetCurrentPosition(MethodCall call, MethodChannel.Result result) {
-    try{
-      if (!permissionManager.hasPermission(context)){
-        result.error(ErrorCodes.permissionDenied.toString(),ErrorCodes.permissionDenied.toDescription(),null);
+    try {
+      if (!permissionManager.hasPermission(context)) {
+        result.error(
+            ErrorCodes.permissionDenied.toString(),
+            ErrorCodes.permissionDenied.toDescription(),
+            null);
         return;
       }
     } catch (PermissionUndefinedException e) {
-       result.error(ErrorCodes.permissionDefinitionsNotFound.toString(), ErrorCodes.permissionDefinitionsNotFound.toDescription(), null);
-       return;
+      result.error(
+          ErrorCodes.permissionDefinitionsNotFound.toString(),
+          ErrorCodes.permissionDefinitionsNotFound.toDescription(),
+          null);
+      return;
     }
 
     @SuppressWarnings("unchecked")
@@ -212,8 +223,7 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     final boolean[] replySubmitted = {false};
 
     LocationClient locationClient =
-        geolocationManager.createLocationClient(
-            context, forceLocationManager, locationOptions);
+        geolocationManager.createLocationClient(context, forceLocationManager, locationOptions);
 
     geolocationManager.startPositionUpdates(
         locationClient,

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
@@ -41,7 +41,7 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
   @Nullable private Activity activity;
 
-  @Nullable private GeolocatorLocationService backgroundLocationService;
+  @Nullable private GeolocatorLocationService foregroundLocationService;
 
   MethodCallHandlerImpl(
       PermissionManager permissionManager,
@@ -126,8 +126,8 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     this.activity = activity;
   }
 
-  void setBackgroundLocationService(@Nullable GeolocatorLocationService backgroundLocationService) {
-    this.backgroundLocationService = backgroundLocationService;
+  void setForegroundLocationService(@Nullable GeolocatorLocationService foregroundLocationService) {
+    this.foregroundLocationService = foregroundLocationService;
   }
 
   private void onCheckPermission(MethodChannel.Result result) {

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
@@ -41,6 +41,8 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
   @Nullable private Activity activity;
 
+  @Nullable private GeolocatorLocationService backgroundLocationService;
+
   MethodCallHandlerImpl(
       PermissionManager permissionManager,
       GeolocationManager geolocationManager,
@@ -124,7 +126,11 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     this.activity = activity;
   }
 
-  private void onCheckPermission(MethodChannel.Result result) {
+    void setBackgroundLocationService(@Nullable GeolocatorLocationService backgroundLocationService) {
+        this.backgroundLocationService = backgroundLocationService;
+    }
+
+    private void onCheckPermission(MethodChannel.Result result) {
     try {
       LocationPermission permission =
           this.permissionManager.checkPermissionStatus(context);

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -22,17 +22,18 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
 
   @Nullable private EventChannel channel;
   @Nullable private Context context;
-    @Nullable private GeolocatorLocationService backgroundLocationService;
+  @Nullable private GeolocatorLocationService backgroundLocationService;
 
   public StreamHandlerImpl(PermissionManager permissionManager) {
     this.permissionManager = permissionManager;
   }
 
-    public void setBackgroundLocationService(@Nullable GeolocatorLocationService backgroundLocationService) {
-        this.backgroundLocationService = backgroundLocationService;
-    }
+  public void setBackgroundLocationService(
+      @Nullable GeolocatorLocationService backgroundLocationService) {
+    this.backgroundLocationService = backgroundLocationService;
+  }
 
-    /**
+  /**
    * Registers this instance as event stream handler on the given {@code messenger}.
    *
    * <p>Stops any previously started and unstopped calls.
@@ -69,18 +70,24 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
   @Override
   public void onListen(Object arguments, EventChannel.EventSink events) {
     try {
-        if (!permissionManager.hasPermission(this.context)){
-            events.error(ErrorCodes.permissionDenied.toString(),ErrorCodes.permissionDenied.toDescription(),null);
-            return;
-        }
+      if (!permissionManager.hasPermission(this.context)) {
+        events.error(
+            ErrorCodes.permissionDenied.toString(),
+            ErrorCodes.permissionDenied.toDescription(),
+            null);
+        return;
+      }
     } catch (PermissionUndefinedException e) {
-        events.error(ErrorCodes.permissionDefinitionsNotFound.toString(), ErrorCodes.permissionDefinitionsNotFound.toDescription(), null);
-        return; 
+      events.error(
+          ErrorCodes.permissionDefinitionsNotFound.toString(),
+          ErrorCodes.permissionDefinitionsNotFound.toDescription(),
+          null);
+      return;
     }
 
-    if(backgroundLocationService == null) {
-        Log.e(TAG, "Location background service has not started correctly");
-        return;
+    if (backgroundLocationService == null) {
+      Log.e(TAG, "Location background service has not started correctly");
+      return;
     }
 
     @SuppressWarnings("unchecked")
@@ -92,20 +99,22 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
     LocationOptions locationOptions = LocationOptions.parseArguments(map);
     ForegroundNotificationOptions foregroundNotificationOptions = null;
 
-    if(map != null) {
-        foregroundNotificationOptions = ForegroundNotificationOptions.parseArguments((Map<String, Object>) map.get("foregroundNotificationConfig"));
+    if (map != null) {
+      foregroundNotificationOptions =
+          ForegroundNotificationOptions.parseArguments(
+              (Map<String, Object>) map.get("foregroundNotificationConfig"));
     }
     backgroundLocationService.startLocationService(forceLocationManager, locationOptions, events);
-    if(foregroundNotificationOptions != null) {
-        backgroundLocationService.enableBackgroundMode(foregroundNotificationOptions);
+    if (foregroundNotificationOptions != null) {
+      backgroundLocationService.enableBackgroundMode(foregroundNotificationOptions);
     }
   }
 
   @Override
   public void onCancel(Object arguments) {
-      if(backgroundLocationService != null) {
-          backgroundLocationService.stopLocationService();
-          backgroundLocationService.disableBackgroundMode();
-      }
+    if (backgroundLocationService != null) {
+      backgroundLocationService.stopLocationService();
+      backgroundLocationService.disableBackgroundMode();
+    }
   }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -1,8 +1,6 @@
 package com.baseflow.geolocator;
 
-import android.app.Activity;
 import android.content.Context;
-import android.location.Location;
 import android.util.Log;
 import androidx.annotation.Nullable;
 import com.baseflow.geolocator.errors.ErrorCodes;
@@ -22,15 +20,15 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
 
   @Nullable private EventChannel channel;
   @Nullable private Context context;
-  @Nullable private GeolocatorLocationService backgroundLocationService;
+  @Nullable private GeolocatorLocationService foregroundLocationService;
 
   public StreamHandlerImpl(PermissionManager permissionManager) {
     this.permissionManager = permissionManager;
   }
 
-  public void setBackgroundLocationService(
-      @Nullable GeolocatorLocationService backgroundLocationService) {
-    this.backgroundLocationService = backgroundLocationService;
+  public void setForegroundLocationService(
+      @Nullable GeolocatorLocationService foregroundLocationService) {
+    this.foregroundLocationService = foregroundLocationService;
   }
 
   /**
@@ -85,7 +83,7 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
       return;
     }
 
-    if (backgroundLocationService == null) {
+    if (foregroundLocationService == null) {
       Log.e(TAG, "Location background service has not started correctly");
       return;
     }
@@ -104,17 +102,17 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
           ForegroundNotificationOptions.parseArguments(
               (Map<String, Object>) map.get("foregroundNotificationConfig"));
     }
-    backgroundLocationService.startLocationService(forceLocationManager, locationOptions, events);
+    foregroundLocationService.startLocationService(forceLocationManager, locationOptions, events);
     if (foregroundNotificationOptions != null) {
-      backgroundLocationService.enableBackgroundMode(foregroundNotificationOptions);
+      foregroundLocationService.enableBackgroundMode(foregroundNotificationOptions);
     }
   }
 
   @Override
   public void onCancel(Object arguments) {
-    if (backgroundLocationService != null) {
-      backgroundLocationService.stopLocationService();
-      backgroundLocationService.disableBackgroundMode();
+    if (foregroundLocationService != null) {
+      foregroundLocationService.stopLocationService();
+      foregroundLocationService.disableBackgroundMode();
     }
   }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/AndroidIconResource.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/AndroidIconResource.java
@@ -1,0 +1,34 @@
+package com.baseflow.geolocator.location;
+
+import java.util.Map;
+
+public class AndroidIconResource {
+    private final String name;
+    private final String defType;
+
+    public static AndroidIconResource parseArguments(Map<String, Object> arguments) {
+        if (arguments == null) {
+            return null;
+        }
+
+        final String name = (String) arguments.get("name");
+        final String defType = (String) arguments.get("defType");
+
+        return new AndroidIconResource(
+                name,
+                defType);
+    }
+
+    private AndroidIconResource(String name, String defType) {
+        this.name = name;
+        this.defType = defType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDefType() {
+        return defType;
+    }
+}

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/BackgroundNotification.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/BackgroundNotification.java
@@ -1,0 +1,102 @@
+package com.baseflow.geolocator.location;
+
+import android.annotation.SuppressLint;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+
+public class BackgroundNotification {
+    private Context context;
+    private Integer notificationId;
+    private String channelId;
+    private ForegroundNotificationOptions options;
+    private NotificationCompat.Builder builder;
+
+    public BackgroundNotification(
+            Context context,
+            String channelId ,
+            Integer notificationId,
+            ForegroundNotificationOptions options
+    ) {
+        this.context = context;
+        this.notificationId = notificationId;
+        this.channelId = channelId;
+        builder = new NotificationCompat.Builder(context, channelId)
+                .setPriority(NotificationCompat.PRIORITY_HIGH);
+        updateNotification(options, false);
+    }
+
+    private int getDrawableId(String iconName, String defType) {
+        return context.getResources().getIdentifier(iconName, defType, context.getPackageName());
+    }
+
+    @SuppressLint("UnspecifiedImmutableFlag")
+    private PendingIntent buildBringToFrontIntent() {
+        Intent intent = context.getPackageManager()
+                .getLaunchIntentForPackage(context.getPackageName());
+
+        if (intent != null) {
+            intent.setPackage(null);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+            int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+            if (Build.VERSION.SDK_INT > 23) {
+                flags = flags | PendingIntent.FLAG_IMMUTABLE;
+            }
+            return PendingIntent.getActivity(context, 0, intent, flags);
+        }
+
+        return null;
+    }
+
+    public void updateChannel(String channelName) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+            NotificationChannel channel = new NotificationChannel(
+                    channelId,
+                    channelName,
+                    NotificationManager.IMPORTANCE_NONE
+            );
+            channel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+            notificationManager.createNotificationChannel(channel);
+        }
+    }
+
+    private void updateNotification(
+            ForegroundNotificationOptions options,
+            boolean notify
+    ) {
+        int iconId = getDrawableId(options.getNotificationIcon().getName(), options.getNotificationIcon().getDefType());
+        if(iconId == 0) {
+            getDrawableId("ic_launcher.png", "mipmap");
+        }
+
+        builder = builder
+                .setContentTitle(options.getNotificationTitle())
+                .setSmallIcon(iconId)
+                .setContentText(options.getNotificationText())
+                .setContentIntent(buildBringToFrontIntent());
+
+
+        if (notify) {
+            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+            notificationManager.notify(notificationId, builder.build());
+        }
+    }
+
+    public void updateOptions(ForegroundNotificationOptions options, boolean isVisible) {
+        updateNotification(options, isVisible);
+        this.options = options;
+    }
+
+    public Notification build() {
+        return builder.build();
+    }
+}

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/BackgroundNotification.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/BackgroundNotification.java
@@ -9,15 +9,18 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 
-import androidx.annotation.Nullable;
+import androidx.annotation.NonNull;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
 public class BackgroundNotification {
-    private Context context;
-    private Integer notificationId;
-    private String channelId;
-    private ForegroundNotificationOptions options;
+    @NonNull
+    private final Context context;
+    @NonNull
+    private final Integer notificationId;
+    @NonNull
+    private final String channelId;
+    @NonNull
     private NotificationCompat.Builder builder;
 
     public BackgroundNotification(
@@ -47,7 +50,7 @@ public class BackgroundNotification {
             intent.setPackage(null);
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
             int flags = PendingIntent.FLAG_UPDATE_CURRENT;
-            if (Build.VERSION.SDK_INT > 23) {
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
                 flags = flags | PendingIntent.FLAG_IMMUTABLE;
             }
             return PendingIntent.getActivity(context, 0, intent, flags);
@@ -93,7 +96,6 @@ public class BackgroundNotification {
 
     public void updateOptions(ForegroundNotificationOptions options, boolean isVisible) {
         updateNotification(options, isVisible);
-        this.options = options;
     }
 
     public Notification build() {

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/ForegroundNotificationOptions.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/ForegroundNotificationOptions.java
@@ -1,0 +1,64 @@
+package com.baseflow.geolocator.location;
+
+import androidx.annotation.Nullable;
+
+import java.util.Map;
+
+@SuppressWarnings({"ConstantConditions", "unchecked"})
+public class ForegroundNotificationOptions {
+
+    private final String notificationTitle;
+    private final String notificationText;
+    private final AndroidIconResource notificationIcon;
+    private final boolean enableWifiLock;
+    private final boolean enableWakeLock;
+
+
+    public static ForegroundNotificationOptions parseArguments(@Nullable  Map<String, Object> arguments) {
+    if (arguments == null) {
+      return null;
+    }
+
+   final AndroidIconResource notificationIcon = AndroidIconResource.parseArguments((Map<String, Object>)arguments.get("notificationIcon"));
+    final String notificationTitle = (String) arguments.get("notificationTitle");
+    final String notificationText = (String) arguments.get("notificationText");
+    final Boolean enableWifiLock = (Boolean) arguments.get("enableWifiLock");
+    final Boolean enableWakeLock = (Boolean) arguments.get("enableWakeLock");
+
+    return new ForegroundNotificationOptions(
+            notificationTitle,
+            notificationText,
+            notificationIcon,
+            enableWifiLock,
+            enableWakeLock);
+  }
+
+    private ForegroundNotificationOptions(String notificationTitle, String notificationText, AndroidIconResource notificationIcon, boolean enableWifiLock, boolean enableWakeLock) {
+        this.notificationTitle = notificationTitle;
+        this.notificationText = notificationText;
+        this.notificationIcon = notificationIcon;
+        this.enableWifiLock = enableWifiLock;
+        this.enableWakeLock = enableWakeLock;
+    }
+
+    public String getNotificationTitle() {
+        return notificationTitle;
+    }
+
+    public String getNotificationText() {
+        return notificationText;
+    }
+
+    public AndroidIconResource getNotificationIcon() {
+        return notificationIcon;
+    }
+
+    public boolean isEnableWifiLock() {
+        return enableWifiLock;
+    }
+
+    public boolean isEnableWakeLock() {
+        return enableWakeLock;
+    }
+
+}

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/ForegroundNotificationOptions.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/ForegroundNotificationOptions.java
@@ -1,5 +1,6 @@
 package com.baseflow.geolocator.location;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.Map;
@@ -7,10 +8,15 @@ import java.util.Map;
 @SuppressWarnings({"ConstantConditions", "unchecked"})
 public class ForegroundNotificationOptions {
 
+    @NonNull
     private final String notificationTitle;
+    @NonNull
     private final String notificationText;
+    @NonNull
     private final AndroidIconResource notificationIcon;
+    @NonNull
     private final boolean enableWifiLock;
+    @NonNull
     private final boolean enableWakeLock;
 
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NotificationImportance.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NotificationImportance.java
@@ -1,0 +1,7 @@
+package com.baseflow.geolocator.location;
+
+public enum NotificationImportance {
+    Default,
+    High,
+    Max,
+}

--- a/geolocator_android/example/android/app/src/main/AndroidManifest.xml
+++ b/geolocator_android/example/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="geolocator_example"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/geolocator_android/example/lib/main.dart
+++ b/geolocator_android/example/lib/main.dart
@@ -285,15 +285,18 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
   void _toggleListening() {
     if (_positionStreamSubscription == null) {
       final androidSettings = AndroidSettings(
-        accuracy: LocationAccuracy.best,
-        distanceFilter: 10,
-        forceLocationManager: false,
-        foregroundNotificationConfig: const ForegroundNotificationConfig(
-          notificationText: "Example app will continue to receive your location even when you aren't using it", //Explain to the user why we are showing this notification
-          notificationTitle: "Running in Background", //Tell the user what we are doing
-          enableWakeLock: true, //Keep the system awake to receive background location information.
-        )
-      );
+          accuracy: LocationAccuracy.best,
+          distanceFilter: 10,
+          forceLocationManager: false,
+          foregroundNotificationConfig: const ForegroundNotificationConfig(
+            notificationText:
+                "Example app will continue to receive your location even when you aren't using it",
+            //Explain to the user why we are showing this notification
+            notificationTitle: "Running in Background",
+            //Tell the user what we are doing
+            enableWakeLock:
+                true, //Keep the system awake to receive background location information.
+          ));
       final positionStream = geolocatorAndroid.getPositionStream(
           locationSettings: androidSettings);
       _positionStreamSubscription = positionStream.handleError((error) {

--- a/geolocator_android/example/lib/main.dart
+++ b/geolocator_android/example/lib/main.dart
@@ -288,6 +288,11 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
         accuracy: LocationAccuracy.best,
         distanceFilter: 10,
         forceLocationManager: false,
+        foregroundNotificationConfig: const ForegroundNotificationConfig(
+          notificationText: "Example app will continue to receive your location even when you aren't using it", //Explain to the user why we are showing this notification
+          notificationTitle: "Running in Background", //Tell the user what we are doing
+          enableWakeLock: true, //Keep the system awake to receive background location information.
+        )
       );
       final positionStream = geolocatorAndroid.getPositionStream(
           locationSettings: androidSettings);

--- a/geolocator_android/lib/geolocator_android.dart
+++ b/geolocator_android/lib/geolocator_android.dart
@@ -1,1 +1,2 @@
-export 'src/types/android_settings.dart';
+export 'src/types/android_settings.dart' show AndroidSettings;
+export 'src/types/foreground_settings.dart' show ForegroundNotificationConfig;

--- a/geolocator_android/lib/src/types/android_settings.dart
+++ b/geolocator_android/lib/src/types/android_settings.dart
@@ -38,7 +38,7 @@ class AndroidSettings extends LocationSettings {
   final Duration? intervalDuration;
 
   /// If this is set then the services is started as a Foreground service with a persistent notification
-  /// showing the user that the service will continue running in the background
+  /// showing the user that the service will continue running in the background.
   final ForegroundNotificationConfig? foregroundNotificationConfig;
 
   @override

--- a/geolocator_android/lib/src/types/android_settings.dart
+++ b/geolocator_android/lib/src/types/android_settings.dart
@@ -1,5 +1,7 @@
 import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 
+import 'foreground_settings.dart';
+
 /// Represents different Android specific settings with which you can set a value
 /// other then the default value of the setting.
 class AndroidSettings extends LocationSettings {
@@ -13,6 +15,7 @@ class AndroidSettings extends LocationSettings {
     int distanceFilter = 0,
     this.intervalDuration,
     Duration? timeLimit,
+    this.foregroundNotificationConfig,
   }) : super(
             accuracy: accuracy,
             distanceFilter: distanceFilter,
@@ -34,12 +37,17 @@ class AndroidSettings extends LocationSettings {
   /// If this value is `null` an interval duration of 5000ms is applied.
   final Duration? intervalDuration;
 
+  /// If this is set then the services is started as a Foreground service with a persistent notification
+  /// showing the user that the service will continue running in the background
+  final ForegroundNotificationConfig? foregroundNotificationConfig;
+
   @override
   Map<String, dynamic> toJson() {
     return super.toJson()
       ..addAll({
         'forceLocationManager': forceLocationManager,
         'timeInterval': intervalDuration?.inMilliseconds,
+        'foregroundNotificationConfig': foregroundNotificationConfig?.toJson(),
       });
   }
 }

--- a/geolocator_android/lib/src/types/foreground_settings.dart
+++ b/geolocator_android/lib/src/types/foreground_settings.dart
@@ -37,10 +37,14 @@ class ForegroundNotificationConfig {
   /// Wifi lock permissions should be obtained first by using a permissions library.
   final bool enableWifiLock;
 
-  /// When enabled, a Wakelock is acquired when background execution is started.
-  /// If this is false then the system can still sleep and all location events will be received at once when the system wakes up again.
+  /// When enabled, a Wakelock is acquired when background execution is
+  /// started.
   ///
-  /// Wake lock permissions should be obtained first by using a permissions library.
+  /// If this is false then the system can still sleep and all location
+  /// events will be received at once when the system wakes up again.
+  ///
+  /// Wake lock permissions should be obtained first by using a permissions
+  /// library.
   final bool enableWakeLock;
 
   /// Creates an Android specific configuration for the [FlutterBackground] plugin.

--- a/geolocator_android/lib/src/types/foreground_settings.dart
+++ b/geolocator_android/lib/src/types/foreground_settings.dart
@@ -38,6 +38,7 @@ class ForegroundNotificationConfig {
   final bool enableWifiLock;
 
   /// When enabled, a Wakelock is acquired when background execution is started.
+  /// If this is false then the system can still sleep and all location events will be received at once when the system wakes up again.
   ///
   /// Wake lock permissions should be obtained first by using a permissions library.
   final bool enableWakeLock;

--- a/geolocator_android/lib/src/types/foreground_settings.dart
+++ b/geolocator_android/lib/src/types/foreground_settings.dart
@@ -1,0 +1,74 @@
+/// Uniquely identifies an Android resource
+class AndroidResource {
+  /// The name of the desired resource.
+  final String name;
+
+  /// Optional default resource type to find, if "type/" is not included in the name. Can be null to require an explicit type.
+  final String defType;
+
+  /// Uniquely identifies an Android resource
+  const AndroidResource({required this.name, this.defType = 'drawable'});
+
+  /// Returns a json representation of this class
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'defType': defType,
+    };
+  }
+}
+
+/// Configuration for the foreground notification. When this is provided the location service will run as a foreground service.
+class ForegroundNotificationConfig {
+  /// The title used for the foreground service notification.
+  final String notificationTitle;
+
+  /// The body used for the foreground service notification.
+  final String notificationText;
+
+  /// The resource name of the icon to be used for the foreground notification.
+  final AndroidResource notificationIcon;
+
+  /// When enabled, a WifiLock is acquired when background execution is started.
+  /// This allows the application to keep the Wi-Fi radio awake, even when the
+  /// user has not used the device in a while (e.g. for background network
+  /// communications).
+  ///
+  /// Wifilock permissions should be obtained first by using a permissions library
+  final bool enableWifiLock;
+
+  /// When enabled, a Wakelock is acquired when background execution is started.
+  ///
+  /// Wakelock permissions should be obtained first by using a permissions library
+  final bool enableWakeLock;
+
+  /// Creates an Android specific configuration for the [FlutterBackground] plugin.
+  ///
+  /// [notificationTitle] is the title used for the foreground service notification.
+  /// [notificationText] is the body used for the foreground service notification.
+  /// [notificationIcon] must be a drawable resource.
+  /// E. g. if the icon with name "background_icon" is in the "drawable" resource folder,
+  /// it should be of value `AndroidResource(name: 'background_icon', defType: 'drawable').
+  /// [enableWifiLock] indicates wether or not a WifiLock is acquired, when the
+  /// background execution is started. This allows the application to keep the
+  /// Wi-Fi radio awake, even when the user has not used the device in a while.
+  const ForegroundNotificationConfig({
+    required this.notificationTitle,
+    required this.notificationText,
+    this.notificationIcon =
+        const AndroidResource(name: 'ic_launcher', defType: 'mipmap'),
+    this.enableWifiLock = false,
+    this.enableWakeLock = false,
+  });
+
+  /// Returns a json representation of this class
+  Map<String, dynamic> toJson() {
+    return {
+      'notificationTitle': notificationTitle,
+      'notificationText': notificationText,
+      'notificationIcon': notificationIcon.toJson(),
+      'enableWifiLock': enableWifiLock,
+      'enableWakeLock': enableWakeLock,
+    };
+  }
+}

--- a/geolocator_android/lib/src/types/foreground_settings.dart
+++ b/geolocator_android/lib/src/types/foreground_settings.dart
@@ -9,7 +9,7 @@ class AndroidResource {
   /// Uniquely identifies an Android resource
   const AndroidResource({required this.name, this.defType = 'drawable'});
 
-  /// Returns a json representation of this class
+  /// Returns a JSON representation of this class.
   Map<String, dynamic> toJson() {
     return {
       'name': name,
@@ -34,12 +34,12 @@ class ForegroundNotificationConfig {
   /// user has not used the device in a while (e.g. for background network
   /// communications).
   ///
-  /// Wifilock permissions should be obtained first by using a permissions library
+  /// Wifi lock permissions should be obtained first by using a permissions library.
   final bool enableWifiLock;
 
   /// When enabled, a Wakelock is acquired when background execution is started.
   ///
-  /// Wakelock permissions should be obtained first by using a permissions library
+  /// Wake lock permissions should be obtained first by using a permissions library.
   final bool enableWakeLock;
 
   /// Creates an Android specific configuration for the [FlutterBackground] plugin.
@@ -61,7 +61,7 @@ class ForegroundNotificationConfig {
     this.enableWakeLock = false,
   });
 
-  /// Returns a json representation of this class
+  /// Returns a JSON representation of this class.
   Map<String, dynamic> toJson() {
     return {
       'notificationTitle': notificationTitle,

--- a/geolocator_android/lib/src/types/foreground_settings.dart
+++ b/geolocator_android/lib/src/types/foreground_settings.dart
@@ -6,7 +6,7 @@ class AndroidResource {
   /// Optional default resource type to find, if "type/" is not included in the name. Can be null to require an explicit type.
   final String defType;
 
-  /// Uniquely identifies an Android resource
+  /// Uniquely identifies an Android resource.
   const AndroidResource({required this.name, this.defType = 'drawable'});
 
   /// Returns a JSON representation of this class.

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 3.0.3
+version: 3.0.4
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  geolocator_platform_interface: ^4.0.0+1
+  geolocator_platform_interface: ^4.0.3
   
 dev_dependencies:
   flutter_test:

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 3.0.4
+version: 3.1.0
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  geolocator_platform_interface: ^3.0.0+1
+  geolocator_platform_interface: ^4.0.0+1
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature: Adds support for background (Foreground service) support to Android for when the applications goes into the background while location stream is active

Related to PR: https://github.com/Baseflow/flutter-geolocator/pull/957

### :arrow_heading_down: What is the current behavior?

Currently when the application goes into background and the OS kills the activity then location streaming stops.

### :new: What is the new behavior (if this is a feature change)?

New options have been introduced on Android that will allow the users to configure the background behaviour allow the service to continue running in the background keeping the activity alive while the location stream is active.

### :boom: Does this PR introduce a breaking change?

A new Android service is introduced which changes the behaviour of the location stream to use the new service but existing apps will not know about this change.

### :bug: Recommendations for testing

Testing the normal mode to validate the location stream is still working as expected and testing the background mode with the application running in the background.

### :memo: Links to relevant issues/docs

https://github.com/Baseflow/flutter-geolocator/issues/948
https://github.com/Baseflow/flutter-geolocator/issues/53

### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
