### PR TITLE
Adds show background location indicator for iOS

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+- Added additional settings to Apple settings to allow the user to configure the background settings of CLocationManager
+
 ## 2.0.1
 
 - Updated to the latest version of the `geolocator_platform_interface': `4.0.0`.
@@ -36,4 +40,3 @@
 ## 1.0.0
 
 - Initial open source release.
-

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.h
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.h
@@ -23,7 +23,8 @@ typedef void (^GeolocatorResult)(CLLocation *_Nullable location);
 
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
                            distanceFilter:(CLLocationDistance)distanceFilter
-        pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
+                            pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
+                            showBackgroundLocationIndicator:(BOOL)showBackgroundLocationIndicator
                              activityType:(CLActivityType)activityType
                             resultHandler:(GeolocatorResult _Nonnull)resultHandler
                              errorHandler:(GeolocatorError _Nonnull)errorHandler;

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
@@ -41,12 +41,19 @@
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
                            distanceFilter:(CLLocationDistance)distanceFilter
         pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
+                             showBackgroundLocationIndicator: (BOOL) showBackgroundLocationIndicator
                              activityType:(CLActivityType)activityType
                             resultHandler:(GeolocatorResult _Nonnull )resultHandler
                              errorHandler:(GeolocatorError _Nonnull)errorHandler {
     
     self.errorHandler = errorHandler;
     self.resultHandler = resultHandler;
+
+#if TARGET_OS_IOS
+    if (@available(iOS 11.0, macOS 11.0, *)) {
+        self.locationManager.showsBackgroundLocationIndicator = showBackgroundLocationIndicator;
+    }
+#endif
     
   [self startUpdatingLocationWithDesiredAccuracy:desiredAccuracy
                                   distanceFilter:distanceFilter

--- a/geolocator_apple/apple/Classes/Handlers/PositionStreamHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/PositionStreamHandler.m
@@ -49,10 +49,13 @@
   CLLocationDistance distanceFilter = [LocationDistanceMapper toCLLocationDistance:(NSNumber *)arguments[@"distanceFilter"]];
   NSNumber* pauseLocationUpdatesAutomatically = arguments[@"pauseLocationUpdatesAutomatically"];
   CLActivityType activityType = [ActivityTypeMapper toCLActivityType:(NSNumber *)arguments[@"activityType"]];
+
+  NSNumber* showBackgroundLocationIndicator = arguments[@"showBackgroundLocationIndicator"];
 	      
   [[weakSelf geolocationHandler] startListeningWithDesiredAccuracy:accuracy
                                                     distanceFilter:distanceFilter
                                  pauseLocationUpdatesAutomatically:pauseLocationUpdatesAutomatically && [pauseLocationUpdatesAutomatically boolValue]
+                                 showBackgroundLocationIndicator:showBackgroundLocationIndicator && [showBackgroundLocationIndicator boolValue]
                                                       activityType:activityType
                                                      resultHandler:^(CLLocation *location) {
     [weakSelf onLocationDidChange: location];

--- a/geolocator_apple/lib/src/types/apple_settings.dart
+++ b/geolocator_apple/lib/src/types/apple_settings.dart
@@ -15,6 +15,7 @@ class AppleSettings extends LocationSettings {
     LocationAccuracy accuracy = LocationAccuracy.best,
     int distanceFilter = 0,
     Duration? timeLimit,
+    this.showBackgroundLocationIndicator = false,
   }) : super(
           accuracy: accuracy,
           distanceFilter: distanceFilter,
@@ -32,12 +33,16 @@ class AppleSettings extends LocationSettings {
   /// to determine when location updates may be automatically paused.
   final ActivityType activityType;
 
+  /// Flag to ask the Apple OS to show the background location indicator (iOS only)
+  final bool showBackgroundLocationIndicator;
+
   @override
   Map<String, dynamic> toJson() {
     return super.toJson()
       ..addAll({
         'pauseLocationUpdatesAutomatically': pauseLocationUpdatesAutomatically,
         'this.activityType': activityType.index,
+        'showBackgroundLocationIndicator': showBackgroundLocationIndicator,
       });
   }
 }

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
-version: 2.0.1
+version: 2.1.0
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_apple
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  geolocator_platform_interface: ^4.0.0
+  geolocator_platform_interface: ^4.0.0+1
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
✨ What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature: Adds support for setting the background location indicator on iOS

Related to PR: https://github.com/Baseflow/flutter-geolocator/pull/957

⤵️ What is the current behavior?

No way to define this setting

🆕 What is the new behavior (if this is a feature change)?
A new boolean option was introduced on Apple settings that can be used to set the background location indicator status. 

💥 Does this PR introduce a breaking change?
No.

🐛 Recommendations for testing
Testing the normal mode to validate the location stream is still working as expected and testing the background mode with the application running in the background.

📝 Links to relevant issues/docs
https://github.com/Baseflow/flutter-geolocator/issues/948
https://github.com/Baseflow/flutter-geolocator/issues/53

### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
