### PR TITLE
Unregister receiver when detaching from activity

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.2
+
+- Fixes an issue with the location status service not unregistering the status receiver.
+
 ## 3.1.1
 
 - Fixes an issue with the foreground service connection not getting unbound correctly.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -69,6 +69,7 @@ public class GeolocatorLocationService extends Service {
   public void onDestroy() {
     Log.d(TAG, "Destroying location service.");
 
+    stopLocationService();
     disableBackgroundMode();
     geolocationManager = null;
     backgroundNotification = null;
@@ -98,6 +99,7 @@ public class GeolocatorLocationService extends Service {
   }
 
   public void stopLocationService() {
+    Log.d(TAG, "Stopping location service.");
     if (locationClient != null && geolocationManager != null) {
       geolocationManager.stopPositionUpdates(locationClient);
     }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
@@ -37,6 +37,8 @@ public class LocationServiceHandlerImpl implements EventChannel.StreamHandler {
     if (channel == null) {
       return;
     }
+
+    disposeListeners();
     channel.setStreamHandler(null);
     channel = null;
   }
@@ -60,6 +62,11 @@ public class LocationServiceHandlerImpl implements EventChannel.StreamHandler {
 
   @Override
   public void onCancel(Object arguments) {
+
+    disposeListeners();
+  }
+
+  private void disposeListeners() {
     activity.unregisterReceiver(receiver);
   }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
@@ -56,7 +56,6 @@ public class LocationServiceHandlerImpl implements EventChannel.StreamHandler {
     IntentFilter filter = new IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION);
     filter.addAction(Intent.ACTION_PROVIDER_CHANGED);
     receiver = new LocationServiceStatusReceiver(events);
-    if (activity == null) return;
     activity.registerReceiver(receiver, filter);
   }
 
@@ -67,6 +66,8 @@ public class LocationServiceHandlerImpl implements EventChannel.StreamHandler {
   }
 
   private void disposeListeners() {
-    activity.unregisterReceiver(receiver);
+    if (activity != null) {
+      activity.unregisterReceiver(receiver);
+    }
   }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -60,6 +60,7 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
       return;
     }
 
+    disposeListeners();
     channel.setStreamHandler(null);
     channel = null;
   }
@@ -110,6 +111,10 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
 
   @Override
   public void onCancel(Object arguments) {
+    disposeListeners();
+  }
+
+  private void disposeListeners() {
     if (foregroundLocationService != null) {
       foregroundLocationService.stopLocationService();
       foregroundLocationService.disableBackgroundMode();

--- a/geolocator_android/example/lib/main.dart
+++ b/geolocator_android/example/lib/main.dart
@@ -285,18 +285,18 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
   void _toggleListening() {
     if (_positionStreamSubscription == null) {
       final androidSettings = AndroidSettings(
-          accuracy: LocationAccuracy.best,
-          distanceFilter: 10,
-          forceLocationManager: false,
-          foregroundNotificationConfig: const ForegroundNotificationConfig(
-            notificationText:
-                "Example app will continue to receive your location even when you aren't using it",
-            //Explain to the user why we are showing this notification
-            notificationTitle: "Running in Background",
-            //Tell the user what we are doing
-            enableWakeLock:
-                false, //Keep the system awake to receive background location information.
-          ),
+        accuracy: LocationAccuracy.best,
+        distanceFilter: 10,
+        forceLocationManager: false,
+        foregroundNotificationConfig: const ForegroundNotificationConfig(
+          notificationText:
+              "Example app will continue to receive your location even when you aren't using it",
+          //Explain to the user why we are showing this notification
+          notificationTitle: "Running in Background",
+          //Tell the user what we are doing
+          enableWakeLock:
+              false, //Keep the system awake to receive background location information.
+        ),
       );
       final positionStream = geolocatorAndroid.getPositionStream(
           locationSettings: androidSettings);

--- a/geolocator_android/example/lib/main.dart
+++ b/geolocator_android/example/lib/main.dart
@@ -295,8 +295,9 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
             notificationTitle: "Running in Background",
             //Tell the user what we are doing
             enableWakeLock:
-                true, //Keep the system awake to receive background location information.
-          ));
+                false, //Keep the system awake to receive background location information.
+          ),
+      );
       final positionStream = geolocatorAndroid.getPositionStream(
           locationSettings: androidSettings);
       _positionStreamSubscription = positionStream.handleError((error) {

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 3.1.1
+version: 3.1.2
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Unregisters the android receiver when we are detaching from the Flutter activity

### :arrow_heading_down: What is the current behavior?

An exception is thrown when the application is terminated

### :new: What is the new behavior (if this is a feature change)?

When the activity is detached and we are closing our streams the receiver gets unregistered preventing an activity leak

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the example application and terminate the android activity verifying that no exceptions are thrown

### :memo: Links to relevant issues/docs

https://github.com/Baseflow/flutter-geolocator/pull/971/commits/8e8458e89e814aafc3d656f2c05ca611f97c9723
https://github.com/Baseflow/flutter-geolocator/issues/986

### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
