### PR TITLE
Feature/ios background location

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -508,4 +508,3 @@ Complete rebuild of the geolocator plugin. Please note the this version contains
 ## 0.0.1
 
 - Initial release
-

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.1
 
-- Added additional settings to Apple settings to allow the user to configure the background settings of CLocationManager
+- Added additional option to Apple settings to allow the user to configure the background location indicator of CLocationManager
 
 ## 2.1.0
 

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- Added additional settings to Apple settings to allow the user to configure the background settings of CLocationManager
+
 ## 2.1.0
 
 - Ensures that the `getCurrentPosition` takes the supplied accuracy into account.
@@ -42,4 +46,3 @@
 ## 1.0.0
 
 - Initial open source release.
-

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.1
 
-- Added additional option to Apple settings to allow the user to configure the background location indicator of CLocationManager
+- Added additional option to Apple settings to allow the user to configure the background location indicator of CLocationManager.
 
 ## 2.1.0
 

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.h
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.h
@@ -24,8 +24,8 @@ typedef void (^GeolocatorResult)(CLLocation *_Nullable location);
 
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
                            distanceFilter:(CLLocationDistance)distanceFilter
-                            pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
-                            showBackgroundLocationIndicator:(BOOL)showBackgroundLocationIndicator
+        pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
+          showBackgroundLocationIndicator:(BOOL)showBackgroundLocationIndicator
                              activityType:(CLActivityType)activityType
                             resultHandler:(GeolocatorResult _Nonnull)resultHandler
                              errorHandler:(GeolocatorError _Nonnull)errorHandler;

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.h
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.h
@@ -24,7 +24,8 @@ typedef void (^GeolocatorResult)(CLLocation *_Nullable location);
 
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
                            distanceFilter:(CLLocationDistance)distanceFilter
