### PR TITLE
MSL Altitude on Android

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -25,6 +25,10 @@
 - Removes deprecated `android.enableR8` property from gradle properties.
 - Updates the example application to request permissions when start listening to the position stream.
 
+## 3.1.9
+
+- Adds the ability to report altitude as MSL obtained from NMEA messages when available.
+
 ## 3.1.8
 
 - Ensures that when Google mobile services are globally excluded as a dependency to automatically fallback to the Android LocationManager.

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.0
+
+- Adds the ability to report altitude as MSL obtained from NMEA messages when available.
+
 ## 4.0.2
 
 - Fix nullpointer in `MethodCallHandlerImpl.getLocationAccuracy`
@@ -8,7 +12,8 @@
 
 ## 4.0.0
 
-> **IMPORTANT:** when updating to version 4.0.0 make sure to also set the `compileSdkVersion` in the `android/app/build.gradle` file to `33`.
+> **IMPORTANT:** when updating to version 4.0.0 make sure to also set the `compileSdkVersion` in
+> the `android/app/build.gradle` file to `33`.
 
 - Set android `compileSdkVersion` to `33` (Android 13);
 - Fixed the deprecation warnings/errors which caused the compilation to fail when using `compileSdkVersion 33`.
@@ -16,12 +21,8 @@
 
 ## 3.2.1
 
-- Use `java.security.SecureRandom` instead of `java.util.Random` to ensure the 
-`ActivityRequest` identifier is generated in a cryptographically strong fasion.
-
-## 3.2.1
-
-- Adds the ability to report altitude as MSL obtained from NMEA messages when available.
+- Use `java.security.SecureRandom` instead of `java.util.Random` to ensure the
+  `ActivityRequest` identifier is generated in a cryptographically strong fasion.
 
 ## 3.2.0
 

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -19,19 +19,20 @@
 - Use `java.security.SecureRandom` instead of `java.util.Random` to ensure the 
 `ActivityRequest` identifier is generated in a cryptographically strong fasion.
 
+## 3.2.1
+
+- Adds the ability to report altitude as MSL obtained from NMEA messages when available.
+
 ## 3.2.0
 
 - Raises minimum Dart version to 2.17 and Flutter version to 3.0.0.
 - Removes deprecated `android.enableR8` property from gradle properties.
 - Updates the example application to request permissions when start listening to the position stream.
 
-## 3.1.9
-
-- Adds the ability to report altitude as MSL obtained from NMEA messages when available.
-
 ## 3.1.8
 
-- Ensures that when Google mobile services are globally excluded as a dependency to automatically fallback to the Android LocationManager.
+- Ensures that when Google mobile services are globally excluded as a dependency to automatically fallback to the
+  Android LocationManager.
 
 ## 3.1.7
 
@@ -63,7 +64,8 @@
 
 ## 3.1.0
 
-- Adds support to make a foreground service and continue processing location updates when the application is moved into the background.
+- Adds support to make a foreground service and continue processing location updates when the application is moved into
+  the background.
 
 ## 3.0.4
 
@@ -71,7 +73,8 @@
 
 ## 3.0.3
 
-- Added a default `intervalDuration` value of 5000ms to prevent the `getCurrentPosition` method to return a cached Location.
+- Added a default `intervalDuration` value of 5000ms to prevent the `getCurrentPosition` method to return a cached
+  Location.
 
 ## 3.0.2
 
@@ -107,22 +110,28 @@
 
 - Added Approximate Location support for Android 12;
 - Added support to request the location accuracy on Android through the `Geolocator.getLocationAccuracy()` method;
