### PR TITLE
OpenIssue #581Handling PermissionRequestInProgressException on iOS fixed

### DIFF
--- a/geolocator_apple/ios/Classes/Handlers/PermissionHandler.m
+++ b/geolocator_apple/ios/Classes/Handlers/PermissionHandler.m
@@ -54,7 +54,6 @@
     // Permission request is already running, return immediatly with error
     errorHandler(GeolocatorErrorPermissionRequestInProgress,
                  @"A request for location permissions is already running, please wait for it to complete before doing another request.");
-    return;
   }
   
   self.confirmationHandler = confirmationHandler;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
It return is removed from the ios native permissionhandle.m

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?
In the permission request the popup appears and once the mobile locked then the popup disappear and the click will not do anything(thing is the await function waiting for the response from popup but the popup disappear(it is default iOS fn).

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter-geolocator/issues/581

### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [ ] I rebased onto current `master`.
