### PR TITLE
Android location stream not cancelling

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.4
+
+- Fix a bug where the location service would not stop correctly when the location stream is cancelled.
+
 ## 4.1.3
 
 - Export `AndroidResource` class at `geolocator_android.at`.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -36,6 +36,7 @@ public class GeolocatorLocationService extends Service {
   // Service is foreground
   private boolean isForeground = false;
   private int connectedEngines = 0;
+  private int listenerCount = 0;
   @Nullable private Activity activity = null;
   @Nullable private GeolocationManager geolocationManager = null;
   @Nullable private LocationClient locationClient;
@@ -83,7 +84,10 @@ public class GeolocatorLocationService extends Service {
     super.onDestroy();
   }
 
-  public boolean canStopLocationService() {
+  public boolean canStopLocationService(boolean cancellationRequested) {
+    if(cancellationRequested) {
+       return listenerCount == 1;
+    }
     return connectedEngines == 0;
   }
 
@@ -104,6 +108,7 @@ public class GeolocatorLocationService extends Service {
       LocationOptions locationOptions,
       EventChannel.EventSink events) {
 
+    listenerCount++;
     if (geolocationManager != null) {
       locationClient =
           geolocationManager.createLocationClient(
@@ -121,6 +126,7 @@ public class GeolocatorLocationService extends Service {
   }
 
   public void stopLocationService() {
+    listenerCount--;
     Log.d(TAG, "Stopping location service.");
     if (locationClient != null && geolocationManager != null) {
       geolocationManager.stopPositionUpdates(locationClient);

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/StreamHandlerImpl.java
@@ -81,7 +81,7 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
       return;
     }
 
-    disposeListeners();
+    disposeListeners(false);
     channel.setStreamHandler(null);
     channel = null;
   }
@@ -145,12 +145,12 @@ class StreamHandlerImpl implements EventChannel.StreamHandler {
 
   @Override
   public void onCancel(Object arguments) {
-    disposeListeners();
+    disposeListeners(true);
   }
 
-  private void disposeListeners() {
+  private void disposeListeners(boolean cancelled) {
     Log.e(TAG, "Geolocator position updates stopped");
-    if (foregroundLocationService != null && foregroundLocationService.canStopLocationService()) {
+    if (foregroundLocationService != null && foregroundLocationService.canStopLocationService(cancelled)) {
       foregroundLocationService.stopLocationService();
       foregroundLocationService.disableBackgroundMode();
     } else {

--- a/geolocator_android/example/lib/main.dart
+++ b/geolocator_android/example/lib/main.dart
@@ -331,7 +331,8 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
         _positionStreamSubscription!.resume();
         statusDisplayValue = 'resumed';
       } else {
-        _positionStreamSubscription!.pause();
+        _positionStreamSubscription!.cancel();
+        _positionStreamSubscription = null;
         statusDisplayValue = 'paused';
       }
 

--- a/geolocator_android/example/lib/main.dart
+++ b/geolocator_android/example/lib/main.dart
@@ -331,8 +331,7 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
         _positionStreamSubscription!.resume();
         statusDisplayValue = 'resumed';
       } else {
-        _positionStreamSubscription!.cancel();
-        _positionStreamSubscription = null;
+        _positionStreamSubscription!.pause();
         statusDisplayValue = 'paused';
       }
 

--- a/geolocator_android/lib/src/types/android_settings.dart
+++ b/geolocator_android/lib/src/types/android_settings.dart
@@ -50,6 +50,12 @@ class AndroidSettings extends LocationSettings {
 
   /// If this is set then the services is started as a Foreground service with a persistent notification
   /// showing the user that the service will continue running in the background.
+  ///
+  /// Note: Using this foreground notification does not run your service in the background, it just
+  /// increases the priority of your activity making it less likely for Android to kill the activity
+  /// when switching between apps. It does not prevent Android from killing the activity. If you want to
+  /// receive background location updates even if the activity is destroyed you need to use a third party
+  /// background service package that will start a new Flutter Engine that is not tied to your main activity.
   final ForegroundNotificationConfig? foregroundNotificationConfig;
 
   /// Set to true if altitude should be calculated as MSL (EGM2008) from NMEA messages

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.1.3
+version: 4.1.4
 
 environment:
   sdk: ">=2.15.0 <3.0.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Currently when the location stream is cancelled the geolocator background service does not fully shutdown correctly.

### :new: What is the new behavior (if this is a feature change)?

This fixes the check for when multiple flutter engines are connected and location stream is explicitly being cancelled by the user instead of being cancelled by the activity process getting destroyed.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

1. Set the Android foreground config. Start the location stream and shortly after stop it. The foreground notification should be removed when the service shuts down.
2. When using a background service like flutter_background_service and starting the geolocator stream in the background service and then killing the main activity should not stop the geolocator service and it should continue to send position updates to the background service

### :memo: Links to relevant issues/docs

https://github.com/Baseflow/flutter-geolocator/issues/1142
https://github.com/Baseflow/flutter-geolocator/issues/986

### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
