### PR TITLE
Multiple Flutter engine support

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Moves the Android complile arguments to the example `build.gradle` so that is not forces the arguments on consumers of the package.
 
+## 4.1.1
+
+- Fix a bug where the location service would stop if we have multiple flutter engines connected and one disconnects
+
 ## 4.1.0
 
 - Adds the ability to report altitude as MSL obtained from NMEA messages when available.

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,10 +1,11 @@
-## 4.1.1
-
-- Moves the Android complile arguments to the example `build.gradle` so that is not forces the arguments on consumers of the package.
-
-## 4.1.1
+## 4.1.2
 
 - Fix a bug where the location service would stop if we have multiple flutter engines connected and one disconnects
+
+## 4.1.1
+
+- Moves the Android complile arguments to the example `build.gradle` so that is not forces the arguments on consumers of
+  the package.
 
 ## 4.1.0
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -83,8 +83,8 @@ public class GeolocatorLocationService extends Service {
     super.onDestroy();
   }
 
-  public boolean isOnlyConnectedEngine() {
-      return connectedEngines == 1;
+  public boolean canStopLocationService() {
+      return connectedEngines == 0;
   }
 
   public void flutterEngineConnected() {

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -60,16 +60,15 @@ public class GeolocatorLocationService extends Service {
   @Nullable
   @Override
   public IBinder onBind(Intent intent) {
-
-    Log.d(TAG, "Binding to location service.");
-    connectedEngines++;
+      connectedEngines++;
+    Log.d(TAG, "Binding to location service. Connected engines " + connectedEngines);
     return binder;
   }
 
   @Override
   public boolean onUnbind(Intent intent) {
-    Log.d(TAG, "Unbinding from location service.");
-    connectedEngines--;
+      connectedEngines--;
+    Log.d(TAG, "Unbinding from location service., Connected engines " + connectedEngines);
     return super.onUnbind(intent);
   }
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -60,15 +60,13 @@ public class GeolocatorLocationService extends Service {
   @Nullable
   @Override
   public IBinder onBind(Intent intent) {
-      connectedEngines++;
-    Log.d(TAG, "Binding to location service. Connected engines " + connectedEngines);
+    Log.d(TAG, "Binding to location service.");
     return binder;
   }
 
   @Override
   public boolean onUnbind(Intent intent) {
-      connectedEngines--;
-    Log.d(TAG, "Unbinding from location service., Connected engines " + connectedEngines);
+    Log.d(TAG, "Unbinding from location service.");
     return super.onUnbind(intent);
   }
 
@@ -87,6 +85,18 @@ public class GeolocatorLocationService extends Service {
 
   public boolean isOnlyConnectedEngine() {
       return connectedEngines == 1;
+  }
+
+  public void flutterEngineConnected() {
+
+      connectedEngines++;
+      Log.d(TAG, "Flutter engine connected. Connected engine count " + connectedEngines);
+  }
+
+  public void flutterEngineDisconnected() {
+
+      connectedEngines--;
+      Log.d(TAG, "Flutter engine disconnected. Connected engine count " + connectedEngines);
   }
 
   public void startLocationService(

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -84,19 +84,19 @@ public class GeolocatorLocationService extends Service {
   }
 
   public boolean canStopLocationService() {
-      return connectedEngines == 0;
+    return connectedEngines == 0;
   }
 
   public void flutterEngineConnected() {
 
-      connectedEngines++;
-      Log.d(TAG, "Flutter engine connected. Connected engine count " + connectedEngines);
+    connectedEngines++;
+    Log.d(TAG, "Flutter engine connected. Connected engine count " + connectedEngines);
   }
 
   public void flutterEngineDisconnected() {
 
-      connectedEngines--;
-      Log.d(TAG, "Flutter engine disconnected. Connected engine count " + connectedEngines);
+    connectedEngines--;
+    Log.d(TAG, "Flutter engine disconnected. Connected engine count " + connectedEngines);
   }
 
   public void startLocationService(
@@ -149,13 +149,12 @@ public class GeolocatorLocationService extends Service {
   public void disableBackgroundMode() {
     if (isForeground) {
       Log.d(TAG, "Stop service in foreground.");
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            stopForeground(ONGOING_NOTIFICATION_ID);
-        }
-        else {
-            stopForeground(true);
-        }
-        releaseWakeLocks();
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        stopForeground(ONGOING_NOTIFICATION_ID);
+      } else {
+        stopForeground(true);
+      }
+      releaseWakeLocks();
       isForeground = false;
       backgroundNotification = null;
     }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -35,6 +35,7 @@ public class GeolocatorLocationService extends Service {
   private final LocalBinder binder = new LocalBinder(this);
   // Service is foreground
   private boolean isForeground = false;
+  private int connectedEngines = 0;
   @Nullable private Activity activity = null;
   @Nullable private GeolocationManager geolocationManager = null;
   @Nullable private LocationClient locationClient;
@@ -61,12 +62,14 @@ public class GeolocatorLocationService extends Service {
   public IBinder onBind(Intent intent) {
 
     Log.d(TAG, "Binding to location service.");
+    connectedEngines++;
     return binder;
   }
 
   @Override
   public boolean onUnbind(Intent intent) {
     Log.d(TAG, "Unbinding from location service.");
+    connectedEngines--;
     return super.onUnbind(intent);
   }
 
@@ -81,6 +84,10 @@ public class GeolocatorLocationService extends Service {
 
     Log.d(TAG, "Destroyed location service.");
     super.onDestroy();
+  }
+
+  public boolean isOnlyConnectedEngine() {
+      return connectedEngines == 1;
   }
 
   public void startLocationService(

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -38,7 +38,7 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
         public void onServiceConnected(ComponentName name, IBinder service) {
           Log.d(TAG, "Geolocator foreground service connected");
           if (service instanceof GeolocatorLocationService.LocalBinder) {
-              initialize(((GeolocatorLocationService.LocalBinder) service).getLocationService());
+            initialize(((GeolocatorLocationService.LocalBinder) service).getLocationService());
           }
         }
 
@@ -192,16 +192,16 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
   }
 
   private void unbindForegroundService(Context context) {
-      if(foregroundLocationService != null) {
-          foregroundLocationService.flutterEngineDisconnected();
-      }
+    if (foregroundLocationService != null) {
+      foregroundLocationService.flutterEngineDisconnected();
+    }
     context.unbindService(serviceConnection);
   }
 
   private void initialize(GeolocatorLocationService service) {
     Log.d(TAG, "Initializing Geolocator services");
     foregroundLocationService = service;
-      foregroundLocationService.flutterEngineConnected();
+    foregroundLocationService.flutterEngineConnected();
 
     if (streamHandler != null) {
       streamHandler.setForegroundLocationService(service);

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -192,12 +192,16 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
   }
 
   private void unbindForegroundService(Context context) {
+      if(foregroundLocationService != null) {
+          foregroundLocationService.flutterEngineDisconnected();
+      }
     context.unbindService(serviceConnection);
   }
 
   private void initialize(GeolocatorLocationService service) {
     Log.d(TAG, "Initializing Geolocator services");
     foregroundLocationService = service;
+      foregroundLocationService.flutterEngineConnected();
 
     if (streamHandler != null) {
       streamHandler.setForegroundLocationService(service);

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -150,7 +150,7 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
 
   private void disposeListeners() {
     Log.e(TAG, "Geolocator position updates stopped");
-    if (foregroundLocationService != null) {
+    if (foregroundLocationService != null && foregroundLocationService.isOnlyConnectedEngine()) {
       foregroundLocationService.stopLocationService();
       foregroundLocationService.disableBackgroundMode();
     }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -154,6 +154,9 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
       foregroundLocationService.stopLocationService();
       foregroundLocationService.disableBackgroundMode();
     }
+    else {
+        Log.e(TAG, "There is still another flutter engine connected, not stopping location service");
+    }
     if (locationClient != null && geolocationManager != null) {
       geolocationManager.stopPositionUpdates(locationClient);
       locationClient = null;

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -153,9 +153,8 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
     if (foregroundLocationService != null && foregroundLocationService.canStopLocationService()) {
       foregroundLocationService.stopLocationService();
       foregroundLocationService.disableBackgroundMode();
-    }
-    else {
-        Log.e(TAG, "There is still another flutter engine connected, not stopping location service");
+    } else {
+      Log.e(TAG, "There is still another flutter engine connected, not stopping location service");
     }
     if (locationClient != null && geolocationManager != null) {
       geolocationManager.stopPositionUpdates(locationClient);

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -150,7 +150,7 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
 
   private void disposeListeners() {
     Log.e(TAG, "Geolocator position updates stopped");
-    if (foregroundLocationService != null && foregroundLocationService.isOnlyConnectedEngine()) {
+    if (foregroundLocationService != null && foregroundLocationService.canStopLocationService()) {
       foregroundLocationService.stopLocationService();
       foregroundLocationService.disableBackgroundMode();
     }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -15,7 +15,19 @@ import com.baseflow.geolocator.errors.ErrorCallback;
 import com.baseflow.geolocator.errors.ErrorCodes;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.ResolvableApiException;
-import com.google.android.gms.location.*;
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationAvailability;
+import com.google.android.gms.location.LocationCallback;
+import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationResult;
+import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.LocationSettingsRequest;
+import com.google.android.gms.location.LocationSettingsResponse;
+import com.google.android.gms.location.LocationSettingsStates;
+import com.google.android.gms.location.LocationSettingsStatusCodes;
+import com.google.android.gms.location.Priority;
+import com.google.android.gms.location.SettingsClient;
+
 import java.security.SecureRandom;
 
 class FusedLocationClient implements LocationClient {
@@ -60,7 +72,7 @@ class FusedLocationClient implements LocationClient {
 
           @Override
           public synchronized void onLocationAvailability(
-                  @NonNull LocationAvailability locationAvailability) {
+              @NonNull LocationAvailability locationAvailability) {
             if (!locationAvailability.isLocationAvailable() && !checkLocationService(context)) {
               if (errorCallback != null) {
                 errorCallback.onError(ErrorCodes.locationServicesDisabled);
@@ -128,9 +140,9 @@ class FusedLocationClient implements LocationClient {
                 if (lsr != null) {
                   LocationSettingsStates settingsStates = lsr.getLocationSettingsStates();
                   boolean isGpsUsable = settingsStates != null && settingsStates.isGpsUsable();
-                  boolean isNetworkUsable = settingsStates != null && settingsStates.isNetworkLocationUsable();
-                  listener.onLocationServiceResult(
-                          isGpsUsable || isNetworkUsable);
+                  boolean isNetworkUsable =
+                      settingsStates != null && settingsStates.isNetworkLocationUsable();
+                  listener.onLocationServiceResult(isGpsUsable || isNetworkUsable);
                 } else {
                   listener.onLocationServiceError(ErrorCodes.locationServicesDisabled);
                 }

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.1.1
+version: 4.1.2
 
 environment:
   sdk: ">=2.15.0 <3.0.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Currently when we have multiple Flutter engines attached and using the plugin they all share the same foreground location service in Android. If one of those engines disconnects, like when Android kills the main Flutter activity, it shuts down the foreground location service which also stops location updates from being sent to the other engines that are still alive.

### :new: What is the new behavior (if this is a feature change)?

The plugin now checks for the amount of engines that have been attached to the foreground location service before just shutting it down and only stops the foreground location service if there are no longer any engines attached to it

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

1. Set Android to not keep activities.
2. Start a foreground task with a plugin like flutter_foreground_task and start listening to position updates.
3. Close the Flutter activity.
4. The foreground tasks should still be receiving position udpates.

### :memo: Links to relevant issues/docs

Possibly resolves issue: https://github.com/Baseflow/flutter-geolocator/issues/1103

### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
