### PR TITLE
Remove activity dependency

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.4
+
+- Fixes support for retrieving the position stream in the absence of an Android activity.
+
 ## 3.1.3
 
 - Fixes a bug introduced in 3.1.2 where unregistering the status location receiver throws an IllegalArgumentException.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -12,6 +12,7 @@ import android.os.Binder;
 import android.os.IBinder;
 import android.os.PowerManager;
 import android.util.Log;
+
 import androidx.annotation.Nullable;
 
 import com.baseflow.geolocator.errors.ErrorCodes;
@@ -30,11 +31,9 @@ public class GeolocatorLocationService extends Service {
   private static final String CHANNEL_ID = "geolocator_channel_01";
   private final String WAKELOCK_TAG = "GeolocatorLocationService:Wakelock";
   private final String WIFILOCK_TAG = "GeolocatorLocationService:WifiLock";
-
+  @Nullable private final LocalBinder binder = new LocalBinder(this);
   // Service is foreground
   private boolean isForeground = false;
-
-  @Nullable private final LocalBinder binder = new LocalBinder(this);
   @Nullable private Activity activity = null;
   @Nullable private GeolocationManager geolocationManager = null;
   @Nullable private LocationClient locationClient;
@@ -51,6 +50,11 @@ public class GeolocatorLocationService extends Service {
     geolocationManager = new GeolocationManager();
   }
 
+  @Override
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    return START_STICKY;
+  }
+
   @Nullable
   @Override
   public IBinder onBind(Intent intent) {
@@ -61,7 +65,7 @@ public class GeolocatorLocationService extends Service {
 
   @Override
   public boolean onUnbind(Intent intent) {
-    Log.d(TAG, "Binding to location service.");
+    Log.d(TAG, "Unbinding from location service.");
     return super.onUnbind(intent);
   }
 
@@ -74,6 +78,7 @@ public class GeolocatorLocationService extends Service {
     geolocationManager = null;
     backgroundNotification = null;
 
+    Log.d(TAG, "Destroyed location service.");
     super.onDestroy();
   }
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -31,7 +31,7 @@ public class GeolocatorLocationService extends Service {
   private static final String CHANNEL_ID = "geolocator_channel_01";
   private final String WAKELOCK_TAG = "GeolocatorLocationService:Wakelock";
   private final String WIFILOCK_TAG = "GeolocatorLocationService:WifiLock";
-  @Nullable private final LocalBinder binder = new LocalBinder(this);
+  private final LocalBinder binder = new LocalBinder(this);
   // Service is foreground
   private boolean isForeground = false;
   @Nullable private Activity activity = null;

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -91,8 +91,8 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
 
     LocationServiceHandlerImpl locationServiceHandler = new LocationServiceHandlerImpl();
     locationServiceHandler.startListening(registrar.context(), registrar.messenger());
-    locationServiceHandler.setContext(registrar.activity());
-    geolocatorPlugin.bindForegroundService(registrar.activity());
+    locationServiceHandler.setContext(registrar.activeContext());
+    geolocatorPlugin.bindForegroundService(registrar.activeContext());
   }
 
   @Override

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/LocationServiceHandlerImpl.java
@@ -19,7 +19,6 @@ public class LocationServiceHandlerImpl implements EventChannel.StreamHandler {
   private static final String TAG = "LocationServiceHandler";
 
   @Nullable private EventChannel channel;
-  @Nullable private Activity activity;
   @Nullable private Context context;
   @Nullable private LocationServiceStatusReceiver receiver;
 
@@ -43,20 +42,20 @@ public class LocationServiceHandlerImpl implements EventChannel.StreamHandler {
     channel = null;
   }
 
-  void setActivity(@Nullable Activity activity) {
-    this.activity = activity;
+  void setContext(@Nullable Context context) {
+    this.context = context;
   }
 
   @Override
   public void onListen(Object arguments, EventChannel.EventSink events) {
-    if (activity == null) {
+    if (context == null) {
       return;
     }
 
     IntentFilter filter = new IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION);
     filter.addAction(Intent.ACTION_PROVIDER_CHANGED);
     receiver = new LocationServiceStatusReceiver(events);
-    activity.registerReceiver(receiver, filter);
+    context.registerReceiver(receiver, filter);
   }
 
   @Override
@@ -66,8 +65,8 @@ public class LocationServiceHandlerImpl implements EventChannel.StreamHandler {
   }
 
   private void disposeListeners() {
-    if (activity != null && receiver != null) {
-      activity.unregisterReceiver(receiver);
+    if (context != null && receiver != null) {
+      context.unregisterReceiver(receiver);
     }
   }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
@@ -41,8 +41,6 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
   @Nullable private Activity activity;
 
-  @Nullable private GeolocatorLocationService foregroundLocationService;
-
   MethodCallHandlerImpl(
       PermissionManager permissionManager,
       GeolocationManager geolocationManager,
@@ -124,10 +122,6 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
   void setActivity(@Nullable Activity activity) {
     this.activity = activity;
-  }
-
-  void setForegroundLocationService(@Nullable GeolocatorLocationService foregroundLocationService) {
-    this.foregroundLocationService = foregroundLocationService;
   }
 
   private void onCheckPermission(MethodChannel.Result result) {

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -17,13 +17,14 @@ import com.google.android.gms.location.*;
 import java.util.Random;
 
 class FusedLocationClient implements LocationClient {
+    private static final String TAG = "FlutterGeolocator";
+
   private final Context context;
   private final LocationCallback locationCallback;
   private final FusedLocationProviderClient fusedLocationProviderClient;
   private final int activityRequestCode;
   @Nullable private final LocationOptions locationOptions;
 
-  @Nullable private Activity activity;
   @Nullable private ErrorCallback errorCallback;
   @Nullable private PositionChangedCallback positionChangedCallback;
 
@@ -39,7 +40,7 @@ class FusedLocationClient implements LocationClient {
           public synchronized void onLocationResult(LocationResult locationResult) {
             if (locationResult == null || positionChangedCallback == null) {
               Log.e(
-                  "Geolocator",
+                      TAG,
                   "LocationCallback was called with empty locationResult or no positionChangedCallback was registered.");
               fusedLocationProviderClient.removeLocationUpdates(locationCallback);
               if (errorCallback != null) {
@@ -140,7 +141,6 @@ class FusedLocationClient implements LocationClient {
       @NonNull PositionChangedCallback positionChangedCallback,
       @NonNull ErrorCallback errorCallback) {
 
-    this.activity = activity;
     this.positionChangedCallback = positionChangedCallback;
     this.errorCallback = errorCallback;
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
@@ -3,14 +3,12 @@ package com.baseflow.geolocator.location;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.baseflow.geolocator.errors.ErrorCallback;
 import com.baseflow.geolocator.errors.ErrorCodes;
-import com.baseflow.geolocator.errors.PermissionUndefinedException;
-import com.baseflow.geolocator.permission.LocationPermission;
-import com.baseflow.geolocator.permission.PermissionManager;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 
@@ -33,8 +31,8 @@ public class GeolocationManager
       PositionChangedCallback positionChangedCallback,
       ErrorCallback errorCallback) {
 
-      LocationClient locationClient = createLocationClient(context, forceLocationManager, null);
-      locationClient.getLastKnownPosition(positionChangedCallback, errorCallback);
+    LocationClient locationClient = createLocationClient(context, forceLocationManager, null);
+    locationClient.getLastKnownPosition(positionChangedCallback, errorCallback);
   }
 
   public void isLocationServiceEnabled(

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 3.1.3
+version: 3.1.4
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Currently when someone tries to obtain a position update stream from a different flutter engine that isn't attached to an activity an error is returned and the location updates aren't being returned.

### :new: What is the new behavior (if this is a feature change)?

This PR introduces changes that allows the geolocator foreground service to bind to the application context instead of an activity which will allow other flutter background libraries to start the service from the background in absence of an Android activity. This also now determine wether to to use our own foreground service or to just start the location updates in the service asking for the position stream.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

The position stream will now behave differently depending on whether foreground notification config has been provided. If not then a position stream is created like it used to before the foreground service was introduced, if it is provided the the foreground service is used instead for the position updates. I've introduced log messages to indicate this distinction. Other libraries like `flutter_foreground_task` should also work correctly now where a new flutter engine is created and bound to this plugin.

### :memo: Links to relevant issues/docs

https://github.com/Baseflow/flutter-geolocator/issues/1012

### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
