### PR TITLE
[iOS] Fix background location indicator not showing on first time using the service

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.4
+
+- Fix background location indicator not showing on first time using the service.
+
 ## 2.1.3
 
 - Fixes repository URL of the package.

--- a/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
@@ -63,39 +63,35 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
                                   distanceFilter:kCLDistanceFilterNone
                pauseLocationUpdatesAutomatically:NO
                                     activityType:CLActivityTypeOther
-                       requestingCurrentLocation:YES];
+                       requestingCurrentLocation:YES
+                 showBackgroundLocationIndicator:NO];
 }
 
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
                            distanceFilter:(CLLocationDistance)distanceFilter
         pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
-          showBackgroundLocationIndicator: (BOOL) showBackgroundLocationIndicator
+          showBackgroundLocationIndicator:(BOOL)showBackgroundLocationIndicator
                              activityType:(CLActivityType)activityType
                             resultHandler:(GeolocatorResult _Nonnull )resultHandler
                              errorHandler:(GeolocatorError _Nonnull)errorHandler {
     
   self.errorHandler = errorHandler;
   self.resultHandler = resultHandler;
-
-#if TARGET_OS_IOS
-  if (@available(iOS 11.0, macOS 11.0, *)) {
-      CLLocationManager *locationManager = [self getLocationManager];
-      locationManager.showsBackgroundLocationIndicator = showBackgroundLocationIndicator;
-  }
-#endif
     
   [self startUpdatingLocationWithDesiredAccuracy:desiredAccuracy
                                   distanceFilter:distanceFilter
                pauseLocationUpdatesAutomatically:pauseLocationUpdatesAutomatically
                                     activityType:activityType
-                       requestingCurrentLocation:NO];
+                       requestingCurrentLocation:NO
+                 showBackgroundLocationIndicator:showBackgroundLocationIndicator];
 }
 
 - (void)startUpdatingLocationWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
                                   distanceFilter:(CLLocationDistance)distanceFilter
                pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
                                     activityType:(CLActivityType)activityType
-                       requestingCurrentLocation:(BOOL)requestingCurrentLocation {
+                       requestingCurrentLocation:(BOOL)requestingCurrentLocation
+                 showBackgroundLocationIndicator:(BOOL)showBackgroundLocationIndicator{
   self.requestingCurrentLocation = requestingCurrentLocation;
   CLLocationManager *locationManager = [self getLocationManager];
   locationManager.desiredAccuracy = desiredAccuracy;
@@ -108,6 +104,9 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
 #if TARGET_OS_IOS
   if (@available(iOS 9.0, macOS 11.0, *)) {
     locationManager.allowsBackgroundLocationUpdates = [GeolocationHandler shouldEnableBackgroundLocationUpdates];
+  }
+  if (@available(iOS 11.0, macOS 11.0, *)) {
+    locationManager.showsBackgroundLocationIndicator = showBackgroundLocationIndicator;
   }
 #endif
   

--- a/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
@@ -79,7 +79,8 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
 
 #if TARGET_OS_IOS
   if (@available(iOS 11.0, macOS 11.0, *)) {
-      self.locationManager.showsBackgroundLocationIndicator = showBackgroundLocationIndicator;
+      CLLocationManager *locationManager = [self getLocationManager];
+      locationManager.showsBackgroundLocationIndicator = showBackgroundLocationIndicator;
   }
 #endif
     

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.1.3
+version: 2.1.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Fix nill self.locationManager if it is not yet init and setting showsBackgroundLocationIndicator has no effect

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Setting showsBackgroundLocationIndicator has no effect if locationManger has not yet init

### :new: What is the new behavior (if this is a feature change)?
Settings showsBackgroundLocationIndicator working as intended

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Calling getPositionStream with showsBackgroundLocationIndicator set to true on iOS

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
