### PR TITLE
Switch to internal method channel for apple

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.1.6
 
-* Switches to a package-internal implementation of the platform interface.
+- Switches to a package-internal implementation of the platform interface.
 
 ## 3.1.5
 

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   geolocator_platform_interface: ^4.0.4
   
 dev_dependencies:
-  async: ^2.9.0
+  async: ^2.8.2
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.4

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.2
+
+- Switches to a package-internal implementation of the platform interface.
+
 ## 2.1.1+1
 
 - Resolves issue with symbolic links in 2.1.1 version.

--- a/geolocator_apple/ios/Classes/GeolocatorPlugin.m
+++ b/geolocator_apple/ios/Classes/GeolocatorPlugin.m
@@ -28,13 +28,13 @@
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   FlutterMethodChannel *methodChannel = [FlutterMethodChannel
-                                         methodChannelWithName:@"flutter.baseflow.com/geolocator"
+                                         methodChannelWithName:@"flutter.baseflow.com/geolocator_apple"
                                          binaryMessenger:registrar.messenger];
   FlutterEventChannel *positionUpdatesEventChannel = [FlutterEventChannel
-                                                      eventChannelWithName:@"flutter.baseflow.com/geolocator_updates"
+                                                      eventChannelWithName:@"flutter.baseflow.com/geolocator_updates_apple"
                                                       binaryMessenger:registrar.messenger];
   
-  FlutterEventChannel *locationServiceUpdatesEventChannel = [FlutterEventChannel eventChannelWithName:@"flutter.baseflow.com/geolocator_service_updates" binaryMessenger:registrar.messenger];
+  FlutterEventChannel *locationServiceUpdatesEventChannel = [FlutterEventChannel eventChannelWithName:@"flutter.baseflow.com/geolocator_service_updates_apple" binaryMessenger:registrar.messenger];
   
   GeolocatorPlugin *instance = [[GeolocatorPlugin alloc] init];
   [registrar addMethodCallDelegate:instance channel:methodChannel];

--- a/geolocator_apple/lib/geolocator_apple.dart
+++ b/geolocator_apple/lib/geolocator_apple.dart
@@ -1,2 +1,20 @@
+export 'package:geolocator_platform_interface/geolocator_platform_interface.dart'
+    show
+        ActivityMissingException,
+        AlreadySubscribedException,
+        InvalidPermissionException,
+        LocationAccuracy,
+        LocationAccuracyStatus,
+        LocationPermission,
+        LocationServiceDisabledException,
+        LocationSettings,
+        PermissionDefinitionsNotFoundException,
+        PermissionDeniedException,
+        PermissionRequestInProgressException,
+        Position,
+        PositionUpdateException,
+        ServiceStatus;
+
+export 'src/geolocator_apple.dart';
 export 'src/types/activity_type.dart';
 export 'src/types/apple_settings.dart';

