### PR TITLE
Update Play Services Location

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.6
+
+- Updates Play Services Location library
+
 ## 4.1.5
 
 - Mark `geolocator_android` as implementation of `geolocator` 

--- a/geolocator_android/android/build.gradle
+++ b/geolocator_android/android/build.gradle
@@ -37,6 +37,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-location:20.0.0'
-    implementation 'androidx.core:core:1.8.0'
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
+    implementation 'androidx.core:core:1.9.0'
 }

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.1.5
+version: 4.1.6
 
 environment:
   sdk: ">=2.15.0 <3.0.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Updates the Play Services Location library for Android

### :arrow_heading_down: What is the current behavior?

If you add 

### :new: What is the new behavior (if this is a feature change)?

App shouldn't crash

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Import a plugin that also adds the Play Services Location library (`camerawesome: 1.2.0`)

### :memo: Links to relevant issues/docs

[androidx.core](https://stackoverflow.com/questions/74085319/class-was-expected-declaration-of-com-google-android-gms-location-fusedlocatio)

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
