### PR TITLE
Fixes IllegalArgumentException when unregistering status location reciever

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.3
+
+- Fixes a bug introduced in 3.1.2 where unregistering the status location receiver throws an IllegalArgumentException.
+
 ## 3.1.2
 
 - Fixes an issue with the location status service not unregistering the status receiver.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -124,11 +124,13 @@ public class GeolocatorLocationService extends Service {
   }
 
   public void disableBackgroundMode() {
-    Log.d(TAG, "Stop service in foreground.");
-    stopForeground(true);
-    releaseWakeLocks();
-    isForeground = false;
-    backgroundNotification = null;
+    if (isForeground) {
+      Log.d(TAG, "Stop service in foreground.");
+      stopForeground(true);
+      releaseWakeLocks();
+      isForeground = false;
+      backgroundNotification = null;
+    }
   }
 
   public void changeNotificationOptions(ForegroundNotificationOptions options) {

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
@@ -66,7 +66,7 @@ public class LocationServiceHandlerImpl implements EventChannel.StreamHandler {
   }
 
   private void disposeListeners() {
-    if (activity != null) {
+    if (activity != null && receiver != null) {
       activity.unregisterReceiver(receiver);
     }
   }

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 3.1.2
+version: 3.1.3
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

IllegalArgumentException gets thrown in some scenarios when the activity is closed

### :new: What is the new behavior (if this is a feature change)?

Adds an additional null check to prevent the call if we haven't registered the reciever

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Terminate the application without having subscribed to the location status stream

### :memo: Links to relevant issues/docs

https://github.com/Baseflow/flutter-geolocator/issues/986

### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
