### PR TITLE
Fixes a bug introduced in `geolocator_android v4.0.0`

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+- Fixes a bug introduced in `4.0.0` that throws an error if API level < 24.
+
 ## 4.0.0
 
 > **IMPORTANT:** when updating to version 4.0.0 make sure to also set the `compileSdkVersion` in the `android/app/build.gradle` file to `33`.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.location.Location;
 import android.net.wifi.WifiManager;
 import android.os.Binder;
+import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
 import android.util.Log;
@@ -128,10 +129,15 @@ public class GeolocatorLocationService extends Service {
     obtainWakeLocks(options);
   }
 
+  @SuppressWarnings("deprecation")
   public void disableBackgroundMode() {
     if (isForeground) {
       Log.d(TAG, "Stop service in foreground.");
-      stopForeground(ONGOING_NOTIFICATION_ID);
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        stopForeground(true);
+      } else {
+        stopForeground(ONGOING_NOTIFICATION_ID);
+      }
       releaseWakeLocks();
       isForeground = false;
       backgroundNotification = null;

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.0.0
+version: 4.0.1
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
#1088 changed `stopForeground (boolean removeNotification)` to `stopForeground(int notificationBehavior)`, but the method `stopForeground(int notificationBehavior)` was added in API level 24 and throws an error if API level < 24

### :new: What is the new behavior (if this is a feature change)?
*

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run the example App on Android SDK 33 and Android SDK < 24

### :memo: Links to relevant issues/docs

[`public final void stopForeground (boolean removeNotification)`](https://developer.android.com/reference/android/app/Service#stopForeground(boolean))
_Added in API level 5
Deprecated in API level 33_

[`public final void stopForeground (int notificationBehavior)`](https://developer.android.com/reference/android/app/Service#stopForeground(int))
_Added in API level 24_

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
