### PR TITLE
Raises Dart and Flutter to 2.17 and 3.0 respectively

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 2.2.0
 
 - Raises minimum Dart version to 2.17 and Flutter version to 3.0.0.
-- Update isMocked flag on iOS 15 and higher.
+- Updates `isMocked` flag on iOS 15 and higher.
+- Updates the example application to request permissions when start listening to the position stream.
 
 ## 2.1.4
 

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 2.1.5
+## 2.2.0
 
+- Raises minimum Dart version to 2.17 and Flutter version to 3.0.0.
 - Update isMocked flag on iOS 15 and higher.
 
 ## 2.1.4

--- a/geolocator_apple/example/lib/main.dart
+++ b/geolocator_apple/example/lib/main.dart
@@ -283,7 +283,13 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
     }
   }
 
-  void _toggleListening() {
+  Future<void> _toggleListening() async {
+    final hasPermission = await _handlePermission();
+
+    if (!hasPermission) {
+      return;
+    }
+
     Exception? error;
 
     if (_positionStreamSubscription == null) {

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,11 +2,11 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.1.5
+version: 2.2.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.8.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -22,12 +22,12 @@ dependencies:
   flutter:
     sdk: flutter
 
-  geolocator_platform_interface: ^4.0.4
+  geolocator_platform_interface: ^4.0.5
   
 dev_dependencies:
   async: ^2.8.2
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
-  mockito: ^5.0.0-nullsafety.7
-  plugin_platform_interface: ^2.0.0
+  flutter_lints: ^2.0.1
+  mockito: ^5.2.0
+  plugin_platform_interface: ^2.1.2


### PR DESCRIPTION
Raises minimum Dart version to 2.17 and Flutter version to 3.0.0.

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
