### PR TITLE
Implement allowBackgroundLocationUpdates iOS setting

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.3
+
+- Implement allowBackgroundLocationUpdates iOS setting
+
 ## 2.2.2
 
 - Fix requesting location while listening to location stream stops the stream

--- a/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
+++ b/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
@@ -235,4 +235,40 @@
   OCMVerify(never(), [self->_mockLocationManager stopUpdatingLocation]);
 }
 
+- (void)testListeningBackgroundGeolocationOnlyWhenAllowedAndEnabled {
+    id geolocationHandlerMock = OCMPartialMock(_geolocationHandler);
+    [geolocationHandlerMock setLocationManagerOverride:_mockLocationManager];
+    OCMStub(ClassMethod([geolocationHandlerMock shouldEnableBackgroundLocationUpdates]))._andReturn([NSNumber numberWithBool:YES]);
+    [geolocationHandlerMock startListeningWithDesiredAccuracy: kCLLocationAccuracyBest
+                                            distanceFilter:0
+                         pauseLocationUpdatesAutomatically:NO
+                           showBackgroundLocationIndicator:NO
+                                              activityType:CLActivityTypeOther
+                            allowBackgroundLocationUpdates:YES
+                                             resultHandler:^(CLLocation * _Nullable location) {
+    }
+                                              errorHandler:^(NSString * _Nonnull errorCode, NSString * _Nonnull errorDescription) {
+      
+    }];
+    OCMVerify([_mockLocationManager setAllowsBackgroundLocationUpdates:YES]);
+}
+
+- (void)testNotListeningBackgroundGeolocationWhenNotEnabled {
+    id geolocationHandlerMock = OCMPartialMock(_geolocationHandler);
+    [geolocationHandlerMock setLocationManagerOverride:_mockLocationManager];
+    OCMStub(ClassMethod([geolocationHandlerMock shouldEnableBackgroundLocationUpdates]))._andReturn([NSNumber numberWithBool:YES]);
+    [geolocationHandlerMock startListeningWithDesiredAccuracy: kCLLocationAccuracyBest
+                                            distanceFilter:0
+                         pauseLocationUpdatesAutomatically:NO
+                           showBackgroundLocationIndicator:NO
+                                              activityType:CLActivityTypeOther
+                            allowBackgroundLocationUpdates:NO
+                                             resultHandler:^(CLLocation * _Nullable location) {
+    }
+                                              errorHandler:^(NSString * _Nonnull errorCode, NSString * _Nonnull errorDescription) {
+      
+    }];
+    OCMVerify(never(), [_mockLocationManager setAllowsBackgroundLocationUpdates:YES]);
+}
+
 @end

--- a/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
+++ b/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
@@ -139,6 +139,7 @@
                        pauseLocationUpdatesAutomatically:NO
                          showBackgroundLocationIndicator:NO
                                             activityType:CLActivityTypeOther
