### PR TITLE
Add unit-test step to Android and iOS jobs

### DIFF
--- a/.github/workflows/geolocator_android.yaml
+++ b/.github/workflows/geolocator_android.yaml
@@ -108,3 +108,38 @@ jobs:
       - name: Run Android build
         run: flutter build apk --release
         working-directory: ${{env.example-directory}}
+
+  tests:
+    name: Unit-tests
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    env:
+      source-directory: ./geolocator_android
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      # Make sure the stable version of Flutter is available
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: 'stable'
+
+      # Download all Flutter packages
+      - name: Download dependencies
+        run: flutter pub get
+        working-directory: ${{env.source-directory}}
+      
+      # Run all unit-tests with code coverage
+      - name: Run unit tests
+        run: flutter test --coverage
+        working-directory: ${{env.source-directory}}
+
+      # Upload code coverage information
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ${{env.source-directory}}/coverage/lcov.info # optional
+          name: Geolocator (App Facing Package) # optional
+          fail_ci_if_error: true

--- a/.github/workflows/geolocator_apple.yaml
+++ b/.github/workflows/geolocator_apple.yaml
@@ -138,6 +138,41 @@ jobs:
         run: flutter build macos --release
         working-directory: ${{env.example-directory}}
 
+  tests:
+    name: Unit-tests
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    env:
+      source-directory: ./geolocator_apple
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      # Make sure the stable version of Flutter is available
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: 'stable'
+
+      # Download all Flutter packages
+      - name: Download dependencies
+        run: flutter pub get
+        working-directory: ${{env.source-directory}}
+      
+      # Run all unit-tests with code coverage
+      - name: Run unit tests
+        run: flutter test --coverage
+        working-directory: ${{env.source-directory}}
+
+      # Upload code coverage information
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ${{env.source-directory}}/coverage/lcov.info # optional
+          name: Geolocator (App Facing Package) # optional
+          fail_ci_if_error: true
+
   test_ios_native:
     name: Test iOS code base
     


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Maintenance

### :arrow_heading_down: What is the current behavior?

The geolocator_android and geolocator_apple package includes unit tests but are not run in CI

### :new: What is the new behavior (if this is a feature change)?

Add unit-test steps in CI for geolocator_android and geolocator_apple packages.

### :boom: Does this PR introduce a breaking change?

no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
