### PR TITLE
Fixes repository URL in package meta data

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.2.1
+
+- Fixes repository URL of the package.
+
 ## 8.2.0
 
 - Adds support to make a foreground service on Android and continue processing location updates when the application is moved into the background.

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -1,8 +1,8 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 8.2.0
-repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator
-issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
+repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator
+issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
+version: 8.2.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.7
+
+- Fixes repository URL of the package.
+
 ## 3.1.6
 
 - Switches to a package-internal implementation of the platform interface.

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -1,8 +1,8 @@
 name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
-version: 3.1.6
-repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_android
-issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
+repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
+issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
+version: 3.1.7
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+- Fixes repository URL of the package.
+
 ## 2.1.2
 
 - Switches to a package-internal implementation of the platform interface.

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -1,8 +1,8 @@
 name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
-version: 2.1.2
-repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_apple
-issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
+repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
+issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
+version: 2.1.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/geolocator_linux/CHANGELOG.md
+++ b/geolocator_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Fixes repository URL of the package.
+
 ## 0.1.0
 
 - Initial implementation for Linux.

--- a/geolocator_linux/pubspec.yaml
+++ b/geolocator_linux/pubspec.yaml
@@ -1,9 +1,9 @@
 name: geolocator_linux
 description: Geolocation Linux plugin for Flutter. This plugin provides the
   Linux implementation for the geolocator.
-version: 0.1.0
-repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_linux
-issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
+repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_linux
+issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
+version: 0.1.1
 
 environment:
   sdk: ">=2.15.0 <3.0.0"

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.5
+
+- Fixes repository URL of the package.
+
 ## 4.0.4
 
 - Fixes a bug where listening to the position stream immediately after an error, results in listening to a dead stream. 

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -1,9 +1,9 @@
 name: geolocator_platform_interface
 description: A common platform interface for the geolocator plugin.
-homepage: https://github.com/baseflow/flutter-geolocator
+repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.0.4
+version: 4.0.5
 
 dependencies:
   flutter:

--- a/geolocator_windows/CHANGELOG.md
+++ b/geolocator_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Fixes repository URL of the package.
+
 ## 0.1.0
 
 - Adds an initial implementation of Windows support for the geolocator plugin.

--- a/geolocator_windows/pubspec.yaml
+++ b/geolocator_windows/pubspec.yaml
@@ -1,8 +1,8 @@
 name: geolocator_windows
 description: Geolocation Windows plugin for Flutter. This plugin provides the Windows implementation for the geolocator.
-version: 0.1.0
-repository: https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator_windows
-issue_tracker: https://github.com/Baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
+repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_windows
+issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
+version: 0.1.1
 
 environment:
   sdk: ">=2.15.0 <3.0.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

The repository URL in the pubspec.yaml (packages meta data) is no longer valid.

### :new: What is the new behavior (if this is a feature change)?

Point URL to the correct location.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [ ] I rebased onto current `master`.