-- Make sure the `getServiceStatusStream` method returns an event when initially the Service Status is enabled on Android Devices (see issue[#812](https://github.com/Baseflow/flutter-geolocator/issues/812).
+- Make sure the `getServiceStatusStream` method returns an event when initially the Service Status is enabled on Android
+  Devices (see issue[#812](https://github.com/Baseflow/flutter-geolocator/issues/812).
 
 ## 2.0.0
 
-> **IMPORTANT:** when updating to version 2.0.0 make sure to also set the compileSdkVersion in the app/build.gradle file to 31.
+> **IMPORTANT:** when updating to version 2.0.0 make sure to also set the compileSdkVersion in the app/build.gradle file
+> to 31.
 
 - Set Android `compileSdkVersion` to `31` (Android 12);
-- Fixed the deprecation warnings/errors which caused the `flutter build appbundle` to fail when using `compileSdkVersion 31`.
+- Fixed the deprecation warnings/errors which caused the `flutter build appbundle` to fail when
+  using `compileSdkVersion 31`.
 
 ## 1.0.2
 
-- Fixed **didChangeAppLifecycleState** goes into a loop after location request (see issue: https://github.com/Baseflow/flutter-geolocator/issues/816).
+- Fixed **didChangeAppLifecycleState** goes into a loop after location request (see
+  issue: https://github.com/Baseflow/flutter-geolocator/issues/816).
 
 ## 1.0.1
 
-- Migrate to mavenCentral as jFrog has sunset jCenter (see [official announcement](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter) for more details);
+- Migrate to mavenCentral as jFrog has sunset jCenter (
+  see [official announcement](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter) for more
+  details);
 - Upgrade to Gradle 4.1.0 to stay in sync with current stable version of Flutter.
 
 ## 1.0.0

--- a/geolocator_android/android/build.gradle
+++ b/geolocator_android/android/build.gradle
@@ -1,6 +1,6 @@
 group 'com.baseflow.geolocator'
 version '1.0'
-def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
+def args = ["-Xlint:deprecation", "-Xlint:unchecked", "-Werror"]
 
 buildscript {
     repositories {
@@ -20,7 +20,7 @@ rootProject.allprojects {
     }
 }
 
-project.getTasks().withType(JavaCompile){
+project.getTasks().withType(JavaCompile) {
     options.compilerArgs.addAll(args)
 }
 
@@ -42,6 +42,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-location:17.0.0'
-    implementation 'androidx.core:core:1.2.0'
+    implementation 'com.google.android.gms:play-services-location:20.0.0'
+    implementation 'androidx.core:core:1.8.0'
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -129,6 +129,7 @@ public class GeolocatorLocationService extends Service {
     obtainWakeLocks(options);
   }
 
+  @SuppressWarnings("deprecation")
   public void disableBackgroundMode() {
     if (isForeground) {
       Log.d(TAG, "Stop service in foreground.");
@@ -136,7 +137,6 @@ public class GeolocatorLocationService extends Service {
             stopForeground(ONGOING_NOTIFICATION_ID);
         }
         else {
-            //noinspection deprecation
             stopForeground(true);
         }
         releaseWakeLocks();

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -136,6 +136,7 @@ public class GeolocatorLocationService extends Service {
             stopForeground(ONGOING_NOTIFICATION_ID);
         }
         else {
+            //noinspection
             stopForeground(true);
         }
         releaseWakeLocks();

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -136,7 +136,7 @@ public class GeolocatorLocationService extends Service {
             stopForeground(ONGOING_NOTIFICATION_ID);
         }
         else {
-            //noinspection
+            //noinspection deprecation
             stopForeground(true);
         }
         releaseWakeLocks();

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.location.Location;
 import android.net.wifi.WifiManager;
 import android.os.Binder;
+import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
 import android.util.Log;
@@ -131,8 +132,13 @@ public class GeolocatorLocationService extends Service {
   public void disableBackgroundMode() {
     if (isForeground) {
       Log.d(TAG, "Stop service in foreground.");
-      stopForeground(ONGOING_NOTIFICATION_ID);
-      releaseWakeLocks();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            stopForeground(ONGOING_NOTIFICATION_ID);
+        }
+        else {
+            stopForeground(true);
+        }
+        releaseWakeLocks();
       isForeground = false;
       backgroundNotification = null;
     }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -7,8 +7,10 @@ import android.content.IntentSender;
 import android.location.Location;
 import android.os.Looper;
 import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.baseflow.geolocator.errors.ErrorCallback;
 import com.baseflow.geolocator.errors.ErrorCodes;
 import com.google.android.gms.common.api.ApiException;
@@ -17,11 +19,12 @@ import com.google.android.gms.location.*;
 import java.security.SecureRandom;
 
 class FusedLocationClient implements LocationClient {
-    private static final String TAG = "FlutterGeolocator";
+  private static final String TAG = "FlutterGeolocator";
 
   private final Context context;
   private final LocationCallback locationCallback;
   private final FusedLocationProviderClient fusedLocationProviderClient;
+  private final NmeaClient nmeaClient;
   private final int activityRequestCode;
   @Nullable private final LocationOptions locationOptions;
 
@@ -32,6 +35,7 @@ class FusedLocationClient implements LocationClient {
     this.context = context;
     this.fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(context);
     this.locationOptions = locationOptions;
+    this.nmeaClient = new NmeaClient(context, locationOptions);
     this.activityRequestCode = generateActivityRequestCode();
 
     locationCallback =
@@ -40,7 +44,7 @@ class FusedLocationClient implements LocationClient {
           public synchronized void onLocationResult(LocationResult locationResult) {
             if (locationResult == null || positionChangedCallback == null) {
               Log.e(
-                      TAG,
+                  TAG,
                   "LocationCallback was called with empty locationResult or no positionChangedCallback was registered.");
               fusedLocationProviderClient.removeLocationUpdates(locationCallback);
               if (errorCallback != null) {
@@ -50,6 +54,7 @@ class FusedLocationClient implements LocationClient {
             }
 
             Location location = locationResult.getLastLocation();
+            nmeaClient.enrichExtrasWithNmea(location);
             positionChangedCallback.onPositionChanged(location);
           }
 
@@ -65,6 +70,40 @@ class FusedLocationClient implements LocationClient {
         };
   }
 
+  private static LocationRequest buildLocationRequest(@Nullable LocationOptions options) {
+    LocationRequest locationRequest = new LocationRequest();
+
+    if (options != null) {
+      locationRequest.setPriority(toPriority(options.getAccuracy()));
+      locationRequest.setInterval(options.getTimeInterval());
+      locationRequest.setFastestInterval(options.getTimeInterval() / 2);
+      locationRequest.setSmallestDisplacement(options.getDistanceFilter());
+    }
+
+    return locationRequest;
+  }
+
+  private static LocationSettingsRequest buildLocationSettingsRequest(
+      LocationRequest locationRequest) {
+    LocationSettingsRequest.Builder builder = new LocationSettingsRequest.Builder();
+    builder.addLocationRequest(locationRequest);
+
+    return builder.build();
+  }
+
+  private static int toPriority(LocationAccuracy locationAccuracy) {
+    switch (locationAccuracy) {
+      case lowest:
+        return LocationRequest.PRIORITY_NO_POWER;
+      case low:
+        return LocationRequest.PRIORITY_LOW_POWER;
+      case medium:
+        return LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY;
+      default:
+        return LocationRequest.PRIORITY_HIGH_ACCURACY;
+    }
+  }
+
   private synchronized int generateActivityRequestCode() {
     SecureRandom random = new SecureRandom();
     return random.nextInt(1 << 16);
@@ -73,8 +112,9 @@ class FusedLocationClient implements LocationClient {
   @SuppressLint("MissingPermission")
   private void requestPositionUpdates(LocationOptions locationOptions) {
     LocationRequest locationRequest = buildLocationRequest(locationOptions);
+    this.nmeaClient.start();
     fusedLocationProviderClient.requestLocationUpdates(
-            locationRequest, locationCallback, Looper.getMainLooper());
+        locationRequest, locationCallback, Looper.getMainLooper());
   }
 
   @Override
@@ -151,9 +191,7 @@ class FusedLocationClient implements LocationClient {
     settingsClient
         .checkLocationSettings(settingsRequest)
         .addOnSuccessListener(
-            locationSettingsResponse ->
-                requestPositionUpdates(this.locationOptions)
-        )
+            locationSettingsResponse -> requestPositionUpdates(this.locationOptions))
         .addOnFailureListener(
             e -> {
               if (e instanceof ResolvableApiException) {
@@ -192,40 +230,7 @@ class FusedLocationClient implements LocationClient {
   }
 
   public void stopPositionUpdates() {
+    this.nmeaClient.stop();
     fusedLocationProviderClient.removeLocationUpdates(locationCallback);
-  }
-
-  private static LocationRequest buildLocationRequest(@Nullable LocationOptions options) {
-    LocationRequest locationRequest = new LocationRequest();
-
-    if (options != null) {
-      locationRequest.setPriority(toPriority(options.getAccuracy()));
-      locationRequest.setInterval(options.getTimeInterval());
-      locationRequest.setFastestInterval(options.getTimeInterval() / 2);
-      locationRequest.setSmallestDisplacement(options.getDistanceFilter());
-    }
-
-    return locationRequest;
-  }
-
-  private static LocationSettingsRequest buildLocationSettingsRequest(
-      LocationRequest locationRequest) {
-    LocationSettingsRequest.Builder builder = new LocationSettingsRequest.Builder();
-    builder.addLocationRequest(locationRequest);
-
-    return builder.build();
-  }
-
-  private static int toPriority(LocationAccuracy locationAccuracy) {
-    switch (locationAccuracy) {
-      case lowest:
-        return LocationRequest.PRIORITY_NO_POWER;
-      case low:
-        return LocationRequest.PRIORITY_LOW_POWER;
-      case medium:
-        return LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY;
-      default:
-        return LocationRequest.PRIORITY_HIGH_ACCURACY;
-    }
   }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationMapper.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationMapper.java
@@ -34,6 +34,12 @@ public class LocationMapper {
       position.put("is_mocked", false);
     }
 
+    if (location.getExtras() != null) {
+      if (location.getExtras().containsKey(NmeaClient.NMEA_ALTITUDE_EXTRA)) {
+        Double mslAltitude = location.getExtras().getDouble(NmeaClient.NMEA_ALTITUDE_EXTRA);
+        position.put("altitude", mslAltitude);
+      }
+    }
     return position;
   }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationOptions.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationOptions.java
@@ -6,15 +6,25 @@ public class LocationOptions {
   private final LocationAccuracy accuracy;
   private final long distanceFilter;
   private final long timeInterval;
+  private final boolean useMSLAltitude;
+
+  private LocationOptions(
+      LocationAccuracy accuracy, long distanceFilter, long timeInterval, boolean useMSLAltitude) {
+    this.accuracy = accuracy;
+    this.distanceFilter = distanceFilter;
+    this.timeInterval = timeInterval;
+    this.useMSLAltitude = useMSLAltitude;
+  }
 
   public static LocationOptions parseArguments(Map<String, Object> arguments) {
     if (arguments == null) {
-      return new LocationOptions(LocationAccuracy.best, 0, 5000);
+      return new LocationOptions(LocationAccuracy.best, 0, 5000, false);
     }
 
     final Integer accuracy = (Integer) arguments.get("accuracy");
     final Integer distanceFilter = (Integer) arguments.get("distanceFilter");
     final Integer timeInterval = (Integer) arguments.get("timeInterval");
+    final Boolean useMSLAltitude = (Boolean) arguments.get("useMSLAltitude");
 
     LocationAccuracy locationAccuracy = LocationAccuracy.best;
 
@@ -44,13 +54,8 @@ public class LocationOptions {
     return new LocationOptions(
         locationAccuracy,
         distanceFilter != null ? distanceFilter : 0,
-        timeInterval != null ? timeInterval : 5000);
-  }
-
-  private LocationOptions(LocationAccuracy accuracy, long distanceFilter, long timeInterval) {
-    this.accuracy = accuracy;
-    this.distanceFilter = distanceFilter;
-    this.timeInterval = timeInterval;
+        timeInterval != null ? timeInterval : 5000,
+        useMSLAltitude != null && useMSLAltitude);
   }
 
   public LocationAccuracy getAccuracy() {
@@ -63,5 +68,9 @@ public class LocationOptions {
 
   public long getTimeInterval() {
     return timeInterval;
+  }
+
+  public boolean isUseMSLAltitude() {
+    return useMSLAltitude;
   }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NmeaClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NmeaClient.java
@@ -1,0 +1,105 @@
+package com.baseflow.geolocator.location;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.location.Location;
+import android.location.LocationManager;
+import android.location.OnNmeaMessageListener;
+import android.os.Build;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Calendar;
+import java.util.Date;
+
+public class NmeaClient {
+
+  public static final String NMEA_ALTITUDE_EXTRA = "geolocator_mslAltitude";
+
+  private final Context context;
+  private final LocationManager locationManager;
+  @Nullable private final LocationOptions locationOptions;
+
+  @TargetApi(Build.VERSION_CODES.N)
+  private OnNmeaMessageListener nmeaMessageListener;
+
+  private String lastNmeaMessage;
+  @Nullable private Calendar lastNmeaMessageTime;
+  private boolean listenerAdded = false;
+
+  public NmeaClient(@NonNull Context context, @Nullable LocationOptions locationOptions) {
+    this.context = context;
+    this.locationOptions = locationOptions;
+    this.locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      nmeaMessageListener =
+          (message, timestamp) -> {
+            if (message.startsWith("$")) {
+              lastNmeaMessage = message;
+              lastNmeaMessageTime = Calendar.getInstance();
+            }
+          };
+    }
+  }
+
+  @SuppressLint("MissingPermission")
+  public void start() {
+    if (listenerAdded) {
+      return;
+    }
+
+    if (locationOptions != null && locationOptions.isUseMSLAltitude()) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && locationManager != null) {
+        locationManager.addNmeaListener(nmeaMessageListener, null);
+        listenerAdded = true;
+      }
+    }
+  }
+
+  public void stop() {
+    if (locationOptions != null && locationOptions.isUseMSLAltitude()) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && locationManager != null) {
+        locationManager.removeNmeaListener(nmeaMessageListener);
+        listenerAdded = false;
+      }
+    }
+  }
+
+  public void enrichExtrasWithNmea(@Nullable Location location) {
+
+    if (location == null) {
+      return;
+    }
+
+    if (lastNmeaMessage != null && locationOptions != null && listenerAdded) {
+
+        Calendar expiryDate = Calendar.getInstance();
+        expiryDate.add(Calendar.SECOND, -5);
+      if (lastNmeaMessageTime != null && lastNmeaMessageTime.before(expiryDate)) {
+          // do not use MSL for old altitude values
+          return;
+      }
+
+      if (locationOptions.isUseMSLAltitude()) {
+        String[] tokens = lastNmeaMessage.split(",");
+        String type = tokens[0];
+
+        // Parse altitude above sea level, Detailed description of NMEA string here
+        // http://aprs.gids.nl/nmea/#gga
+        if (type.startsWith("$GPGGA") && tokens.length > 9) {
+          if (!tokens[9].isEmpty()) {
+            double mslAltitude = Double.parseDouble(tokens[9]);
+            if (location.getExtras() == null) {
+              location.setExtras(Bundle.EMPTY);
+            }
+            location.getExtras().putDouble(NMEA_ALTITUDE_EXTRA, mslAltitude);
+          }
+        }
+      }
+    }
+  }
+}

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NmeaClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NmeaClient.java
@@ -13,7 +13,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.Calendar;
-import java.util.Date;
 
 public class NmeaClient {
 
@@ -38,7 +37,7 @@ public class NmeaClient {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       nmeaMessageListener =
           (message, timestamp) -> {
-            if (message.startsWith("$")) {
+            if (message.startsWith("$GPGGA")) {
               lastNmeaMessage = message;
               lastNmeaMessageTime = Calendar.getInstance();
             }
@@ -77,11 +76,11 @@ public class NmeaClient {
 
     if (lastNmeaMessage != null && locationOptions != null && listenerAdded) {
 
-        Calendar expiryDate = Calendar.getInstance();
-        expiryDate.add(Calendar.SECOND, -5);
+      Calendar expiryDate = Calendar.getInstance();
+      expiryDate.add(Calendar.SECOND, -5);
       if (lastNmeaMessageTime != null && lastNmeaMessageTime.before(expiryDate)) {
-          // do not use MSL for old altitude values
-          return;
+        // do not use MSL for old altitude values
+        return;
       }
 
       if (locationOptions.isUseMSLAltitude()) {

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionUtils.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionUtils.java
@@ -1,21 +1,9 @@
 package com.baseflow.geolocator.permission;
 
-import android.Manifest;
-import android.app.Activity;
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.util.Log;
-
-import androidx.annotation.RequiresApi;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class PermissionUtils {
   public static boolean hasPermissionInManifest(Context context, String permission) {

--- a/geolocator_android/example/lib/main.dart
+++ b/geolocator_android/example/lib/main.dart
@@ -293,6 +293,7 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
       final androidSettings = AndroidSettings(
         accuracy: LocationAccuracy.best,
         distanceFilter: 10,
+        intervalDuration: const Duration(seconds: 1),
         forceLocationManager: false,
         useMSLAltitude: true,
         foregroundNotificationConfig: const ForegroundNotificationConfig(
@@ -310,10 +311,13 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
       _positionStreamSubscription = positionStream.handleError((error) {
         _positionStreamSubscription?.cancel();
         _positionStreamSubscription = null;
-      }).listen((position) => _updatePositionList(
-            _PositionItemType.position,
-            position.toString(),
-          ));
+      }).listen((position) {
+        debugPrint(position.altitude.toString());
+        _updatePositionList(
+          _PositionItemType.position,
+          position.toString(),
+        );
+      });
       _positionStreamSubscription?.pause();
     }
 

--- a/geolocator_android/example/lib/main.dart
+++ b/geolocator_android/example/lib/main.dart
@@ -294,6 +294,7 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
         accuracy: LocationAccuracy.best,
         distanceFilter: 10,
         forceLocationManager: false,
+        useMSLAltitude: true,
         foregroundNotificationConfig: const ForegroundNotificationConfig(
           notificationText:
               "Example app will continue to receive your location even when you aren't using it",

--- a/geolocator_android/lib/src/types/android_settings.dart
+++ b/geolocator_android/lib/src/types/android_settings.dart
@@ -16,6 +16,7 @@ class AndroidSettings extends LocationSettings {
     this.intervalDuration,
     Duration? timeLimit,
     this.foregroundNotificationConfig,
+    this.useMSLAltitude = false,
   }) : super(
             accuracy: accuracy,
             distanceFilter: distanceFilter,
@@ -51,6 +52,22 @@ class AndroidSettings extends LocationSettings {
   /// showing the user that the service will continue running in the background.
   final ForegroundNotificationConfig? foregroundNotificationConfig;
 
+  /// Set to true if altitude should be calculated as MSL (EGM2008) from NMEA messages
+  /// and reported as the altitude instead of using the geoidal height (WSG84). Setting
+  /// this property true will help to align Android altitude to that of iOS which uses MSL.
+  ///
+  /// If the NMEA message is empty then the altitude reported will still be the standard WSG84
+  /// altitude from the GPS receiver.
+  ///
+  /// MSL Altitude is only available starting from Android N and not all devices support
+  /// NMEA message returning $GPGGA sequences.
+  ///
+  /// This property only works with position stream updates and has no effect when getting the
+  /// current position or last known position.
+  ///
+  /// Defaults to false
+  final bool useMSLAltitude;
+
   @override
   Map<String, dynamic> toJson() {
     return super.toJson()
@@ -58,6 +75,7 @@ class AndroidSettings extends LocationSettings {
         'forceLocationManager': forceLocationManager,
         'timeInterval': intervalDuration?.inMilliseconds,
         'foregroundNotificationConfig': foregroundNotificationConfig?.toJson(),
+        'useMSLAltitude': useMSLAltitude,
       });
   }
 }

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.0.2
+version: 4.1.0
 
 environment:
   sdk: ">=2.15.0 <3.0.0"

--- a/geolocator_android/test/geolocator_android_test.dart
+++ b/geolocator_android/test/geolocator_android_test.dart
@@ -714,7 +714,8 @@ void main() {
           stream: streamController.stream,
         );
 
-        var stream = GeolocatorAndroid().getPositionStream(locationSettings: AndroidSettings(useMSLAltitude: false));
+        var stream = GeolocatorAndroid().getPositionStream(
+            locationSettings: AndroidSettings(useMSLAltitude: false));
         StreamSubscription<Position>? streamSubscription =
             stream.listen((event) {});
 
@@ -766,7 +767,8 @@ void main() {
         );
 
         // Act
-        final positionStream = GeolocatorAndroid().getPositionStream(locationSettings: AndroidSettings(useMSLAltitude: false));
+        final positionStream = GeolocatorAndroid().getPositionStream(
+            locationSettings: AndroidSettings(useMSLAltitude: false));
         final streamQueue = StreamQueue(positionStream);
 
         // Emit test events
@@ -1243,26 +1245,23 @@ void main() {
     });
 
     group('jsonSerialization: When serializing to json', () {
-      test('Should produce valid map with all the settings when calling toJson', () async {
+      test('Should produce valid map with all the settings when calling toJson',
+          () async {
         // Arrange
         final settings = AndroidSettings(
-          accuracy: LocationAccuracy.best,
-          distanceFilter: 5,
-          forceLocationManager: false,
-          intervalDuration: const Duration(seconds: 1),
-          timeLimit: const Duration(seconds: 1),
-          useMSLAltitude: false,
-          foregroundNotificationConfig: const ForegroundNotificationConfig(
-            notificationText: 'text',
-            notificationTitle: 'title',
-            enableWakeLock: false,
-            enableWifiLock: false,
-            notificationIcon: AndroidResource(
-              name: 'name',
-              defType: 'defType'
-            )
-          )
-        );
+            accuracy: LocationAccuracy.best,
+            distanceFilter: 5,
+            forceLocationManager: false,
+            intervalDuration: const Duration(seconds: 1),
+            timeLimit: const Duration(seconds: 1),
+            useMSLAltitude: false,
+            foregroundNotificationConfig: const ForegroundNotificationConfig(
+                notificationText: 'text',
+                notificationTitle: 'title',
+                enableWakeLock: false,
+                enableWifiLock: false,
+                notificationIcon:
+                    AndroidResource(name: 'name', defType: 'defType')));
 
         // Act
         final jsonMap = settings.toJson();
@@ -1300,7 +1299,7 @@ void main() {
 
         // Act
         final hasOpenedLocationSettings =
-        await GeolocatorAndroid().openLocationSettings();
+            await GeolocatorAndroid().openLocationSettings();
 
         // Assert
         expect(

--- a/geolocator_android/test/geolocator_android_test.dart
+++ b/geolocator_android/test/geolocator_android_test.dart
@@ -4,6 +4,7 @@ import 'package:async/async.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator_android/geolocator_android.dart';
+import 'package:geolocator_android/src/types/foreground_settings.dart';
 
 import 'event_channel_mock.dart';
 import 'method_channel_mock.dart';
@@ -713,7 +714,7 @@ void main() {
           stream: streamController.stream,
         );
 
-        var stream = GeolocatorAndroid().getPositionStream();
+        var stream = GeolocatorAndroid().getPositionStream(locationSettings: AndroidSettings(useMSLAltitude: false));
         StreamSubscription<Position>? streamSubscription =
             stream.listen((event) {});
 
@@ -765,7 +766,7 @@ void main() {
         );
 
         // Act
-        final positionStream = GeolocatorAndroid().getPositionStream();
+        final positionStream = GeolocatorAndroid().getPositionStream(locationSettings: AndroidSettings(useMSLAltitude: false));
         final streamQueue = StreamQueue(positionStream);
 
         // Emit test events
@@ -1232,6 +1233,74 @@ void main() {
         // Act
         final hasOpenedLocationSettings =
             await GeolocatorAndroid().openLocationSettings();
+
+        // Assert
+        expect(
+          hasOpenedLocationSettings,
+          false,
+        );
+      });
+    });
+
+    group('jsonSerialization: When serializing to json', () {
+      test('Should produce valid map with all the settings when calling toJson', () async {
+        // Arrange
+        final settings = AndroidSettings(
+          accuracy: LocationAccuracy.best,
+          distanceFilter: 5,
+          forceLocationManager: false,
+          intervalDuration: const Duration(seconds: 1),
+          timeLimit: const Duration(seconds: 1),
+          useMSLAltitude: false,
+          foregroundNotificationConfig: const ForegroundNotificationConfig(
+            notificationText: 'text',
+            notificationTitle: 'title',
+            enableWakeLock: false,
+            enableWifiLock: false,
+            notificationIcon: AndroidResource(
+              name: 'name',
+              defType: 'defType'
+            )
+          )
+        );
+
+        // Act
+        final jsonMap = settings.toJson();
+
+        // Assert
+        expect(
+          jsonMap['accuracy'],
+          settings.accuracy.index,
+        );
+        expect(
+          jsonMap['distanceFilter'],
+          settings.distanceFilter,
+        );
+        expect(
+          jsonMap['forceLocationManager'],
+          settings.forceLocationManager,
+        );
+        expect(
+          jsonMap['timeInterval'],
+          settings.intervalDuration!.inMilliseconds,
+        );
+        expect(
+          jsonMap['useMSLAltitude'],
+          settings.useMSLAltitude,
+        );
+      });
+
+      test('Should receive false if an error occurred', () async {
+        // Arrange
+        MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          method: 'openLocationSettings',
+          result: false,
+        );
+
+        // Act
+        final hasOpenedLocationSettings =
+        await GeolocatorAndroid().openLocationSettings();
 
         // Assert
         expect(


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behaviour?

Currently android reports location altitude as the value received from the GPS directly. 

### :new: What is the new behaviour (if this is a feature change)?

There are some use cases where MSL altitude is desired instead.  NMEA messages can used in these scenarios to get the MSL altitude for the location instead of the normal geoid altitude. This feature adds a new Android setting requesting the platform to report altitude as MSL instead which will then register and NMEA client on the Android side if available and use the NMEA messages instead as the altitude values for position updates.

### :boom: Does this PR introduce a breaking change?

No, the change is backwards compatible with existing clients.

### :bug: Recommendations for testing

Toggle the Android setting to use MSL or not to use MSL in the example app and observe the difference in altitude being reported

### :memo: Links to relevant issues/docs

https://github.com/Baseflow/flutter-geolocator/issues/987

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
