### PR TITLE
[macos] Fix GeolocatorApple plugin registration

### DIFF
--- a/.github/workflows/geolocator_apple.yaml
+++ b/.github/workflows/geolocator_apple.yaml
@@ -180,7 +180,7 @@ jobs:
     runs-on: macos-latest
 
     env:
-      xcodebuild-destination: "platform=iOS Simulator,OS=16,name=iPhone 14"
+      xcodebuild-destination: "platform=iOS Simulator,OS=16.0,name=iPhone 14"
       source-directory: ./geolocator_apple 
       example-directory: ./geolocator_apple/example
       ios-example-directory: ./geolocator_apple/example/ios

--- a/.github/workflows/geolocator_apple.yaml
+++ b/.github/workflows/geolocator_apple.yaml
@@ -180,7 +180,7 @@ jobs:
     runs-on: macos-latest
 
     env:
-      xcodebuild-destination: "platform=iOS Simulator,OS=15.2,name=iPhone 13"
+      xcodebuild-destination: "platform=iOS Simulator,OS=16,name=iPhone 14"
       source-directory: ./geolocator_apple 
       example-directory: ./geolocator_apple/example
       ios-example-directory: ./geolocator_apple/example/ios

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.5
+
+- Mark `geolocator_android` as implementation of `geolocator` 
+
 ## 4.1.4
 
 - Fix a bug where the location service would not stop correctly when the location stream is cancelled.

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.1.4
+version: 4.1.5
 
 environment:
   sdk: ">=2.15.0 <3.0.0"

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+  implements: geolocator
     platforms:
       android:
         package: com.baseflow.geolocator

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 flutter:
   plugin:
-  implements: geolocator
+    implements: geolocator
     platforms:
       android:
         package: com.baseflow.geolocator

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.4
+
+- Fix plugin registration in `dart_plugin_registrant.dart`
+
 ## 2.2.3
 
 - Implement allowBackgroundLocationUpdates iOS setting

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.2.3
+version: 2.2.4
 
 environment:
   sdk: ">=2.15.0 <3.0.0"

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: geolocator
     platforms:
       ios:
         pluginClass: GeolocatorPlugin

--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.7
+
+- Mark `geolocator_web` as implementation of `geolocator` 
+
 ## 2.1.6
 
 - Migrates to Dart SDK 2.15.0 and Flutter 2.8.0.

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -6,6 +6,7 @@ version: 2.1.6
 
 flutter:
   plugin:
+  implements: geolocator
     platforms:
       web:
         pluginClass: GeolocatorPlugin

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_web
 description: Official web implementation of the geolocator plugin.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_web
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.1.6
+version: 2.1.7
 
 flutter:
   plugin:

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.1.6
 
 flutter:
   plugin:
-  implements: geolocator
+    implements: geolocator
     platforms:
       web:
         pluginClass: GeolocatorPlugin

--- a/geolocator_windows/CHANGELOG.md
+++ b/geolocator_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- Fix plugin registration in `dart_plugin_registrant.dart`
+
 ## 0.1.1
 
 - Fixes repository URL of the package.

--- a/geolocator_windows/pubspec.yaml
+++ b/geolocator_windows/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+  implements: geolocator
     platforms:
       windows:
         pluginClass: GeolocatorWindows

--- a/geolocator_windows/pubspec.yaml
+++ b/geolocator_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_windows
 description: Geolocation Windows plugin for Flutter. This plugin provides the Windows implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_windows
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 0.1.1
+version: 0.1.2
 
 environment:
   sdk: ">=2.15.0 <3.0.0"

--- a/geolocator_windows/pubspec.yaml
+++ b/geolocator_windows/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 flutter:
   plugin:
-  implements: geolocator
+    implements: geolocator
     platforms:
       windows:
         pluginClass: GeolocatorWindows


### PR DESCRIPTION
On macos the plugin registration wasn't working. `dart_plugin_registrant.dart` did not include

```dart
    } else if (Platform.isMacOS) {
      try {
        GeolocatorApple.registerWith();
      } catch (err) {
        print(
          '`geolocator_apple` threw an error: $err. '
          'The app may not function as expected until you remove this plugin from pubspec.yaml'
        );
        rethrow;
      }
```

To fix it, I had to add the `implements: geolocator` to the platform implementations. The code above is now generated correctly by `flutter_tools`.

I changed it for all others where it was missing. But it should have only caused problems for [desktop platforms](https://github.com/flutter/flutter/blob/484e09ef798bb6feaad5942b81bcc92baa061e52/packages/flutter_tools/lib/src/flutter_plugins.dart#L1266-L1284)

This fixes #1129