### PR TITLE
Migrates Dart SDK to 2.15.0 and Flutter to 2.8.0.

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.0.1
+
+- Migrates to Dart SDK 2.15.0 and Flutter 2.8.0.
+
 ## 9.0.0
 
 > **IMPORTANT:** when updating to version 9.0.0 make sure to also set the `compileSdkVersion` in the `android/app/build.gradle` file to `33`.

--- a/geolocator/example/pubspec.yaml
+++ b/geolocator/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the geolocator plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   baseflow_plugin_template:

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissu
 version: 9.0.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  sdk: ">=2.15.0 <3.0.0"
+  flutter: ">=2.8.0"
 
 flutter:
   plugin:

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+- Migrates to Dart SDK 2.15.0 and Flutter 2.8.0.
+
 ## 4.0.0
 
 > **IMPORTANT:** when updating to version 4.0.0 make sure to also set the `compileSdkVersion` in the `android/app/build.gradle` file to `33`.

--- a/geolocator_android/example/pubspec.yaml
+++ b/geolocator_android/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the geolocator_android plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   baseflow_plugin_template:

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissu
 version: 4.0.0
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
+  flutter: ">=2.8.0"
 
 flutter:
   plugin:

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+- Migrates to Dart SDK 2.15.0 and Flutter 2.8.0.
+
 ## 2.2.0
 
 - Raises minimum Dart version to 2.17 and Flutter version to 3.0.0.

--- a/geolocator_apple/example/pubspec.yaml
+++ b/geolocator_apple/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the geolocator_ios plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   baseflow_plugin_template:

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissu
 version: 2.2.0
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
+  flutter: ">=2.8.0"
 
 flutter:
   plugin:

--- a/geolocator_linux/CHANGELOG.md
+++ b/geolocator_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- Migrates to Dart SDK 2.15.0 and Flutter 2.8.0.
+
 ## 0.1.1
 
 - Fixes repository URL of the package.

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.6
+
+- Migrates to Dart SDK 2.15.0 and Flutter 2.8.0.
+
 ## 4.0.5
 
 - Fixes repository URL of the package.

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -21,5 +21,5 @@ dev_dependencies:
   mockito: ^5.0.0-nullsafety.7
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.10.0"
+  sdk: ">=2.15.0 <3.0.0"
+  flutter: ">=2.8.0"

--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.6
+
+- Migrates to Dart SDK 2.15.0 and Flutter 2.8.0.
+
 ## 2.1.5
 
 - Fixes repository URL of the package.

--- a/geolocator_web/example/pubspec.yaml
+++ b/geolocator_web/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the geolocator plugin on the web platform.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.15.0-0 <3.0.0"
 
 dependencies:
   baseflow_plugin_template:

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -25,5 +25,5 @@ dev_dependencies:
   mockito: ^5.0.0
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.20.0"
+  sdk: '>=2.15.0 <3.0.0'
+  flutter: ">=2.8.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Maintenance

### :arrow_heading_down: What is the current behavior?

Different packages of the geolocator plugin use different Dart SDK and Flutter versions.

### :new: What is the new behavior (if this is a feature change)?

This PR migrates all packages to use Dart SDK 2.15.0 and Flutter 2.8.0.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
