### PR TITLE
fix location stream on current location request

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2
+
+- Fix requesting location while listening to location stream stops the stream
+
 ## 2.2.1
 
 - Migrates to Dart SDK 2.15.0 and Flutter 2.8.0.

--- a/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
+++ b/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
@@ -154,6 +154,37 @@
   OCMVerify(never(), [self->_mockLocationManager stopUpdatingLocation]);
 }
 
+- (void)testRequestingPositionWhileListeningDoesntStopStream {
+  CLLocation *mockLocation = [[CLLocation alloc] initWithLatitude:54.0 longitude:6.4];
+  XCTestExpectation *expectationStream = [self expectationWithDescription:@"expect result return third location"];
+    XCTestExpectation *expectationForeground = [self expectationWithDescription:@"expect result return third location"];
+  [_geolocationHandler startListeningWithDesiredAccuracy: kCLLocationAccuracyBest
+                                          distanceFilter:0
+                       pauseLocationUpdatesAutomatically:NO
+                         showBackgroundLocationIndicator:NO
+                                            activityType:CLActivityTypeOther
+                                           resultHandler:^(CLLocation * _Nullable location) {
+    XCTAssertEqual(location, mockLocation);
+    [expectationStream fulfill];
+  }
+                                            errorHandler:^(NSString * _Nonnull errorCode, NSString * _Nonnull errorDescription) {
+    
+  }];
+    
+  [_geolocationHandler requestPositionWithDesiredAccuracy:kCLLocationAccuracyHundredMeters
+                                            resultHandler:^(CLLocation * _Nullable location) {
+      XCTAssertEqual(location, mockLocation);
+      [expectationForeground fulfill];
+    } errorHandler:^(NSString * _Nonnull errorCode, NSString * _Nonnull errorDescription) {
+        
+    }];
+  [_geolocationHandler locationManager:_mockLocationManager didUpdateLocations: @[mockLocation]];
+  
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+  
+  OCMVerify(never(), [self->_mockLocationManager stopUpdatingLocation]);
+}
+
 - (void)testStartListeningShouldNotStopListeningOnError {
   NSError *error = [NSError errorWithDomain:kCLErrorDomain code:kCLErrorDenied userInfo:nil];
   XCTestExpectation *expectation = [self expectationWithDescription:@"expect result return third location"];

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.2.1
+version: 2.2.2
 
 environment:
   sdk: ">=2.15.0 <3.0.0"
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
 
   geolocator_platform_interface: ^4.0.5
-  
+
 dev_dependencies:
   async: ^2.8.2
   flutter_test:


### PR DESCRIPTION
This is my first PR so please be gentle :)

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Currently if the background location in enabled and you ask for the current location, the background stream will stop.

### :new: What is the new behavior (if this is a feature change)?
While listening to location updates, requesting the current location will not stop location updates.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Run the iOS example app, start listening for location updates and request the current position.

### :memo: Links to relevant issues/docs
Fixes #1122 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