--- a/geolocator_apple/lib/src/geolocator_apple.dart
+++ b/geolocator_apple/lib/src/geolocator_apple.dart
@@ -1,0 +1,249 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
+
+/// An implementation of [GeolocatorPlatform] that uses method channels.
+class GeolocatorApple extends GeolocatorPlatform {
+  /// The method channel used to interact with the native platform.
+  static const _methodChannel =
+      MethodChannel('flutter.baseflow.com/geolocator_apple');
+
+  /// The event channel used to receive [Position] updates from the native
+  /// platform.
+  static const _eventChannel =
+      EventChannel('flutter.baseflow.com/geolocator_updates_apple');
+
+  /// The event channel used to receive [LocationServiceStatus] updates from the
+  /// native platform.
+  static const _serviceStatusEventChannel =
+      EventChannel('flutter.baseflow.com/geolocator_service_updates_apple');
+
+  /// Registers this class as the default instance of [GeolocatorPlatform].
+  static void registerWith() {
+    GeolocatorPlatform.instance = GeolocatorApple();
+  }
+
+  /// On Android devices you can set [forcedLocationManager]
+  /// to true to force the plugin to use the [LocationManager] to determine the
+  /// position instead of the [FusedLocationProviderClient]. On iOS this is
+  /// ignored.
+  bool forcedLocationManager = false;
+
+  Stream<Position>? _positionStream;
+  Stream<ServiceStatus>? _serviceStatusStream;
+
+  @override
+  Future<LocationPermission> checkPermission() async {
+    try {
+      // ignore: omit_local_variable_types
+      final int permission =
+          await _methodChannel.invokeMethod('checkPermission');
+
+      return permission.toLocationPermission();
+    } on PlatformException catch (e) {
+      final error = _handlePlatformException(e);
+
+      throw error;
+    }
+  }
+
+  @override
+  Future<LocationPermission> requestPermission() async {
+    try {
+      // ignore: omit_local_variable_types
+      final int permission =
+          await _methodChannel.invokeMethod('requestPermission');
+
+      return permission.toLocationPermission();
+    } on PlatformException catch (e) {
+      final error = _handlePlatformException(e);
+
+      throw error;
+    }
+  }
+
+  @override
+  Future<bool> isLocationServiceEnabled() async => _methodChannel
+      .invokeMethod<bool>('isLocationServiceEnabled')
+      .then((value) => value ?? false);
+
+  @override
+  Future<Position?> getLastKnownPosition({
+    bool forceLocationManager = false,
+  }) async {
+    try {
+      final parameters = <String, dynamic>{
+        'forceLocationManager': forceLocationManager,
+      };
+
+      final positionMap =
+          await _methodChannel.invokeMethod('getLastKnownPosition', parameters);
+
+      return positionMap != null ? Position.fromMap(positionMap) : null;
+    } on PlatformException catch (e) {
+      final error = _handlePlatformException(e);
+
+      throw error;
+    }
+  }
+
+  @override
+  Future<LocationAccuracyStatus> getLocationAccuracy() async {
+    final int accuracy =
+        await _methodChannel.invokeMethod('getLocationAccuracy');
+    return LocationAccuracyStatus.values[accuracy];
+  }
+
+  @override
+  Future<Position> getCurrentPosition({
+    LocationSettings? locationSettings,
+  }) async {
+    try {
+      Future<dynamic> positionFuture;
+
+      var timeLimit = locationSettings?.timeLimit;
+
+      if (timeLimit != null) {
+        positionFuture = _methodChannel
+            .invokeMethod(
+              'getCurrentPosition',
+              locationSettings?.toJson(),
+            )
+            .timeout(timeLimit);
+      } else {
+        positionFuture = _methodChannel.invokeMethod(
+          'getCurrentPosition',
+          locationSettings?.toJson(),
+        );
+      }
+
+      final positionMap = await positionFuture;
+      return Position.fromMap(positionMap);
+    } on PlatformException catch (e) {
+      final error = _handlePlatformException(e);
+
+      throw error;
+    }
+  }
+
+  @override
+  Stream<ServiceStatus> getServiceStatusStream() {
+    if (_serviceStatusStream != null) {
+      return _serviceStatusStream!;
+    }
+    var serviceStatusStream =
+        _serviceStatusEventChannel.receiveBroadcastStream();
+
+    _serviceStatusStream = serviceStatusStream
+        .map((dynamic element) => ServiceStatus.values[element as int])
+        .handleError((error) {
+      _serviceStatusStream = null;
+      if (error is PlatformException) {
+        error = _handlePlatformException(error);
+      }
+      throw error;
+    });
+
+    return _serviceStatusStream!;
+  }
+
+  @override
+  Stream<Position> getPositionStream({
+    LocationSettings? locationSettings,
+  }) {
+    if (_positionStream != null) {
+      return _positionStream!;
+    }
+    var originalStream = _eventChannel.receiveBroadcastStream(
+      locationSettings?.toJson(),
+    );
+    var positionStream = _wrapStream(originalStream);
+
+    var timeLimit = locationSettings?.timeLimit;
+
+    if (timeLimit != null) {
+      positionStream = positionStream.timeout(
+        timeLimit,
+        onTimeout: (s) {
+          _positionStream = null;
+          s.addError(TimeoutException(
+            'Time limit reached while waiting for position update.',
+            timeLimit,
+          ));
+          s.close();
+        },
+      );
+    }
+
+    _positionStream = positionStream
+        .map<Position>((dynamic element) =>
+            Position.fromMap(element.cast<String, dynamic>()))
+        .handleError(
+      (error) {
+        if (error is PlatformException) {
+          error = _handlePlatformException(error);
+        }
+        throw error;
+      },
+    );
+    return _positionStream!;
+  }
+
+  Stream<dynamic> _wrapStream(Stream<dynamic> incoming) {
+    return incoming.asBroadcastStream(onCancel: (subscription) {
+      subscription.cancel();
+      _positionStream = null;
+    });
+  }
+
+  @override
+  Future<LocationAccuracyStatus> requestTemporaryFullAccuracy({
+    required String purposeKey,
+  }) async {
+    try {
+      final int status = await _methodChannel.invokeMethod(
+        'requestTemporaryFullAccuracy',
+        <String, dynamic>{
+          'purposeKey': purposeKey,
+        },
+      );
+      return LocationAccuracyStatus.values[status];
+    } on PlatformException catch (e) {
+      final error = _handlePlatformException(e);
+      throw error;
+    }
+  }
+
+  @override
+  Future<bool> openAppSettings() async => _methodChannel
+      .invokeMethod<bool>('openAppSettings')
+      .then((value) => value ?? false);
+
+  @override
+  Future<bool> openLocationSettings() async => _methodChannel
+      .invokeMethod<bool>('openLocationSettings')
+      .then((value) => value ?? false);
+
+  Exception _handlePlatformException(PlatformException exception) {
+    switch (exception.code) {
+      case 'ACTIVITY_MISSING':
+        return ActivityMissingException(exception.message);
+      case 'LOCATION_SERVICES_DISABLED':
+        return const LocationServiceDisabledException();
+      case 'LOCATION_SUBSCRIPTION_ACTIVE':
+        return const AlreadySubscribedException();
+      case 'PERMISSION_DEFINITIONS_NOT_FOUND':
+        return PermissionDefinitionsNotFoundException(exception.message);
+      case 'PERMISSION_DENIED':
+        return PermissionDeniedException(exception.message);
+      case 'PERMISSION_REQUEST_IN_PROGRESS':
+        return PermissionRequestInProgressException(exception.message);
+      case 'LOCATION_UPDATE_FAILURE':
+        return PositionUpdateException(exception.message);
+      default:
+        return exception;
+    }
+  }
+}

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -1,28 +1,31 @@
 name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
-version: 2.1.1+1
+version: 2.1.2
 repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_apple
 issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=2.8.0"
 
 flutter:
   plugin:
     platforms:
       ios:
         pluginClass: GeolocatorPlugin
+        dartPluginClass: GeolocatorApple
       macos:
         pluginClass: GeolocatorPlugin
+        dartPluginClass: GeolocatorApple
 
 dependencies:
   flutter:
     sdk: flutter
 