+                          allowBackgroundLocationUpdates:NO
                                            resultHandler:^(CLLocation * _Nullable location) {
     XCTAssertEqual(location, mockLocation);
     [expectation fulfill];
@@ -163,6 +164,7 @@
                        pauseLocationUpdatesAutomatically:NO
                          showBackgroundLocationIndicator:NO
                                             activityType:CLActivityTypeOther
+                          allowBackgroundLocationUpdates:NO
                                            resultHandler:^(CLLocation * _Nullable location) {
     XCTAssertEqual(location, mockLocation);
     [expectationStream fulfill];
@@ -193,6 +195,7 @@
                        pauseLocationUpdatesAutomatically:NO
                          showBackgroundLocationIndicator:NO
                                             activityType:CLActivityTypeOther
+                          allowBackgroundLocationUpdates:NO
                                            resultHandler:^(CLLocation * _Nullable location) {
   }
                                             errorHandler:^(NSString * _Nonnull errorCode, NSString * _Nonnull errorDescription) {
@@ -216,6 +219,7 @@
                        pauseLocationUpdatesAutomatically:NO
                          showBackgroundLocationIndicator:NO
                                             activityType:CLActivityTypeOther
+                          allowBackgroundLocationUpdates:NO
                                            resultHandler:^(CLLocation * _Nullable location) {
     [expectation fulfill];
   }

--- a/geolocator_apple/example/lib/main.dart
+++ b/geolocator_apple/example/lib/main.dart
@@ -298,8 +298,11 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
         accuracy: LocationAccuracy.best,
         distanceFilter: 10,
         activityType: ActivityType.other,
-        // Only set to true if our app will be started up in the background.
+        // Only set showBackgroundLocationIndicator and
+        // allowBackgroundLocationUpdates to true if our app will be started up
+        // in the background.
         showBackgroundLocationIndicator: false,
+        allowBackgroundLocationUpdates: false,
       ));
       _positionStreamSubscription = positionStream.handleError((e) {
         _positionStreamSubscription?.cancel();

--- a/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.h
+++ b/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.h
@@ -32,6 +32,7 @@ typedef void (^GeolocatorResult)(CLLocation *_Nullable location);
                              errorHandler:(GeolocatorError _Nonnull)errorHandler;
 
 - (void)stopListening;
++ (BOOL) shouldEnableBackgroundLocationUpdates;
 @end
 
 #endif /* GeolocatorHandler_h */

--- a/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.h
+++ b/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.h
@@ -27,6 +27,7 @@ typedef void (^GeolocatorResult)(CLLocation *_Nullable location);
         pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
           showBackgroundLocationIndicator:(BOOL)showBackgroundLocationIndicator
                              activityType:(CLActivityType)activityType
+           allowBackgroundLocationUpdates:(BOOL)allowBackgroundLocationUpdates
                             resultHandler:(GeolocatorResult _Nonnull)resultHandler
                              errorHandler:(GeolocatorError _Nonnull)errorHandler;
 

--- a/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
@@ -65,7 +65,8 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
                pauseLocationUpdatesAutomatically:NO
                                     activityType:CLActivityTypeOther
                    isListeningForPositionUpdates:self.isListeningForPositionUpdates
-                 showBackgroundLocationIndicator:NO];
+                 showBackgroundLocationIndicator:NO
+                  allowBackgroundLocationUpdates:NO];
 }
 
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
@@ -73,6 +74,7 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
         pauseLocationUpdatesAutomatically:(BOOL)pauseLocationUpdatesAutomatically
           showBackgroundLocationIndicator:(BOOL)showBackgroundLocationIndicator
                              activityType:(CLActivityType)activityType
+           allowBackgroundLocationUpdates:(BOOL)allowBackgroundLocationUpdates
                             resultHandler:(GeolocatorResult _Nonnull )resultHandler
                              errorHandler:(GeolocatorError _Nonnull)errorHandler {
     
@@ -84,7 +86,8 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
                pauseLocationUpdatesAutomatically:pauseLocationUpdatesAutomatically
                                     activityType:activityType
                    isListeningForPositionUpdates:YES
-                 showBackgroundLocationIndicator:showBackgroundLocationIndicator];
+                 showBackgroundLocationIndicator:showBackgroundLocationIndicator
+                  allowBackgroundLocationUpdates:allowBackgroundLocationUpdates];
 }
 
 - (void)startUpdatingLocationWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
@@ -93,6 +96,7 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
                                     activityType:(CLActivityType)activityType
                    isListeningForPositionUpdates:(BOOL)isListeningForPositionUpdates
                  showBackgroundLocationIndicator:(BOOL)showBackgroundLocationIndicator
