### PR TITLE
Use SecureRandom instead of Random

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.2.1
+
+- Use `java.security.SecureRandom` instead of `java.util.Random` to ensure the 
+`ActivityRequest` identifier is generated in a cryptographically strong fasion.
+
 ## 3.2.0
 
 - Raises minimum Dart version to 2.17 and Flutter version to 3.0.0.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -14,7 +14,7 @@ import com.baseflow.geolocator.errors.ErrorCodes;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.ResolvableApiException;
 import com.google.android.gms.location.*;
-import java.util.Random;
+import java.security.SecureRandom;
 
 class FusedLocationClient implements LocationClient {
     private static final String TAG = "FlutterGeolocator";
@@ -66,7 +66,7 @@ class FusedLocationClient implements LocationClient {
   }
 
   private synchronized int generateActivityRequestCode() {
-    Random random = new Random();
+    SecureRandom random = new SecureRandom();
     return random.nextInt(1 << 16);
   }
 

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 3.2.0
+version: 3.2.1
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Security update

Updates the geolocator_android package to use `java.security.SecureRandom` instead of `java.util.Random` to ensure the `ActivityRequest` identifier is generated in a cryptographically strong fasion.

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