-  geolocator_platform_interface: ^4.0.3
+  geolocator_platform_interface: ^4.0.4
   
 dev_dependencies:
+  async: ^2.8.2
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.4

--- a/geolocator_apple/test/event_channel_mock.dart
+++ b/geolocator_apple/test/event_channel_mock.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class EventChannelMock {
+  final MethodChannel _methodChannel;
+  final log = <MethodCall>[];
+
+  Stream? stream;
+  StreamSubscription? _streamSubscription;
+
+  EventChannelMock({
+    required String channelName,
+    required this.stream,
+  }) : _methodChannel = MethodChannel(channelName) {
+    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+        .setMockMethodCallHandler(_methodChannel, _handler);
+  }
+
+  Future _handler(MethodCall methodCall) {
+    log.add(methodCall);
+
+    switch (methodCall.method) {
+      case 'listen':
+        _onListen();
+        break;
+      case 'cancel':
+        _onCancel();
+        break;
+      default:
+        return Future.value(null);
+    }
+
+    return Future.value();
+  }
+
+  void _onListen() {
+    _streamSubscription = stream!.handleError((e) {
+      _sendErrorEnvelope(e);
+    }).listen(
+      _sendSuccessEnvelope,
+      onDone: () {
+        _sendEnvelope(null);
+      },
+    );
+  }
+
+  void _onCancel() {
+    if (_streamSubscription != null) {
+      _streamSubscription!.cancel();
+      stream = null;
+    }
+  }
+
+  void _sendErrorEnvelope(Exception error) {
+    var code = "UNKNOWN_EXCEPTION";
+    String? message;
+    dynamic details;
+
+    if (error is PlatformException) {
+      code = error.code;
+      message = error.message;
+      details = error.details;
+    }
+
+    final envelope = const StandardMethodCodec()
+        .encodeErrorEnvelope(code: code, message: message, details: details);
+
+    _sendEnvelope(envelope);
+  }
+
+  void _sendSuccessEnvelope(dynamic event) {
+    final envelope = const StandardMethodCodec().encodeSuccessEnvelope(event);
+    _sendEnvelope(envelope);
+  }
+
+  void _sendEnvelope(ByteData? envelope) {
+    if (TestDefaultBinaryMessengerBinding.instance == null) {
+      return;
+    }
+
+    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+        .handlePlatformMessage(
+      _methodChannel.name,
+      envelope,
+      (_) {},
+    );
+  }
+}

