### PR TITLE
Fix deprecation warning and move Android compile arguments.

### DIFF
--- a/geolocator/example/android/app/build.gradle
+++ b/geolocator/example/android/app/build.gradle
@@ -21,6 +21,12 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+def args = ["-Xlint:deprecation", "-Xlint:unchecked", "-Werror"]
+
+project.getTasks().withType(JavaCompile) {
+    options.compilerArgs.addAll(args)
+}
+
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 

--- a/geolocator/example/pubspec.yaml
+++ b/geolocator/example/pubspec.yaml
@@ -9,10 +9,8 @@ environment:
   sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
-  baseflow_plugin_template:
-    git:
-      url: https://github.com/Baseflow/baseflow_plugin_template.git
-      ref: v2.1.0
+  baseflow_plugin_template: ^2.1.1
+  
   flutter:
     sdk: flutter
 

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+- Moves the Android complile arguments to the example `build.gradle` so that is not forces the arguments on consumers of the package.
+
 ## 4.1.0
 
 - Adds the ability to report altitude as MSL obtained from NMEA messages when available.

--- a/geolocator_android/android/build.gradle
+++ b/geolocator_android/android/build.gradle
@@ -1,6 +1,5 @@
 group 'com.baseflow.geolocator'
 version '1.0'
-def args = ["-Xlint:deprecation", "-Xlint:unchecked", "-Werror"]
 
 buildscript {
     repositories {
@@ -18,10 +17,6 @@ rootProject.allprojects {
         google()
         mavenCentral()
     }
-}
-
-project.getTasks().withType(JavaCompile) {
-    options.compilerArgs.addAll(args)
 }
 
 apply plugin: 'com.android.library'

--- a/geolocator_android/example/android/app/build.gradle
+++ b/geolocator_android/example/android/app/build.gradle
@@ -21,6 +21,12 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+def args = ["-Xlint:deprecation", "-Xlint:unchecked", "-Werror"]
+
+project.getTasks().withType(JavaCompile) {
+    options.compilerArgs.addAll(args)
+}
+
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 

--- a/geolocator_android/example/pubspec.yaml
+++ b/geolocator_android/example/pubspec.yaml
@@ -9,10 +9,7 @@ environment:
   sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
-  baseflow_plugin_template:
-    git:
-      url: https://github.com/Baseflow/baseflow_plugin_template.git
-      ref: v2.1.0
+  baseflow_plugin_template: ^2.1.1
   flutter:
     sdk: flutter
 

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.1.0
+version: 4.1.1
 
 environment:
   sdk: ">=2.15.0 <3.0.0"

--- a/geolocator_apple/example/pubspec.yaml
+++ b/geolocator_apple/example/pubspec.yaml
@@ -9,10 +9,7 @@ environment:
   sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
-  baseflow_plugin_template:
-    git:
-      url: https://github.com/Baseflow/baseflow_plugin_template.git
-      ref: v2.1.0
+  baseflow_plugin_template: ^2.1.1
   flutter:
     sdk: flutter
 

--- a/geolocator_linux/example/pubspec.yaml
+++ b/geolocator_linux/example/pubspec.yaml
@@ -9,10 +9,7 @@ environment:
   sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
-  baseflow_plugin_template:
-    git:
-      url: https://github.com/Baseflow/baseflow_plugin_template.git
-      ref: v2.1.0
+  baseflow_plugin_template: ^2.1.1
   flutter:
     sdk: flutter
 

--- a/geolocator_web/example/pubspec.yaml
+++ b/geolocator_web/example/pubspec.yaml
@@ -9,10 +9,7 @@ environment:
   sdk: ">=2.15.0-0 <3.0.0"
 
 dependencies:
-  baseflow_plugin_template:
-    git:
-      url: https://github.com/Baseflow/baseflow_plugin_template.git
-      ref: v2.1.0
+  baseflow_plugin_template: ^2.1.1
   flutter:
     sdk: flutter
 

--- a/geolocator_windows/example/pubspec.yaml
+++ b/geolocator_windows/example/pubspec.yaml
@@ -9,10 +9,7 @@ environment:
   sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
-  baseflow_plugin_template:
-    git:
-      url: https://github.com/Baseflow/baseflow_plugin_template.git
-      ref: v2.1.0
+  baseflow_plugin_template: ^2.1.1
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

The current implementation of `geolocator_android` package contains the `-Werror` compile argument in the plugins `build.gradle` file. This has the side effect of enforcing this argument down the pipeline to app developers who no longer have the option to choose themselves.

### :new: What is the new behavior (if this is a feature change)?

Moves the Java compile arguments into the `build.gradle` file of the `example` application. This doesn't populate to the consuming developers but still allows us to be warned when deprecation or other warnings occur.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Fixes #1124 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
