### PR TITLE
Bug fix to unbind the Android service connection

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+
+- Fixes and issue with the foreground service connection not getting unbound correctly.
+
 ## 3.1.0
 
 - Adds support to make a foreground service and continue processing location updates when the application is moved into the background.

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.1.1
 
-- Fixes and issue with the foreground service connection not getting unbound correctly.
+- Fixes an issue with the foreground service connection not getting unbound correctly.
 
 ## 3.1.0
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -144,6 +144,9 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
   public void onDetachedFromActivity() {
     dispose();
     deregisterListeners();
+
+    pluginBinding.getActivity().unbindService(serviceConnection);
+    pluginBinding = null;
   }
 
   private void registerListeners() {

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -145,8 +145,10 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
     dispose();
     deregisterListeners();
 
-    pluginBinding.getActivity().unbindService(serviceConnection);
-    pluginBinding = null;
+    if (pluginBinding != null) {
+      pluginBinding.getActivity().unbindService(serviceConnection);
+      pluginBinding = null;
+    }
   }
 
   private void registerListeners() {

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 3.1.0
+version: 3.1.1
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fixes a bug with the foreground service connection that does not unbind when the activity is destroyed by Android.

### :arrow_heading_down: What is the current behavior?

The service connection stays attached producing an error from the Android system

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Force close the activity while it is in the background and make sure the error message does not show up

### :memo: Links to relevant issues/docs

https://github.com/Baseflow/flutter-geolocator/issues/986

### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
