### PR TITLE
Update mock flag on ios

### DIFF
--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 8.2.1
+version: 8.2.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -28,7 +28,7 @@ dependencies:
   
   geolocator_platform_interface: ^4.0.3
   geolocator_android: ^3.1.0
-  geolocator_apple: ^2.1.1+1
+  geolocator_apple: ^2.1.5
   geolocator_web: ^2.1.3
   geolocator_windows: ^0.1.0
 

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 8.2.2
+version: 8.2.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -28,7 +28,7 @@ dependencies:
   
   geolocator_platform_interface: ^4.0.3
   geolocator_android: ^3.1.0
-  geolocator_apple: ^2.1.5
+  geolocator_apple: ^2.1.1+1
   geolocator_web: ^2.1.3
   geolocator_windows: ^0.1.0
 

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.5
+
+- Update isMocked flag on iOS 15 and higher.
+
 ## 2.1.4
 
 - Fix background location indicator not showing on first time using the service.

--- a/geolocator_apple/ios/Classes/Utils/LocationMapper.m
+++ b/geolocator_apple/ios/Classes/Utils/LocationMapper.m
@@ -32,6 +32,10 @@
     [locationMap setObject:@(speedAccuracy) forKey: @"speed_accuracy"];
     [locationMap setObject:@(location.course) forKey: @"heading"];
     
+    if(@available(iOS 15.0, *)) {
+        [locationMap setObject:@(location.isSimulatedBySoftware) forKey: @"is_mocked"];
+    }
+    
     if (@available(macOS 10.15, *)) {
       if(location.floor && location.floor.level) {
         [locationMap setObject:@(location.floor.level) forKey:@"floor"];

--- a/geolocator_apple/ios/Classes/Utils/LocationMapper.m
+++ b/geolocator_apple/ios/Classes/Utils/LocationMapper.m
@@ -33,7 +33,7 @@
     [locationMap setObject:@(location.course) forKey: @"heading"];
     
     if(@available(iOS 15.0, *)) {
-        [locationMap setObject:@(location.isSimulatedBySoftware) forKey: @"is_mocked"];
+        [locationMap setObject:@(location.sourceInformation.isSimulatedBySoftware) forKey: @"is_mocked"];
     }
     
     if (@available(macOS 10.15, *)) {

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.1.4
+version: 2.1.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Add support for mock location detection on iOS

### :arrow_heading_down: What is the current behavior?
Detecting mocked location on iOS doesn't work.

### :new: What is the new behavior (if this is a feature change)?
On iOS 15 we can check flag if location is real or mocked so we will look on it and update isMocked flag in GeoLocator.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Check iOS 15 with GPS location and mocked location from XCode.

### :memo: Links to relevant issues/docs
https://developer.apple.com/documentation/corelocation/cllocationsourceinformation/3861807-issimulatedbysoftware?language=objc

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
