### PR TITLE
LocationManagerClient to avoid FUSED_PROVIDER

### DIFF
--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -75,43 +75,28 @@ class LocationManagerClient implements LocationClient, LocationListener {
 
   private static String getBestProvider(
       LocationManager locationManager, LocationAccuracy accuracy) {
-    Criteria criteria = new Criteria();
-
-    criteria.setBearingRequired(false);
-    criteria.setAltitudeRequired(false);
-    criteria.setSpeedRequired(false);
-
+    final boolean gpsEnabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+    final boolean networkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
     switch (accuracy) {
       case lowest:
-        criteria.setAccuracy(Criteria.NO_REQUIREMENT);
-        criteria.setHorizontalAccuracy(Criteria.NO_REQUIREMENT);
-        criteria.setPowerRequirement(Criteria.NO_REQUIREMENT);
-        break;
       case low:
-        criteria.setAccuracy(Criteria.ACCURACY_COARSE);
-        criteria.setHorizontalAccuracy(Criteria.ACCURACY_LOW);
-        criteria.setPowerRequirement(Criteria.NO_REQUIREMENT);
-        break;
       case medium:
-        criteria.setAccuracy(Criteria.ACCURACY_COARSE);
-        criteria.setHorizontalAccuracy(Criteria.ACCURACY_MEDIUM);
-        criteria.setPowerRequirement(Criteria.POWER_MEDIUM);
-        break;
+        if (networkEnabled) {
+          return LocationManager.NETWORK_PROVIDER;
+        }else if (gpsEnabled){
+          return LocationManager.GPS_PROVIDER;
+        }else{
+          return LocationManager.PASSIVE_PROVIDER;
+        }
       default:
-        criteria.setAccuracy(Criteria.ACCURACY_FINE);
-        criteria.setHorizontalAccuracy(Criteria.ACCURACY_HIGH);
-        criteria.setPowerRequirement(Criteria.POWER_HIGH);
-        break;
+        if (gpsEnabled) {
+          return LocationManager.GPS_PROVIDER;
+        }else if (networkEnabled){
+          return LocationManager.NETWORK_PROVIDER;
+        }else{
+          return LocationManager.PASSIVE_PROVIDER;
+        }
     }
-
-    String provider = locationManager.getBestProvider(criteria, true);
-
-    if (provider.trim().isEmpty()) {
-      List<String> providers = locationManager.getProviders(true);
-      if (providers.size() > 0) provider = providers.get(0);
-    }
-
-    return provider;
   }
 
   private static float accuracyToFloat(LocationAccuracy accuracy) {


### PR DESCRIPTION
!!!WARNING!!! This fixed an issue for me but I don't have enough understanding of the overall code to be sure this isn't causing undesired side-effects - MERGE AT YOUR OWN RISK - I'm making this code change available in case it helps, along with a description of the bug it is fixing.

The current implementation results in the `getBestProvider` method sometimes returning `LocationManager.PASSIVE_PROVIDER`, which is not what I would expect from the LocationManagerClient, since we're trying to avoid using the fused provider.

This change is to ensure the provider returned is always `LocationManager.GPS_PROVIDER` or `LocationManager.NETWORK_PROVIDER`.

In my app using `forceLocationManager` everywhere, this creates the following bug:
* Start the app with location services disabled
* Attempt to access your location and get prompted to enable location services
* Enable location services
* Attempt to get the location from the app
* The bug happens:
    * EXPECTED: the location becomes available to the app
    * ACTUAL: the location is not available to the app until the app is restarted

I hope this helps!

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)


### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [ ] I rebased onto current `master`.