--- a/geolocator_apple/test/geolocator_apple_test.dart
+++ b/geolocator_apple/test/geolocator_apple_test.dart
@@ -1,0 +1,1239 @@
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator_apple/geolocator_apple.dart';
+
+import 'event_channel_mock.dart';
+import 'method_channel_mock.dart';
+
+Position get mockPosition => Position(
+    latitude: 52.561270,
+    longitude: 5.639382,
+    timestamp: DateTime.fromMillisecondsSinceEpoch(
+      500,
+      isUtc: true,
+    ),
+    altitude: 3000.0,
+    accuracy: 0.0,
+    heading: 0.0,
+    speed: 0.0,
+    speedAccuracy: 0.0,
+    isMocked: false);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('$GeolocatorApple()', () {
+    final log = <MethodCall>[];
+
+    tearDown(log.clear);
+
+    group('checkPermission: When checking for permission', () {
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should receive whenInUse if permission is granted when App is in use',
+          () async {
+        // Arrange
+        MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator_apple',
+            method: 'checkPermission',
+            result: LocationPermission.whileInUse.index);
+
+        // Act
+        final permission = await GeolocatorApple().checkPermission();
+
+        // Assert
+        expect(
+          permission,
+          LocationPermission.whileInUse,
+        );
+      });
+
+      test('Should receive always if permission is granted always', () async {
+        // Arrange
+        MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator_apple',
+            method: 'checkPermission',
+            result: LocationPermission.always.index);
+
+        // Act
+        final permission = await GeolocatorApple().checkPermission();
+
+        // Assert
+        expect(
+          permission,
+          LocationPermission.always,
+        );
+      });
+
+      test('Should receive denied if permission is denied', () async {
+        // Arrange
+        MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator_apple',
+            method: 'checkPermission',
+            result: LocationPermission.denied.index);
+
+        // Act
+        final permission = await GeolocatorApple().checkPermission();
+
+        // Assert
+        expect(
+          permission,
+          LocationPermission.denied,
+        );
+      });
+
+      test('Should receive deniedForEver if permission is denied for ever',
+          () async {
+        // Arrange
+        MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator_apple',
+            method: 'checkPermission',
+            result: LocationPermission.deniedForever.index);
+
+        // Act
+        final permission = await GeolocatorApple().checkPermission();
+
+        // Assert
+        expect(
+          permission,
+          LocationPermission.deniedForever,
+        );
+      });
+
+      test('Should receive an exception when permission definitions not found',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'checkPermission',
+          result: PlatformException(
+            code: 'PERMISSION_DEFINITIONS_NOT_FOUND',
+            message: 'Permission definitions are not found.',
+            details: null,
+          ),
+        );
+
+        // Act
+        final permissionFuture = GeolocatorApple().checkPermission();
+
+        // Assert
+        expect(
+          permissionFuture,
+          throwsA(
+            isA<PermissionDefinitionsNotFoundException>().having(
+              (e) => e.message,
+              'description',
+              'Permission definitions are not found.',
+            ),
+          ),
+        );
+      });
+    });
+
+    group(
+        'requestTemporaryFullAccuracy: When requesting temporary full'
+        'accuracy.', () {
+      test(
+          'Should receive reduced accuracy if Location Accuracy is pinned to'
+          ' reduced', () async {
+        // Arrange
+        final methodChannel = MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator_apple',
+            method: 'requestTemporaryFullAccuracy',
+            result: 0);
+
+        final expectedArguments = <String, dynamic>{
+          'purposeKey': 'purposeKeyValue',
+        };
+
+        // Act
+        final accuracy = await GeolocatorApple().requestTemporaryFullAccuracy(
+          purposeKey: 'purposeKeyValue',
+        );
+
+        // Assert
+        expect(accuracy, LocationAccuracyStatus.reduced);
+
+        expect(methodChannel.log, <Matcher>[
+          isMethodCall(
+            'requestTemporaryFullAccuracy',
+            arguments: expectedArguments,
+          ),
+        ]);
+      });
+
+      test(
+          'Should receive reduced accuracy if Location Accuracy is already set'
+          ' to precise location accuracy', () async {
+        // Arrange
+        MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator_apple',
+            method: 'requestTemporaryFullAccuracy',
+            result: 1);
+
+        // Act
+        final accuracy = await GeolocatorApple()
+            .requestTemporaryFullAccuracy(purposeKey: 'purposeKey');
+
+        // Assert
+        expect(accuracy, LocationAccuracyStatus.precise);
+      });
+
+      test('Should receive an exception when permission definitions not found',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'requestTemporaryFullAccuracy',
+          result: PlatformException(
+            code: 'PERMISSION_DEFINITIONS_NOT_FOUND',
+            message: 'Permission definitions are not found.',
+            details: null,
+          ),
+        );
+
+        // Act
+        final future = GeolocatorApple()
+            .requestTemporaryFullAccuracy(purposeKey: 'purposeKey');
+
+        // Assert
+        expect(
+          future,
+          throwsA(
+            isA<PermissionDefinitionsNotFoundException>().having(
+              (e) => e.message,
+              'description',
+              'Permission definitions are not found.',
+            ),
+          ),
+        );
+      });
+    });
+
+    group('getLocationAccuracy: When requesting the Location Accuracy Status',
+        () {
+      test('Should receive reduced accuracy if Location Accuracy is reduced',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'getLocationAccuracy',
+          result: 0,
+        );
+
+        // Act
+        final locationAccuracy = await GeolocatorApple().getLocationAccuracy();
+
+        // Assert
+        expect(locationAccuracy, LocationAccuracyStatus.reduced);
+      });
+
+      test('Should receive reduced accuracy if Location Accuracy is reduced',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'getLocationAccuracy',
+          result: 1,
+        );
+
+        // Act
+        final locationAccuracy = await GeolocatorApple().getLocationAccuracy();
+
+        // Assert
+        expect(locationAccuracy, LocationAccuracyStatus.precise);
+      });
+    });
+
+    group('requestPermission: When requesting for permission', () {
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should receive whenInUse if permission is granted when App is in use',
+          () async {
+        // Arrange
+        MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator_apple',
+            method: 'requestPermission',
+            result: LocationPermission.whileInUse.index);
+
+        // Act
+        final permission = await GeolocatorApple().requestPermission();
+
+        // Assert
+        expect(
+          permission,
+          LocationPermission.whileInUse,
+        );
+      });
+
+      test('Should receive always if permission is granted always', () async {
+        // Arrange
+        MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator_apple',
+            method: 'requestPermission',
+            result: LocationPermission.always.index);
+
+        // Act
+        final permission = await GeolocatorApple().requestPermission();
+
+        // Assert
+        expect(
+          permission,
+          LocationPermission.always,
+        );
+      });
+
+      test('Should receive denied if permission is denied', () async {
+        // Arrange
+        MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator_apple',
+            method: 'requestPermission',
+            result: LocationPermission.denied.index);
+
+        // Act
+        final permission = await GeolocatorApple().requestPermission();
+
+        // Assert
+        expect(
+          permission,
+          LocationPermission.denied,
+        );
+      });
+
+      test('Should receive deniedForever if permission is denied for ever',
+          () async {
+        // Arrange
+        MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator_apple',
+            method: 'requestPermission',
+            result: LocationPermission.deniedForever.index);
+
+        // Act
+        final permission = await GeolocatorApple().requestPermission();
+
+        // Assert
+        expect(
+          permission,
+          LocationPermission.deniedForever,
+        );
+      });
+
+      test('Should receive an exception when already requesting permission',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'requestPermission',
+          result: PlatformException(
+            code: "PERMISSION_REQUEST_IN_PROGRESS",
+            message: "Permissions already being requested.",
+            details: null,
+          ),
+        );
+
+        // Act
+        final permissionFuture = GeolocatorApple().requestPermission();
+
+        // Assert
+        expect(
+          permissionFuture,
+          throwsA(
+            isA<PermissionRequestInProgressException>().having(
+              (e) => e.message,
+              'description',
+              'Permissions already being requested.',
+            ),
+          ),
+        );
+      });
+
+      test('Should receive an exception when permission definitions not found',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'requestPermission',
+          result: PlatformException(
+            code: 'PERMISSION_DEFINITIONS_NOT_FOUND',
+            message: 'Permission definitions are not found.',
+            details: null,
+          ),
+        );
+
+        // Act
+        final permissionFuture = GeolocatorApple().requestPermission();
+
+        // Assert
+        expect(
+          permissionFuture,
+          throwsA(
+            isA<PermissionDefinitionsNotFoundException>().having(
+              (e) => e.message,
+              'description',
+              'Permission definitions are not found.',
+            ),
+          ),
+        );
+      });
+
+      test('Should receive an exception when android activity is missing',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'requestPermission',
+          result: PlatformException(
+            code: 'ACTIVITY_MISSING',
+            message: 'Activity is missing.',
+            details: null,
+          ),
+        );
+
+        // Act
+        final permissionFuture = GeolocatorApple().requestPermission();
+
+        // Assert
+        expect(
+          permissionFuture,
+          throwsA(
+            isA<ActivityMissingException>().having(
+              (e) => e.message,
+              'description',
+              'Activity is missing.',
+            ),
+          ),
+        );
+      });
+    });
+
+    group('isLocationServiceEnabled: When checking the location service status',
+        () {
+      test('Should receive true if location services are enabled', () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'isLocationServiceEnabled',
+          result: true,
+        );
+
+        // Act
+        final isLocationServiceEnabled =
+            await GeolocatorApple().isLocationServiceEnabled();
+
+        // Assert
+        expect(
+          isLocationServiceEnabled,
+          true,
+        );
+      });
+
+      test('Should receive false if location services are disabled', () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'isLocationServiceEnabled',
+          result: false,
+        );
+
+        // Act
+        final isLocationServiceEnabled =
+            await GeolocatorApple().isLocationServiceEnabled();
+
+        // Assert
+        expect(
+          isLocationServiceEnabled,
+          false,
+        );
+      });
+    });
+
+    group('getLastKnownPosition: When requesting the last know position', () {
+      test('Should receive a position if permissions are granted', () async {
+        // Arrange
+        final methodChannel = MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'getLastKnownPosition',
+          result: mockPosition.toJson(),
+        );
+
+        final expectedArguments = <String, dynamic>{
+          "forceLocationManager": false,
+        };
+
+        // Act
+        final position = await GeolocatorApple().getLastKnownPosition(
+          forceLocationManager: false,
+        );
+
+        // Arrange
+        expect(position, mockPosition);
+        expect(methodChannel.log, <Matcher>[
+          isMethodCall(
+            'getLastKnownPosition',
+            arguments: expectedArguments,
+          ),
+        ]);
+      });
+
+      test('Should receive an exception if permissions are denied', () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'getLastKnownPosition',
+          result: PlatformException(
+            code: "PERMISSION_DENIED",
+            message: "Permission denied",
+            details: null,
+          ),
+        );
+
+        // Act
+        final future = GeolocatorApple().getLastKnownPosition(
+          forceLocationManager: false,
+        );
+
+        // Assert
+        expect(
+          future,
+          throwsA(
+            isA<PermissionDeniedException>().having(
+              (e) => e.message,
+              'description',
+              'Permission denied',
+            ),
+          ),
+        );
+      });
+    });
+
+    group('getCurrentPosition: When requesting the current position', () {
+      test('Should receive a position if permissions are granted', () async {
+        // Arrange
+        final channel = MethodChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator_apple',
+            method: 'getCurrentPosition',
+            result: mockPosition.toJson());
+        const expectedArguments =
+            LocationSettings(accuracy: LocationAccuracy.low);
+
+        // Act
+        final position = await GeolocatorApple().getCurrentPosition(
+            locationSettings:
+                const LocationSettings(accuracy: LocationAccuracy.low));
+
+        // Assert
+        expect(position, mockPosition);
+        expect(channel.log, <Matcher>[
+          isMethodCall(
+            'getCurrentPosition',
+            arguments: expectedArguments.toJson(),
+          ),
+        ]);
+      });
+
+      test('Should receive a position for each call', () async {
+        // Arrange
+        final channel = MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'getCurrentPosition',
+          result: mockPosition.toJson(),
+        );
+        const expectedFirstArguments = LocationSettings(
+          accuracy: LocationAccuracy.low,
+        );
+        const expectedSecondArguments = LocationSettings(
+          accuracy: LocationAccuracy.high,
+        );
+
+        // Act
+        final plugin = GeolocatorApple();
+        final firstPosition = await plugin.getCurrentPosition(
+            locationSettings: const LocationSettings(
+          accuracy: LocationAccuracy.low,
+        ));
+        final secondPosition = await plugin.getCurrentPosition(
+            locationSettings: const LocationSettings(
+          accuracy: LocationAccuracy.high,
+        ));
+
+        // Assert
+        expect(firstPosition, mockPosition);
+        expect(secondPosition, mockPosition);
+        expect(channel.log, <Matcher>[
+          isMethodCall(
+            'getCurrentPosition',
+            arguments: expectedFirstArguments.toJson(),
+          ),
+          isMethodCall(
+            'getCurrentPosition',
+            arguments: expectedSecondArguments.toJson(),
+          ),
+        ]);
+      });
+
+      test('Should throw a permission denied exception if permission is denied',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'getCurrentPosition',
+          result: PlatformException(
+            code: 'PERMISSION_DENIED',
+            message: 'Permission denied',
+            details: null,
+          ),
+        );
+
+        // Act
+        final future = GeolocatorApple().getCurrentPosition();
+
+        // Assert
+        expect(
+          future,
+          throwsA(
+            isA<PermissionDeniedException>().having(
+              (e) => e.message,
+              'message',
+              'Permission denied',
+            ),
+          ),
+        );
+      });
+
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should throw a location service disabled exception if location services are disabled',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'getCurrentPosition',
+          result: PlatformException(
+            code: 'LOCATION_SERVICES_DISABLED',
+            message: '',
+            details: null,
+          ),
+        );
+
+        // Act
+        final future = GeolocatorApple().getCurrentPosition();
+
+        // Assert
+        expect(
+          future,
+          throwsA(isA<LocationServiceDisabledException>()),
+        );
+      });
+
+      test('Should throw a timeout exception when timeLimit is reached',
+          () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          delay: const Duration(milliseconds: 10),
+          method: 'getCurrentPosition',
+          result: mockPosition.toJson(),
+        );
+
+        try {
+          await GeolocatorApple().getCurrentPosition(
+            locationSettings: const LocationSettings(
+              timeLimit: Duration(milliseconds: 5),
+            ),
+          );
+
+          fail('Expected a TimeoutException and should not reach here.');
+        } on TimeoutException catch (e) {
+          expect(e, isA<TimeoutException>());
+        }
+      });
+    });
+
+    group('getPositionStream: When requesting a stream of position updates',
+        () {
+      group('And requesting for position update multiple times', () {
+        test('Should return the same stream', () {
+          final plugin = GeolocatorApple();
+          final firstStream = plugin.getPositionStream();
+          final secondStream = plugin.getPositionStream();
+
+          expect(
+            identical(firstStream, secondStream),
+            true,
+          );
+        });
+
+        test('Should return a new stream when all subscriptions are cancelled',
+            () {
+          final plugin = GeolocatorApple();
+
+          // Get two position streams
+          final firstStream = plugin.getPositionStream();
+          final secondStream = plugin.getPositionStream();
+
+          // Streams are the same object
+          expect(firstStream == secondStream, true);
+
+          // Add multiple subscriptions
+          StreamSubscription<Position>? firstSubscription =
+              firstStream.listen((event) {});
+          StreamSubscription<Position>? secondSubscription =
+              secondStream.listen((event) {});
+
+          // Cancel first subscription
+          firstSubscription.cancel();
+          firstSubscription = null;
+
+          // Stream is still the same as the first one
+          final cachedStream = plugin.getPositionStream();
+          expect(firstStream == cachedStream, true);
+
+          // Cancel second subscription
+          secondSubscription.cancel();
+          secondSubscription = null;
+
+          // After all listeners have been removed, the next stream
+          // retrieved is a new one.
+          final thirdStream = plugin.getPositionStream();
+          expect(firstStream != thirdStream, true);
+        });
+      });
+
+      test('PositionStream can be listened to and can be canceled', () {
+        // Arrange
+        final streamController =
+            StreamController<Map<String, dynamic>>.broadcast();
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_updates_apple',
+          stream: streamController.stream,
+        );
+
+        var stream = GeolocatorApple().getPositionStream();
+        StreamSubscription<Position>? streamSubscription =
+            stream.listen((event) {});
+
+        streamSubscription.pause();
+        expect(streamSubscription.isPaused, true);
+        streamSubscription.resume();
+        expect(streamSubscription.isPaused, false);
+        streamSubscription.cancel();
+        streamSubscription = null;
+      });
+
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should correctly handle done event', () async {
+        // Arrange
+        final completer = Completer();
+        completer.future.timeout(const Duration(milliseconds: 50),
+            onTimeout: () =>
+                fail('getPositionStream should trigger done and not timeout.'));
+        final streamController =
+            StreamController<Map<String, dynamic>>.broadcast();
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_updates_apple',
+          stream: streamController.stream,
+        );
+
+        // Act
+        GeolocatorApple().getPositionStream().listen(
+              (event) {},
+              onDone: completer.complete,
+            );
+
+        await streamController.close();
+
+        //Assert
+        await completer.future;
+      });
+
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should receive a stream with position updates if permissions are granted',
+          () async {
+        // Arrange
+        final streamController =
+            StreamController<Map<String, dynamic>>.broadcast();
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_updates_apple',
+          stream: streamController.stream,
+        );
+
+        // Act
+        final positionStream = GeolocatorApple().getPositionStream();
+        final streamQueue = StreamQueue(positionStream);
+
+        // Emit test events
+        streamController.add(mockPosition.toJson());
+        streamController.add(mockPosition.toJson());
+        streamController.add(mockPosition.toJson());
+
+        // Assert
+        expect(await streamQueue.next, mockPosition);
+        expect(await streamQueue.next, mockPosition);
+        expect(await streamQueue.next, mockPosition);
+
+        // Clean up
+        await streamQueue.cancel();
+        await streamController.close();
+      });
+
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should continue listening to the stream when exception is thrown ',
+          () async {
+        // Arrange
+        final streamController =
+            StreamController<Map<String, dynamic>>.broadcast();
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_updates_apple',
+          stream: streamController.stream,
+        );
+
+        // Act
+        final positionStream = GeolocatorApple().getPositionStream();
+        final streamQueue = StreamQueue(positionStream);
+
+        // Emit test events
+        streamController.add(mockPosition.toJson());
+        streamController.addError(PlatformException(
+            code: 'PERMISSION_DENIED',
+            message: 'Permission denied',
+            details: null));
+        streamController.add(mockPosition.toJson());
+
+        // Assert
+        expect(await streamQueue.next, mockPosition);
+        expect(
+            streamQueue.next,
+            throwsA(
+              isA<PermissionDeniedException>().having(
+                (e) => e.message,
+                'message',
+                'Permission denied',
+              ),
+            ));
+        expect(await streamQueue.next, mockPosition);
+
+        // Clean up
+        await streamQueue.cancel();
+        await streamController.close();
+      });
+
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should receive a permission denied exception if permission is denied',
+          () async {
+        // Arrange
+        final streamController =
+            StreamController<PlatformException>.broadcast();
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_updates_apple',
+          stream: streamController.stream,
+        );
+
+        // Act
+        final positionStream = GeolocatorApple().getPositionStream();
+        final streamQueue = StreamQueue(positionStream);
+
+        // Emit test error
+        streamController.addError(PlatformException(
+            code: 'PERMISSION_DENIED',
+            message: 'Permission denied',
+            details: null));
+
+        // Assert
+        expect(
+            streamQueue.next,
+            throwsA(
+              isA<PermissionDeniedException>().having(
+                (e) => e.message,
+                'message',
+                'Permission denied',
+              ),
+            ));
+
+        // Clean up
+        streamQueue.cancel();
+        streamController.close();
+      });
+
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should receive a location service disabled exception if location service is disabled',
+          () async {
+        // Arrange
+        final streamController =
+            StreamController<PlatformException>.broadcast();
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_updates_apple',
+          stream: streamController.stream,
+        );
+
+        // Act
+        final positionStream = GeolocatorApple().getPositionStream();
+        final streamQueue = StreamQueue(positionStream);
+
+        // Emit test error
+        streamController.addError(PlatformException(
+            code: 'LOCATION_SERVICES_DISABLED',
+            message: 'Location services disabled',
+            details: null));
+
+        // Assert
+        expect(
+            streamQueue.next,
+            throwsA(
+              isA<LocationServiceDisabledException>(),
+            ));
+
+        // Clean up
+        streamQueue.cancel();
+        streamController.close();
+      });
+
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should receive a already subscribed exception', () async {
+        // Arrange
+        final streamController =
+            StreamController<PlatformException>.broadcast();
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_updates_apple',
+          stream: streamController.stream,
+        );
+
+        // Act
+        final positionStream = GeolocatorApple().getPositionStream();
+        final streamQueue = StreamQueue(positionStream);
+
+        // Emit test error
+        streamController.addError(PlatformException(
+            code: 'PERMISSION_REQUEST_IN_PROGRESS',
+            message: 'A permission request is already in progress',
+            details: null));
+
+        // Assert
+        expect(
+            streamQueue.next,
+            throwsA(
+              isA<PermissionRequestInProgressException>(),
+            ));
+
+        // Clean up
+        streamQueue.cancel();
+        streamController.close();
+      });
+
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should receive a already subscribed exception', () async {
+        // Arrange
+        final streamController =
+            StreamController<PlatformException>.broadcast();
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_updates_apple',
+          stream: streamController.stream,
+        );
+
+        // Act
+        final positionStream = GeolocatorApple().getPositionStream();
+        final streamQueue = StreamQueue(positionStream);
+
+        // Emit test error
+        streamController.addError(PlatformException(
+            code: 'LOCATION_SUBSCRIPTION_ACTIVE',
+            message: 'Already subscribed to receive a position stream',
+            details: null));
+
+        // Assert
+        expect(
+            streamQueue.next,
+            throwsA(
+              isA<AlreadySubscribedException>(),
+            ));
+
+        // Clean up
+        streamQueue.cancel();
+        streamController.close();
+      });
+
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should receive a position update exception', () async {
+        // Arrange
+        final streamController =
+            StreamController<PlatformException>.broadcast();
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_updates_apple',
+          stream: streamController.stream,
+        );
+
+        // Act
+        final positionStream = GeolocatorApple().getPositionStream();
+        final streamQueue = StreamQueue(positionStream);
+
+        // Emit test error
+        streamController.addError(PlatformException(
+            code: 'LOCATION_UPDATE_FAILURE',
+            message: 'A permission request is already in progress',
+            details: null));
+
+        // Assert
+        expect(
+            streamQueue.next,
+            throwsA(
+              isA<PositionUpdateException>(),
+            ));
+
+        // Clean up
+        streamQueue.cancel();
+        streamController.close();
+      });
+
+      test('Should throw a timeout exception when timeLimit is reached',
+          () async {
+        // Arrange
+        final streamController = StreamController<Map<String, dynamic>>();
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_updates_apple',
+          stream: streamController.stream,
+        );
+        const expectedArguments = LocationSettings(
+          accuracy: LocationAccuracy.low,
+          distanceFilter: 0,
+        );
+
+        // Act
+        final positionStream = GeolocatorApple().getPositionStream(
+          locationSettings: LocationSettings(
+            accuracy: expectedArguments.accuracy,
+            timeLimit: const Duration(milliseconds: 5),
+          ),
+        );
+        final streamQueue = StreamQueue(positionStream);
+
+        streamController.add(mockPosition.toJson());
+
+        await Future.delayed(const Duration(milliseconds: 5));
+
+        // Assert
+        expect(await streamQueue.next, mockPosition);
+        expect(streamQueue.next, throwsA(isA<TimeoutException>()));
+      });
+
+      test('Should cleanup the previous stream on timeout exception', () async {
+        // Arrange
+        final streamController = StreamController<Map<String, dynamic>>();
+        final retryController = StreamController<Map<String, dynamic>>();
+        late Stream<Position> retryStream;
+
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_updates_apple',
+          stream: streamController.stream,
+        );
+        const locationSettings = LocationSettings(
+          accuracy: LocationAccuracy.low,
+          timeLimit: Duration(milliseconds: 5),
+        );
+
+        final geolocator = GeolocatorApple();
+
+        // Act
+        final positionStream = geolocator.getPositionStream(
+          locationSettings: locationSettings,
+        );
+
+        final subscription = positionStream.listen((event) {});
+
+        // Listen for position changes again on timeout
+        subscription.onError((err) {
+          EventChannelMock(
+            channelName: 'flutter.baseflow.com/geolocator_updates_apple',
+            stream: retryController.stream,
+          );
+          retryStream = geolocator.getPositionStream(
+            locationSettings: locationSettings,
+          );
+        });
+
+        await Future.delayed(const Duration(milliseconds: 5));
+
+        final streamQueue = StreamQueue(retryStream);
+        retryController.add(mockPosition.toJson());
+
+        // Assert
+
+        // If previous stream is not properly cleaned up this will have no elements
+        expect(await streamQueue.next, mockPosition);
+      });
+    });
+
+    group(
+        // ignore: lines_longer_than_80_chars
+        'getServiceStream: When requesting a stream of location service status updates',
+        () {
+      group('And requesting for location service status updates multiple times',
+          () {
+        test('Should return the same stream', () {
+          final plugin = GeolocatorApple();
+          final firstStream = plugin.getServiceStatusStream();
+          final secondstream = plugin.getServiceStatusStream();
+
+          expect(
+            identical(firstStream, secondstream),
+            true,
+          );
+        });
+      });
+
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should receive a stream with location service updates if permissions are granted',
+          () async {
+        // Arrange
+        final streamController = StreamController<int>.broadcast();
+        EventChannelMock(
+            channelName:
+                'flutter.baseflow.com/geolocator_service_updates_apple',
+            stream: streamController.stream);
+
+        // Act
+        final locationServiceStream =
+            GeolocatorApple().getServiceStatusStream();
+        final streamQueue = StreamQueue(locationServiceStream);
+
+        // Emit test events
+        streamController.add(0); // disabled value in native enum
+        streamController.add(1); // enabled value in native enum
+
+        //Assert
+        expect(await streamQueue.next, ServiceStatus.disabled);
+        expect(await streamQueue.next, ServiceStatus.enabled);
+
+        // Clean up
+        await streamQueue.cancel();
+        await streamController.close();
+      });
+
+      test(
+          // ignore: lines_longer_than_80_chars
+          'Should receive an exception if android activity is missing',
+          () async {
+        // Arrange
+        final streamController =
+            StreamController<PlatformException>.broadcast();
+        EventChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_service_updates_apple',
+          stream: streamController.stream,
+        );
+
+        // Act
+        final positionStream = GeolocatorApple().getServiceStatusStream();
+        final streamQueue = StreamQueue(positionStream);
+
+        // Emit test error
+        streamController.addError(PlatformException(
+            code: 'ACTIVITY_MISSING',
+            message: 'Activity missing',
+            details: null));
+
+        // Assert
+        expect(
+            streamQueue.next,
+            throwsA(
+              isA<ActivityMissingException>().having(
+                (e) => e.message,
+                'message',
+                'Activity missing',
+              ),
+            ));
+
+        // Clean up
+        streamQueue.cancel();
+        streamController.close();
+      });
+    });
+
+    group('openAppSettings: When opening the App settings', () {
+      test('Should receive true if the page can be opened', () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'openAppSettings',
+          result: true,
+        );
+
+        // Act
+        final hasOpenedAppSettings = await GeolocatorApple().openAppSettings();
+
+        // Assert
+        expect(
+          hasOpenedAppSettings,
+          true,
+        );
+      });
+
+      test('Should receive false if an error occurred', () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'openAppSettings',
+          result: false,
+        );
+
+        // Act
+        final hasOpenedAppSettings = await GeolocatorApple().openAppSettings();
+
+        // Assert
+        expect(
+          hasOpenedAppSettings,
+          false,
+        );
+      });
+    });
+
+    group('openLocationSettings: When opening the Location settings', () {
+      test('Should receive true if the page can be opened', () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'openLocationSettings',
+          result: true,
+        );
+
+        // Act
+        final hasOpenedLocationSettings =
+            await GeolocatorApple().openLocationSettings();
+
+        // Assert
+        expect(
+          hasOpenedLocationSettings,
+          true,
+        );
+      });
+
+      test('Should receive false if an error occurred', () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_apple',
+          method: 'openLocationSettings',
+          result: false,
+        );
+
+        // Act
+        final hasOpenedLocationSettings =
+            await GeolocatorApple().openLocationSettings();
+
+        // Assert
+        expect(
+          hasOpenedLocationSettings,
+          false,
+        );
+      });
+    });
+  });
+}

--- a/geolocator_apple/test/method_channel_mock.dart
+++ b/geolocator_apple/test/method_channel_mock.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class MethodChannelMock {
+  final Duration delay;
+  final MethodChannel methodChannel;
+  final String method;
+  final dynamic result;
+  final log = <MethodCall>[];
+
+  MethodChannelMock({
+    required String channelName,
+    required this.method,
+    this.delay = Duration.zero,
+    this.result,
+  }) : methodChannel = MethodChannel(channelName) {
+    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+        .setMockMethodCallHandler(methodChannel, _handler);
+  }
+
+  Future _handler(MethodCall methodCall) async {
+    log.add(methodCall);
+
+    if (methodCall.method != method) {
+      throw MissingPluginException('No implementation found for method '
+          '$method on channel ${methodChannel.name}');
+    }
+
+    return Future.delayed(delay, () {
+      if (result is Exception) {
+        throw result;
+      }
+
+      return Future.value(result);
+    });
+  }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

The iOS and macOS implementations currently use the default method channel implementation from the geolocator_platform_interface.

### :new: What is the new behavior (if this is a feature change)?

Switches the geolocator_apple package to an internal implementation allowing for easier implementation of Apple specific logic.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
