### PR TITLE
Fix: iOS location manager background geolocation settings overridden by getCurrentPosition

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.4
+
+- Fixed iOS location manager background geolocation settings overridden by getCurrentPosition
+
 ## 2.2.3
 
 - Implement allowBackgroundLocationUpdates iOS setting

--- a/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
+++ b/geolocator_apple/example/ios/RunnerTests/GeolocationHandlerTests.m
@@ -271,4 +271,39 @@
     OCMVerify(never(), [_mockLocationManager setAllowsBackgroundLocationUpdates:YES]);
 }
 
+- (void)testKeepLocationManagerSettingsWhenRequestingCurrentPosition {
+  id geolocationHandlerMock = OCMPartialMock(_geolocationHandler);
+  [geolocationHandlerMock setLocationManagerOverride:_mockLocationManager];
+  OCMStub(ClassMethod([geolocationHandlerMock shouldEnableBackgroundLocationUpdates]))
+    ._andReturn([NSNumber numberWithBool:YES]);
+  OCMStub([_mockLocationManager allowsBackgroundLocationUpdates])
+    ._andReturn([NSNumber numberWithBool:YES]);
+  if (@available(iOS 11.0, *)) {
+    OCMStub([_mockLocationManager showsBackgroundLocationIndicator])
+      ._andReturn([NSNumber numberWithBool:YES]);
+  }
+  [geolocationHandlerMock startListeningWithDesiredAccuracy: kCLLocationAccuracyBest
+                                          distanceFilter:0
+                       pauseLocationUpdatesAutomatically:NO
+                         showBackgroundLocationIndicator:YES
+                                            activityType:CLActivityTypeOther
+                          allowBackgroundLocationUpdates:YES
+                                           resultHandler:^(CLLocation * _Nullable location) {
+  }
+                                            errorHandler:^(NSString * _Nonnull errorCode, NSString * _Nonnull errorDescription) {
+    
+  }];
+  OCMVerify([_mockLocationManager setAllowsBackgroundLocationUpdates:YES]);
+  if (@available(iOS 11.0, *)) {
+    OCMVerify([_mockLocationManager setShowsBackgroundLocationIndicator:YES]);
+  }
+  [geolocationHandlerMock requestPositionWithDesiredAccuracy: kCLLocationAccuracyBest
+                                               resultHandler:^(CLLocation * _Nullable location) {}
+                                                errorHandler:^(NSString * _Nonnull errorCode, NSString * _Nonnull errorDescription) {}];
+  OCMVerify(never(), [_mockLocationManager setAllowsBackgroundLocationUpdates:NO]);
+  if (@available(iOS 11.0, *)) {
+    OCMVerify(never(), [_mockLocationManager setShowsBackgroundLocationIndicator:NO]);
+  }
+}
+
 @end

--- a/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
@@ -14,7 +14,6 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
 @interface GeolocationHandler() <CLLocationManagerDelegate>
 
 @property(assign, nonatomic) bool isListeningForPositionUpdates;
-@property(assign, nonatomic) bool isBackgroundGeolocationAllowed;
 
 @property(strong, nonatomic, nonnull) CLLocationManager *locationManager;
 

--- a/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
@@ -14,6 +14,7 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
 @interface GeolocationHandler() <CLLocationManagerDelegate>
 
 @property(assign, nonatomic) bool isListeningForPositionUpdates;
+@property(assign, nonatomic) bool isBackgroundGeolocationAllowed;
 
 @property(strong, nonatomic, nonnull) CLLocationManager *locationManager;
 
@@ -59,14 +60,24 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
                               errorHandler:(GeolocatorError _Nonnull)errorHandler {
   self.errorHandler = errorHandler;
   self.currentLocationResultHandler = resultHandler;
+    
+  CLLocationManager *locationManager = [self getLocationManager];
+  BOOL showBackgroundLocationIndicator = NO;
+  BOOL allowBackgroundLocationUpdates = NO;
+  #if TARGET_OS_IOS
+    if (self.isListeningForPositionUpdates) {
+      showBackgroundLocationIndicator = locationManager.showsBackgroundLocationIndicator;
+      allowBackgroundLocationUpdates = locationManager.allowsBackgroundLocationUpdates;
+    }
+  #endif
   
   [self startUpdatingLocationWithDesiredAccuracy:desiredAccuracy
                                   distanceFilter:kCLDistanceFilterNone
                pauseLocationUpdatesAutomatically:NO
                                     activityType:CLActivityTypeOther
                    isListeningForPositionUpdates:self.isListeningForPositionUpdates
-                 showBackgroundLocationIndicator:NO
-                  allowBackgroundLocationUpdates:NO];
+                 showBackgroundLocationIndicator:showBackgroundLocationIndicator
+                  allowBackgroundLocationUpdates:allowBackgroundLocationUpdates];
 }
 
 - (void)startListeningWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.2.3
+version: 2.2.4
 
 environment:
   sdk: ">=2.15.0 <3.0.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When you request positions stream with `Geolocator.getPositionStream` and `showBackgroundLocationIndicator` or `allowBackgroundLocationUpdates` set to `true` and then request the current position with `Geolocator.getCurrentPosition`, you get the iOS location manager settings (`showBackgroundLocationIndicator` and `allowBackgroundLocationUpdates`) set back to `false`.

### :new: What is the new behavior (if this is a feature change)?
Calling `Geolocator.getCurrentPosition` is not affecting `showBackgroundLocationIndicator` and `allowBackgroundLocationUpdates` while listening for position updates.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
1. Start listening for background updates with `Geolocator.getPositionStream` and `allowBackgroundLocationUpdates` and `allowBackgroundLocationUpdates` set to `true`
2. Request current position with `Geolocator.getCurrentPosition`
3. Send the app to the background
4. Check if background indicator is active

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
