### PR TITLE
- fixed an issue where the is service location would fail an not repo…

### DIFF
--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -146,6 +146,8 @@ class FusedLocationClient implements LocationClient {
                 } else {
                   listener.onLocationServiceError(ErrorCodes.locationServicesDisabled);
                 }
+              } else {
+                  listener.onLocationServiceError(ErrorCodes.locationServicesDisabled);
               }
             });
   }


### PR DESCRIPTION
Resolves Proposal 1 from the #1183 

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
It fixes an issue where the location service availability check fails and doesn't report anything.


### :arrow_heading_down: What is the current behavior?
Nothing, the check just hangs.


### :new: What is the new behavior (if this is a feature change)?
The check returns an error if it fails.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Install an app on a work profile part of the Android device, and disable the location for the work profile part, and it will be reproducible.

### :memo: Links to relevant issues/docs
#1183 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
