### PR TITLE
Prepare for fix to https://github.com/flutter/flutter/issues/109339.

### DIFF
--- a/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
+++ b/geolocator_platform_interface/test/geolocator_platform_interface_test.dart
@@ -19,7 +19,14 @@ void main() {
     test('Cannot be implemented with `implements`', () {
       expect(() {
         GeolocatorPlatform.instance = ImplementsGeolocatorPlatform();
-      }, throwsNoSuchMethodError);
+        // In versions of `package:plugin_platform_interface` prior to fixing
+        // https://github.com/flutter/flutter/issues/109339, an attempt to
+        // implement a platform interface using `implements` would sometimes
+        // throw a `NoSuchMethodError` and other times throw an
+        // `AssertionError`.  After the issue is fixed, an `AssertionError` will
+        // always be thrown.  For the purpose of this test, we don't really care
+        // what exception is thrown, so just allow any exception.
+      }, throwsA(anything));
     });
 
     test('Can be extended', () {


### PR DESCRIPTION
Currently, in some circumstances where a subclasses of
`PlatformInterface` erroneously uses `implements` rather than
`extends`, a `NoSuchMethodError` will be thrown (in spite of the
documentation at
https://pub.dev/documentation/plugin_platform_interface/latest/plugin_platform_interface/PlatformInterface/verify.html
claiming that `AssertionError` will be thrown).

After https://github.com/flutter/flutter/issues/109339 is fixed, the
correct type of exception will be thrown.  To avoid a test breakage in
`geolocator_platform_interface_test.dart` when the fix happens, we
need to modify the test so that it doesn't care what kind of exception
is thrown.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

The test expects `NoSuchMethodError` to be thrown; this will break after https://github.com/flutter/flutter/issues/109339 is fixed.

### :new: What is the new behavior (if this is a feature change)?

The test doesn't care what kind of exception is thrown, so fixing https://github.com/flutter/flutter/issues/109339 will not cause a breakage.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
