### PR TITLE
Clear stream before emitting error

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.4
+
+- Fixes a bug where listening to the position stream immediately after an error, results in listening to a dead stream. 
 
 ## 4.0.3
 

--- a/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
+++ b/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart
@@ -167,12 +167,12 @@ class MethodChannelGeolocator extends GeolocatorPlatform {
       positionStream = positionStream.timeout(
         timeLimit,
         onTimeout: (s) {
+          _positionStream = null;
           s.addError(TimeoutException(
             'Time limit reached while waiting for position update.',
             timeLimit,
           ));
           s.close();
-          _positionStream = null;
         },
       );
     }

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 homepage: https://github.com/baseflow/flutter-geolocator
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.0.3
+version: 4.0.4
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When the location stream times out, if your handler for this error is to immediately re-try listening to the stream, you receive a dead stream.

### :new: What is the new behavior (if this is a feature change)?

Clear out the stale stream before throwing the error so re-listening will get a fresh stream.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Something along these lines (but force it to timeout)

```dart
void _setupLocationStream() {
  final stream = Geolocator.getPositionStream(
    locationSettings: LocationSettings(timeLimit: Duration(seconds: 3))
  );
  locationSubscription = stream.listen((location) {
    print(location);
  });
   locationSubscription!.onError((error) {
     // This attempt to re-setup the stream will get the already timed out stream, meaning
     // you do not get any more updates.
     // If you await a Future.delayed(Duration(milliseconds: 100)); here, you do get updates
     _setupLocationStream();
   });
}
```

### :memo: Links to relevant issues/docs

Specifically [this check](https://github.com/NextFaze/flutter-geolocator/blob/master/geolocator_platform_interface/lib/src/implementations/method_channel_geolocator.dart#L156-L158) is not null because the call to check if the existing stream is null fails (verified with breakpoints)

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [x] I rebased onto current `master`.