+                  allowBackgroundLocationUpdates:(BOOL)allowBackgroundLocationUpdates
                             {
   self.isListeningForPositionUpdates = isListeningForPositionUpdates;
   CLLocationManager *locationManager = [self getLocationManager];
@@ -105,7 +109,8 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
   
 #if TARGET_OS_IOS
   if (@available(iOS 9.0, macOS 11.0, *)) {
-    locationManager.allowsBackgroundLocationUpdates = [GeolocationHandler shouldEnableBackgroundLocationUpdates];
+    locationManager.allowsBackgroundLocationUpdates = allowBackgroundLocationUpdates
+      && [GeolocationHandler shouldEnableBackgroundLocationUpdates];
   }
   if (@available(iOS 11.0, macOS 11.0, *)) {
     locationManager.showsBackgroundLocationIndicator = showBackgroundLocationIndicator;

--- a/geolocator_apple/ios/Classes/Handlers/PositionStreamHandler.m
+++ b/geolocator_apple/ios/Classes/Handlers/PositionStreamHandler.m
@@ -49,6 +49,7 @@
   CLLocationDistance distanceFilter = [LocationDistanceMapper toCLLocationDistance:(NSNumber *)arguments[@"distanceFilter"]];
   NSNumber* pauseLocationUpdatesAutomatically = arguments[@"pauseLocationUpdatesAutomatically"];
   CLActivityType activityType = [ActivityTypeMapper toCLActivityType:(NSNumber *)arguments[@"activityType"]];
+  NSNumber* allowBackgroundLocationUpdates = arguments[@"allowBackgroundLocationUpdates"];
 
   NSNumber* showBackgroundLocationIndicator = arguments[@"showBackgroundLocationIndicator"];
 	      
@@ -57,6 +58,7 @@
                                  pauseLocationUpdatesAutomatically:pauseLocationUpdatesAutomatically && [pauseLocationUpdatesAutomatically boolValue]
                                    showBackgroundLocationIndicator:showBackgroundLocationIndicator && [showBackgroundLocationIndicator boolValue]
                                                       activityType:activityType
+                                    allowBackgroundLocationUpdates:[allowBackgroundLocationUpdates boolValue]
                                                      resultHandler:^(CLLocation *location) {
     [weakSelf onLocationDidChange: location];
   }

--- a/geolocator_apple/lib/src/types/apple_settings.dart
+++ b/geolocator_apple/lib/src/types/apple_settings.dart
@@ -17,6 +17,7 @@ class AppleSettings extends LocationSettings {
     int distanceFilter = 0,
     Duration? timeLimit,
     this.showBackgroundLocationIndicator = false,
+    this.allowBackgroundLocationUpdates = true,
   }) : super(
           accuracy: accuracy,
           distanceFilter: distanceFilter,
@@ -41,6 +42,13 @@ class AppleSettings extends LocationSettings {
   /// have granted "always" permissions for location retrieval.
   final bool showBackgroundLocationIndicator;
 
+  /// Flag to allow the app to receive location updates in the background (iOS only)
+  ///
+  /// For this setting to work Info.plist should contain the following keys:
+  /// - UIBackgroundModes and the value should contain "location"
+  /// - NSLocationAlwaysUsageDescription
+  final bool allowBackgroundLocationUpdates;
+
   /// Returns a JSON representation of this class.
   @override
   Map<String, dynamic> toJson() {
@@ -49,6 +57,7 @@ class AppleSettings extends LocationSettings {
         'pauseLocationUpdatesAutomatically': pauseLocationUpdatesAutomatically,
         'this.activityType': activityType.index,
         'showBackgroundLocationIndicator': showBackgroundLocationIndicator,
+        'allowBackgroundLocationUpdates': allowBackgroundLocationUpdates,
       });
   }
 }

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.2.2
+version: 2.2.3
 
 environment:
   sdk: ">=2.15.0 <3.0.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently geolocator sets `allowBackgroundLocationUpdates` equal to `true` by default when the `UIBackgroundModes` contains `location` value inside the app's Info.plist, which leads to `Geolocator.getPositionStream` receiving background geolocations even if you don't need them

### :new: What is the new behavior (if this is a feature change)?
User can disable background geolocations updates even if their app contains `location` value inside the `UIBackgroundModes` key

### :boom: Does this PR introduce a breaking change?
No, `allowBackgroundLocationUpdates` is set to true by default

### :bug: Recommendations for testing
Can be tested on iOS devices and simulators
1. Add `location` value to the `UIBackgroundModes` Info.plist key
2. Request position stream with `getPositionStream` with `locationSettings` equal to:
```dart
AppleSettings(
  allowBackgroundLocationUpdates: false
)
```
3. Send app to the background 
4. Check that there is no background geolocation indicator visible in status bar

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