-        pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
+                            pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
+                            showBackgroundLocationIndicator:(BOOL)showBackgroundLocationIndicator
                              activityType:(CLActivityType)activityType
                             resultHandler:(GeolocatorResult _Nonnull)resultHandler
                              errorHandler:(GeolocatorError _Nonnull)errorHandler;

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
@@ -74,13 +74,13 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
                             resultHandler:(GeolocatorResult _Nonnull )resultHandler
                              errorHandler:(GeolocatorError _Nonnull)errorHandler {
     
-    self.errorHandler = errorHandler;
-    self.resultHandler = resultHandler;
+  self.errorHandler = errorHandler;
+  self.resultHandler = resultHandler;
 
 #if TARGET_OS_IOS
-    if (@available(iOS 11.0, macOS 11.0, *)) {
-        self.locationManager.showsBackgroundLocationIndicator = showBackgroundLocationIndicator;
-    }
+  if (@available(iOS 11.0, macOS 11.0, *)) {
+      self.locationManager.showsBackgroundLocationIndicator = showBackgroundLocationIndicator;
+  }
 #endif
     
   [self startUpdatingLocationWithDesiredAccuracy:desiredAccuracy

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
@@ -69,12 +69,20 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
                            distanceFilter:(CLLocationDistance)distanceFilter
         pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
+                             showBackgroundLocationIndicator: (BOOL) showBackgroundLocationIndicator
                              activityType:(CLActivityType)activityType
                             resultHandler:(GeolocatorResult _Nonnull )resultHandler
                              errorHandler:(GeolocatorError _Nonnull)errorHandler {
-  self.errorHandler = errorHandler;
-  self.resultHandler = resultHandler;
-  
+    
+    self.errorHandler = errorHandler;
+    self.resultHandler = resultHandler;
+
+#if TARGET_OS_IOS
+    if (@available(iOS 11.0, macOS 11.0, *)) {
+        self.locationManager.showsBackgroundLocationIndicator = showBackgroundLocationIndicator;
+    }
+#endif
+    
   [self startUpdatingLocationWithDesiredAccuracy:desiredAccuracy
                                   distanceFilter:distanceFilter
                pauseLocationUpdatesAutomatically:pauseLocationUpdatesAutomatically

--- a/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/GeolocationHandler.m
@@ -69,7 +69,7 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
                            distanceFilter:(CLLocationDistance)distanceFilter
         pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
-                             showBackgroundLocationIndicator: (BOOL) showBackgroundLocationIndicator
+          showBackgroundLocationIndicator: (BOOL) showBackgroundLocationIndicator
                              activityType:(CLActivityType)activityType
                             resultHandler:(GeolocatorResult _Nonnull )resultHandler
                              errorHandler:(GeolocatorError _Nonnull)errorHandler {

--- a/geolocator_apple/apple/Classes/Handlers/PositionStreamHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/PositionStreamHandler.m
@@ -49,10 +49,13 @@
   CLLocationDistance distanceFilter = [LocationDistanceMapper toCLLocationDistance:(NSNumber *)arguments[@"distanceFilter"]];
   NSNumber* pauseLocationUpdatesAutomatically = arguments[@"pauseLocationUpdatesAutomatically"];
   CLActivityType activityType = [ActivityTypeMapper toCLActivityType:(NSNumber *)arguments[@"activityType"]];
+
+  NSNumber* showBackgroundLocationIndicator = arguments[@"showBackgroundLocationIndicator"];
 	      
   [[weakSelf geolocationHandler] startListeningWithDesiredAccuracy:accuracy
                                                     distanceFilter:distanceFilter
                                  pauseLocationUpdatesAutomatically:pauseLocationUpdatesAutomatically && [pauseLocationUpdatesAutomatically boolValue]
+                                 showBackgroundLocationIndicator:showBackgroundLocationIndicator && [showBackgroundLocationIndicator boolValue]
                                                       activityType:activityType
                                                      resultHandler:^(CLLocation *location) {
     [weakSelf onLocationDidChange: location];

--- a/geolocator_apple/apple/Classes/Handlers/PositionStreamHandler.m
+++ b/geolocator_apple/apple/Classes/Handlers/PositionStreamHandler.m
@@ -55,7 +55,7 @@
   [[weakSelf geolocationHandler] startListeningWithDesiredAccuracy:accuracy
                                                     distanceFilter:distanceFilter
                                  pauseLocationUpdatesAutomatically:pauseLocationUpdatesAutomatically && [pauseLocationUpdatesAutomatically boolValue]
-                                 showBackgroundLocationIndicator:showBackgroundLocationIndicator && [showBackgroundLocationIndicator boolValue]
+                                   showBackgroundLocationIndicator:showBackgroundLocationIndicator && [showBackgroundLocationIndicator boolValue]
                                                       activityType:activityType
                                                      resultHandler:^(CLLocation *location) {
     [weakSelf onLocationDidChange: location];

--- a/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
+++ b/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
@@ -136,8 +136,8 @@
   XCTestExpectation *expectation = [self expectationWithDescription:@"expect result return third location"];
   [_geolocationHandler startListeningWithDesiredAccuracy: kCLLocationAccuracyBest
                                           distanceFilter:0
-                                        pauseLocationUpdatesAutomatically:NO
-                                        showBackgroundLocationIndicator:NO
+                       pauseLocationUpdatesAutomatically:NO
+                         showBackgroundLocationIndicator:NO
                                             activityType:CLActivityTypeOther
                                            resultHandler:^(CLLocation * _Nullable location) {
     XCTAssertEqual(location, mockLocation);

--- a/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
+++ b/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
@@ -160,7 +160,7 @@
   [_geolocationHandler startListeningWithDesiredAccuracy: kCLLocationAccuracyBest
                                           distanceFilter:0
                        pauseLocationUpdatesAutomatically:NO
-                       showBackgroundLocationIndicator:NO
+                         showBackgroundLocationIndicator:NO
                                             activityType:CLActivityTypeOther
                                            resultHandler:^(CLLocation * _Nullable location) {
   }

--- a/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
+++ b/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
@@ -136,7 +136,8 @@
   XCTestExpectation *expectation = [self expectationWithDescription:@"expect result return third location"];
   [_geolocationHandler startListeningWithDesiredAccuracy: kCLLocationAccuracyBest
                                           distanceFilter:0
-                       pauseLocationUpdatesAutomatically:NO
+                                        pauseLocationUpdatesAutomatically:NO
+                                        showBackgroundLocationIndicator:NO
                                             activityType:CLActivityTypeOther
                                            resultHandler:^(CLLocation * _Nullable location) {
     XCTAssertEqual(location, mockLocation);
@@ -159,6 +160,7 @@
   [_geolocationHandler startListeningWithDesiredAccuracy: kCLLocationAccuracyBest
                                           distanceFilter:0
                        pauseLocationUpdatesAutomatically:NO
+                       showBackgroundLocationIndicator:NO
                                             activityType:CLActivityTypeOther
                                            resultHandler:^(CLLocation * _Nullable location) {
   }
@@ -181,6 +183,7 @@
   [_geolocationHandler startListeningWithDesiredAccuracy: kCLLocationAccuracyBest
                                           distanceFilter:0
                        pauseLocationUpdatesAutomatically:NO
+                       showBackgroundLocationIndicator:NO
                                             activityType:CLActivityTypeOther
                                            resultHandler:^(CLLocation * _Nullable location) {
     [expectation fulfill];

--- a/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
+++ b/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
@@ -183,7 +183,7 @@
   [_geolocationHandler startListeningWithDesiredAccuracy: kCLLocationAccuracyBest
                                           distanceFilter:0
                        pauseLocationUpdatesAutomatically:NO
-                       showBackgroundLocationIndicator:NO
+                         showBackgroundLocationIndicator:NO
                                             activityType:CLActivityTypeOther
                                            resultHandler:^(CLLocation * _Nullable location) {
     [expectation fulfill];

--- a/geolocator_apple/example/lib/main.dart
+++ b/geolocator_apple/example/lib/main.dart
@@ -287,14 +287,14 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
     Exception? error;
 
     if (_positionStreamSubscription == null) {
-      final Stream<Position> positionStream =
-          geolocatorApple.getPositionStream(locationSettings: AppleSettings(
-            accuracy: LocationAccuracy.best,
-            distanceFilter: 10,
-            activityType: ActivityType.other,
-            // Only set to true if our app will be started up in the background.
-            showBackgroundLocationIndicator: false,
-          ));
+      final Stream<Position> positionStream = geolocatorApple.getPositionStream(
+          locationSettings: AppleSettings(
+        accuracy: LocationAccuracy.best,
+        distanceFilter: 10,
+        activityType: ActivityType.other,
+        // Only set to true if our app will be started up in the background.
+        showBackgroundLocationIndicator: false,
+      ));
       _positionStreamSubscription = positionStream.handleError((e) {
         _positionStreamSubscription?.cancel();
         _positionStreamSubscription = null;

--- a/geolocator_apple/example/lib/main.dart
+++ b/geolocator_apple/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io' show Platform;
 
 import 'package:baseflow_plugin_template/baseflow_plugin_template.dart';
 import 'package:flutter/material.dart';
+import 'package:geolocator_apple/geolocator_apple.dart';
 import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 
 /// Defines the main theme color.
@@ -287,7 +288,13 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
 
     if (_positionStreamSubscription == null) {
       final Stream<Position> positionStream =
-          geolocatorApple.getPositionStream();
+          geolocatorApple.getPositionStream(locationSettings: AppleSettings(
+            accuracy: LocationAccuracy.best,
+            distanceFilter: 10,
+            activityType: ActivityType.other,
+            // Only set to true if our app will be started up in the background.
+            showBackgroundLocationIndicator: false,
+          ));
       _positionStreamSubscription = positionStream.handleError((e) {
         _positionStreamSubscription?.cancel();
         _positionStreamSubscription = null;

--- a/geolocator_apple/lib/src/types/apple_settings.dart
+++ b/geolocator_apple/lib/src/types/apple_settings.dart
@@ -36,6 +36,9 @@ class AppleSettings extends LocationSettings {
 
   /// Flag to ask the Apple OS to show the background location indicator (iOS only)
   /// if app starts up and background and requests the users location.
+  ///
+  /// For this setting to work and for the location to be retrieved the user must
+  /// have granted "always" permissions for location retrieval.
   final bool showBackgroundLocationIndicator;
 
   /// Returns a JSON representation of this class.

--- a/geolocator_apple/lib/src/types/apple_settings.dart
+++ b/geolocator_apple/lib/src/types/apple_settings.dart
@@ -1,4 +1,5 @@
 import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
+
 import 'activity_type.dart';
 
 /// Represents different iOS specific settings with which you can set a value
@@ -34,8 +35,10 @@ class AppleSettings extends LocationSettings {
   final ActivityType activityType;
 
   /// Flag to ask the Apple OS to show the background location indicator (iOS only)
+  /// if app starts up and background and requests the users location.
   final bool showBackgroundLocationIndicator;
 
+  /// Returns a JSON representation of this class.
   @override
   Map<String, dynamic> toJson() {
     return super.toJson()

--- a/geolocator_apple/lib/src/types/apple_settings.dart
+++ b/geolocator_apple/lib/src/types/apple_settings.dart
@@ -15,6 +15,7 @@ class AppleSettings extends LocationSettings {
     LocationAccuracy accuracy = LocationAccuracy.best,
     int distanceFilter = 0,
     Duration? timeLimit,
+    this.showBackgroundLocationIndicator = false,
   }) : super(
           accuracy: accuracy,
           distanceFilter: distanceFilter,
@@ -32,12 +33,16 @@ class AppleSettings extends LocationSettings {
   /// to determine when location updates may be automatically paused.
   final ActivityType activityType;
 
+  /// Flag to ask the Apple OS to show the background location indicator (iOS only)
+  final bool showBackgroundLocationIndicator;
+
   @override
   Map<String, dynamic> toJson() {
     return super.toJson()
       ..addAll({
         'pauseLocationUpdatesAutomatically': pauseLocationUpdatesAutomatically,
         'this.activityType': activityType.index,
+        'showBackgroundLocationIndicator': showBackgroundLocationIndicator,
       });
   }
 }

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  geolocator_platform_interface: ^4.0.0+1
+  geolocator_platform_interface: ^4.0.3
   
 dev_dependencies:
   flutter_test:

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
-version: 2.1.0
+version: 2.1.1
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_apple
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  geolocator_platform_interface: ^4.0.0
+  geolocator_platform_interface: ^4.0.0+1
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Adds an additional option to Apple settings that allows the user to configure the background location indicator that needs to be set to true if the application is started up in the background by some other process and it then requests a location.

### :arrow_heading_down: What is the current behavior?

Cannot be set currently.

### :new: What is the new behavior (if this is a feature change)?

Exposing the CLocation manager setting to the user

### :boom: Does this PR introduce a breaking change?

No it doesn't.

### :bug: Recommendations for testing

One will have to start the application in the background through a system event or reminder and then request the location.

### :memo: Links to relevant issues/docs

N/A

### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
