### PR TITLE
Export AndroidResource class from geolocator_android also in geolocator

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 9.0.2
+
+- Updated dependency on geolocator_android to version 4.1.3
+- Export `AndroidResource` class at `geolocator/lib/geolocator.dart.at`.
+
 ## 9.0.1
 
 - Migrates to Dart SDK 2.15.0 and Flutter 2.8.0.

--- a/geolocator/lib/geolocator.dart
+++ b/geolocator/lib/geolocator.dart
@@ -6,7 +6,7 @@ import 'package:geolocator_apple/geolocator_apple.dart';
 import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 
 export 'package:geolocator_android/geolocator_android.dart'
-    show AndroidSettings, ForegroundNotificationConfig;
+    show AndroidSettings, ForegroundNotificationConfig, AndroidResource;
 export 'package:geolocator_apple/geolocator_apple.dart'
     show AppleSettings, ActivityType;
 export 'package:geolocator_platform_interface/geolocator_platform_interface.dart';

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 9.0.1
+version: 9.0.2
 
 environment:
   sdk: ">=2.15.0 <3.0.0"
@@ -27,7 +27,7 @@ dependencies:
     sdk: flutter
 
   geolocator_platform_interface: ^4.0.3
-  geolocator_android: ^4.0.0
+  geolocator_android: ^4.1.3
   geolocator_apple: ^2.1.1+1
   geolocator_web: ^2.1.3
   geolocator_windows: ^0.1.0


### PR DESCRIPTION


### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Export `AndroidResource` class from the `geolocator` library to allow configuring the icon of the notifications

### :arrow_heading_down: What is the current behavior?
`AndroidResource` class is not exported, so there is no way to configure the `notificationIcon` of the `ForegroundNotificationConfig` class.

### :new: What is the new behavior (if this is a feature change)?
Users can use the `AndroidResource` class to configure the `notificationIcon` of the `ForegroundNotificationConfig` class.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
NA

### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter-geolocator/issues/1011

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
