### PR TITLE
Cancel location stream on `getCurrentPosition` timeout

### DIFF
--- a/.github/workflows/geolocator.yaml
+++ b/.github/workflows/geolocator.yaml
@@ -30,6 +30,10 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
       
       # Make sure the stable version of Flutter is available
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/geolocator.yaml
+++ b/.github/workflows/geolocator.yaml
@@ -71,8 +71,10 @@ jobs:
         working-directory: ${{env.source-directory}}
 
       # Upload code coverage information
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ${{env.source-directory}}/coverage/lcov.info # optional
           name: geolocator (App Facing Package) # optional
+          flags: unittests # optional
           fail_ci_if_error: true

--- a/.github/workflows/geolocator_android.yaml
+++ b/.github/workflows/geolocator_android.yaml
@@ -41,8 +41,8 @@ jobs:
         run: flutter pub get
         working-directory: ${{env.source-directory}}
 
-      # Run Flutter Format to ensure formatting is valid
-      - name: Run Flutter Format
+      # Run Dart Format to ensure formatting is valid
+      - name: Run Dart Format
         run: dart format --set-exit-if-changed .
         working-directory: ${{env.source-directory}}
 

--- a/geolocator/example/android/app/build.gradle
+++ b/geolocator/example/android/app/build.gradle
@@ -33,9 +33,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 33
 
-    lintOptions {
-        disable 'InvalidPackage'
-    }
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
@@ -52,6 +49,10 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
+    }
+    namespace 'com.baseflow.geolocator_example'
+    lint {
+        disable 'InvalidPackage'
     }
 }
 

--- a/geolocator/example/android/app/src/debug/AndroidManifest.xml
+++ b/geolocator/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.baseflow.geolocator_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/geolocator/example/android/app/src/main/AndroidManifest.xml
+++ b/geolocator/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.baseflow.geolocator_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide

--- a/geolocator/example/android/app/src/profile/AndroidManifest.xml
+++ b/geolocator/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.baseflow.geolocator_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/geolocator/example/android/build.gradle
+++ b/geolocator/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.1.2'
     }
 }
 

--- a/geolocator/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/geolocator/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip

--- a/geolocator/example/lib/main.dart
+++ b/geolocator/example/lib/main.dart
@@ -118,7 +118,7 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
           ExamplePage(
             Icons.location_on,
             (context) => Scaffold(
-              backgroundColor: Theme.of(context).backgroundColor,
+              backgroundColor: Theme.of(context).colorScheme.background,
               body: ListView.builder(
                 itemCount: _positionItems.length,
                 itemBuilder: (context, index) {

--- a/geolocator/example/pubspec.yaml
+++ b/geolocator/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
-  baseflow_plugin_template: ^2.1.1
+  baseflow_plugin_template: ^2.1.2
   
   flutter:
     sdk: flutter
@@ -46,5 +46,3 @@ flutter:
   assets:
     - res/images/baseflow_logo_def_light-02.png
     - res/images/poweredByBaseflowLogoLight@3x.png
-    - packages/baseflow_plugin_template/logo.png
-    - packages/baseflow_plugin_template/poweredByBaseflow.png

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.9
+
+* Fixes a bug where the location service would not stop correctly when the location stream timed out.
+
 ## 4.1.8
 
 * Adds compatibility with Android Gradle Plugin 8.0.

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.1.9
 
-* Fixes a bug where the location service would not stop correctly when the location stream timed out.
+* Resolves an issue where the location service failed to stop properly upon timeout of the location stream.
 
 ## 4.1.8
 

--- a/geolocator_android/android/build.gradle
+++ b/geolocator_android/android/build.gradle
@@ -43,4 +43,7 @@ android {
 dependencies {
     implementation 'com.google.android.gms:play-services-location:21.0.1'
     implementation 'androidx.core:core:1.9.0'
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.1.1'
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/MethodCallHandlerImpl.java
@@ -24,6 +24,8 @@ import com.baseflow.geolocator.utils.Utils;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
+
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -37,6 +39,8 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
   private final GeolocationManager geolocationManager;
   private final LocationAccuracyManager locationAccuracyManager;
 
+  private final Map<String, LocationClient> pendingCurrentPositionLocationClients;
+
   @Nullable private Context context;
 
   @Nullable private Activity activity;
@@ -48,6 +52,7 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     this.permissionManager = permissionManager;
     this.geolocationManager = geolocationManager;
     this.locationAccuracyManager = locationAccuracyManager;
+    this.pendingCurrentPositionLocationClients = new HashMap<>();
   }
 
   @Nullable private MethodChannel channel;
@@ -72,6 +77,9 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
         break;
       case "getCurrentPosition":
         onGetCurrentPosition(call, result);
+        break;
+      case "cancelGetCurrentPosition":
+        onCancelGetCurrentPosition(call, result);
         break;
       case "openAppSettings":
         boolean hasOpenedAppSettings = Utils.openAppSettings(this.context);
@@ -190,6 +198,13 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
             result.error(errorCode.toString(), errorCode.toDescription(), null));
   }
 
+    /**
+     * Retrieves the current position.
+     *
+     * <p>Listens to location updates until it receives a location or encounters an error.
+     *
+     * <p>To manually cancel this request, call {@link #onCancelGetCurrentPosition}.
+     */
   private void onGetCurrentPosition(MethodCall call, MethodChannel.Result result) {
     try {
       if (!permissionManager.hasPermission(context)) {
@@ -210,14 +225,17 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     @SuppressWarnings("unchecked")
     Map<String, Object> map = (Map<String, Object>) call.arguments;
     boolean forceLocationManager = false;
-    if (map != null && map.get("forceLocationManager") != null) {
+    if (map.get("forceLocationManager") != null) {
       forceLocationManager = (boolean) map.get("forceLocationManager");
     }
     LocationOptions locationOptions = LocationOptions.parseArguments(map);
+    String requestId = (String) map.get("requestId");
+
     final boolean[] replySubmitted = {false};
 
     LocationClient locationClient =
         geolocationManager.createLocationClient(context, forceLocationManager, locationOptions);
+    pendingCurrentPositionLocationClients.put(requestId, locationClient);
 
     geolocationManager.startPositionUpdates(
         locationClient,
@@ -229,6 +247,7 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
           replySubmitted[0] = true;
           geolocationManager.stopPositionUpdates(locationClient);
+          pendingCurrentPositionLocationClients.remove(requestId);
           result.success(LocationMapper.toHashMap(location));
         },
         (ErrorCodes errorCode) -> {
@@ -238,7 +257,24 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
           replySubmitted[0] = true;
           geolocationManager.stopPositionUpdates(locationClient);
+          pendingCurrentPositionLocationClients.remove(requestId);
           result.error(errorCode.toString(), errorCode.toDescription(), null);
         });
   }
+
+    /**
+     * Cancels a request for the current position that was initiated with {@link #onGetCurrentPosition}.
+     */
+    private void onCancelGetCurrentPosition(MethodCall call, MethodChannel.Result result) {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> arguments = (Map<String, Object>) call.arguments;
+      String requestId = (String) arguments.get("requestId");
+
+      LocationClient locationClient = this.pendingCurrentPositionLocationClients.get(requestId);
+      if (locationClient != null) {
+        locationClient.stopPositionUpdates();
+      }
+
+      result.success(null);
+    }
 }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationMapper.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationMapper.java
@@ -6,7 +6,6 @@ import android.os.Build;
 import java.util.HashMap;
 import java.util.Map;
 
-@SuppressWarnings("deprecation")
 public class LocationMapper {
   public static Map<String, Object> toHashMap(Location location) {
     if (location == null) {

--- a/geolocator_android/android/src/test/java/com/baseflow/geolocator/MethodCallHandlerImplTest.java
+++ b/geolocator_android/android/src/test/java/com/baseflow/geolocator/MethodCallHandlerImplTest.java
@@ -1,0 +1,132 @@
+package com.baseflow.geolocator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.location.Location;
+
+import com.baseflow.geolocator.errors.PermissionUndefinedException;
+import com.baseflow.geolocator.location.GeolocationManager;
+import com.baseflow.geolocator.location.LocationAccuracyManager;
+import com.baseflow.geolocator.location.LocationClient;
+import com.baseflow.geolocator.location.LocationMapper;
+import com.baseflow.geolocator.location.PositionChangedCallback;
+import com.baseflow.geolocator.permission.PermissionManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+
+public class MethodCallHandlerImplTest {
+  @Mock PermissionManager mockPermissionManager;
+  @Mock GeolocationManager mockGeolocationManager;
+  @Mock LocationAccuracyManager mockLocationAccuracyManager;
+  @Mock Location mockLocation;
+  @Mock LocationClient mockLocationClient;
+  @Mock AutoCloseable mockCloseable;
+
+  @Before
+  public void setUp() throws PermissionUndefinedException {
+    mockCloseable = MockitoAnnotations.openMocks(this);
+
+    when(mockLocation.getLatitude()).thenReturn(10.0);
+    when(mockLocation.getLongitude()).thenReturn(20.0);
+    when(mockLocation.getTime()).thenReturn(30L);
+    when(mockLocation.isMock()).thenReturn(false);
+    when(mockPermissionManager.hasPermission(any())).thenReturn(true);
+    when(mockGeolocationManager.createLocationClient(any(), anyBoolean(), any()))
+        .thenReturn(mockLocationClient);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mockCloseable.close();
+  }
+
+  @Test
+  public void onGetCurrentPosition_getsPosition() {
+    // Arrange
+    MethodCallHandlerImpl methodCallHandler = createMethodCallHandler();
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+
+    final ArgumentCaptor<PositionChangedCallback> callbackCaptor =
+        ArgumentCaptor.forClass(PositionChangedCallback.class);
+    Answer<Void> answer = invocation -> {
+      callbackCaptor.getValue().onPositionChanged(mockLocation);
+      return null;
+    };
+    doAnswer(answer)
+        .when(mockGeolocationManager)
+        .startPositionUpdates(any(), any(), callbackCaptor.capture(), any());
+
+    Map<String, Object> arguments = new HashMap<>();
+    ArgumentCaptor<Object> resultCaptor = ArgumentCaptor.forClass(Object.class);
+    Map<String, Object> expectedJson = LocationMapper.toHashMap(mockLocation);
+
+    // Act
+    methodCallHandler.onMethodCall(new MethodCall("getCurrentPosition", arguments), mockResult);
+
+    // Assert
+    verify(mockResult).success(resultCaptor.capture());
+    assertEquals(expectedJson, resultCaptor.getValue());
+  }
+
+  @Test
+  public void onGetCurrentPosition_setsPendingLocationClient() {
+    // Arrange
+    MethodCallHandlerImpl methodCallHandler = createMethodCallHandler();
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+
+    String requestId = "example_request_id";
+    Map<String, Object> arguments = new HashMap<>();
+    arguments.put("requestId", requestId);
+
+    // Act
+    methodCallHandler.onMethodCall(new MethodCall("getCurrentPosition", arguments), mockResult);
+
+    // Assert
+    assertTrue(methodCallHandler.pendingCurrentPositionLocationClients.containsKey(requestId));
+  }
+
+  @Test
+  public void onCancelGetCurrentPosition_clearsPendingLocationClient() {
+    // Arrange
+    MethodCallHandlerImpl methodCallHandler = createMethodCallHandler();
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+
+    String requestId = "example_request_id";
+    methodCallHandler.pendingCurrentPositionLocationClients.put(requestId, null);
+    Map<String, Object> arguments = new HashMap<>();
+    arguments.put("requestId", requestId);
+
+    // Act
+    methodCallHandler.onMethodCall(new MethodCall("cancelGetCurrentPosition", arguments), mockResult);
+
+    // Assert
+    assertTrue(methodCallHandler.pendingCurrentPositionLocationClients.isEmpty());
+  }
+
+  private MethodCallHandlerImpl createMethodCallHandler() {
+    return new MethodCallHandlerImpl(
+        mockPermissionManager,
+        mockGeolocationManager,
+        mockLocationAccuracyManager
+    );
+  }
+}

--- a/geolocator_android/example/android/app/src/main/AndroidManifest.xml
+++ b/geolocator_android/example/android/app/src/main/AndroidManifest.xml
@@ -51,4 +51,12 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+
+    <queries>
+      <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="https" />
+      </intent>
+    </queries>
 </manifest>

--- a/geolocator_android/example/android/build.gradle
+++ b/geolocator_android/example/android/build.gradle
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/geolocator_android/example/pubspec.yaml
+++ b/geolocator_android/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
-  baseflow_plugin_template: ^2.1.1
+  baseflow_plugin_template: ^2.1.2
   flutter:
     sdk: flutter
 
@@ -45,5 +45,3 @@ flutter:
   assets:
     - res/images/baseflow_logo_def_light-02.png
     - res/images/poweredByBaseflowLogoLight@3x.png
-    - packages/baseflow_plugin_template/logo.png
-    - packages/baseflow_plugin_template/poweredByBaseflow.png

--- a/geolocator_android/lib/src/geolocator_android.dart
+++ b/geolocator_android/lib/src/geolocator_android.dart
@@ -101,8 +101,9 @@ class GeolocatorAndroid extends GeolocatorPlatform {
   @override
   Future<Position> getCurrentPosition({
     LocationSettings? locationSettings,
+    String? requestId,
   }) async {
-    final String requestId = _uuid.v4();
+    requestId = requestId ?? _uuid.v4();
 
     try {
       Future<dynamic> positionFuture;

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.1.8
+version: 4.1.9
 
 environment:
   sdk: ">=2.15.0 <3.0.0"
@@ -21,6 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   geolocator_platform_interface: ^4.0.4
+  uuid: ^3.0.7
 
 dev_dependencies:
   async: ^2.8.2

--- a/geolocator_android/test/event_channel_mock.dart
+++ b/geolocator_android/test/event_channel_mock.dart
@@ -14,7 +14,7 @@ class EventChannelMock {
     required String channelName,
     required this.stream,
   }) : _methodChannel = MethodChannel(channelName) {
-    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(_methodChannel, _handler);
   }
 
@@ -76,11 +76,7 @@ class EventChannelMock {
   }
 
   void _sendEnvelope(ByteData? envelope) {
-    if (TestDefaultBinaryMessengerBinding.instance == null) {
-      return;
-    }
-
-    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .handlePlatformMessage(
       _methodChannel.name,
       envelope,

--- a/geolocator_android/test/geolocator_android_test.dart
+++ b/geolocator_android/test/geolocator_android_test.dart
@@ -37,9 +37,14 @@ void main() {
           () async {
         // Arrange
         MethodChannelMock(
-            channelName: 'flutter.baseflow.com/geolocator_android',
-            method: 'checkPermission',
-            result: LocationPermission.whileInUse.index);
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          methods: [
+            MethodMock(
+              methodName: 'checkPermission',
+              result: LocationPermission.whileInUse.index,
+            ),
+          ],
+        );
 
         // Act
         final permission = await GeolocatorAndroid().checkPermission();
@@ -54,9 +59,14 @@ void main() {
       test('Should receive always if permission is granted always', () async {
         // Arrange
         MethodChannelMock(
-            channelName: 'flutter.baseflow.com/geolocator_android',
-            method: 'checkPermission',
-            result: LocationPermission.always.index);
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          methods: [
+            MethodMock(
+              methodName: 'checkPermission',
+              result: LocationPermission.always.index,
+            ),
+          ],
+        );
 
         // Act
         final permission = await GeolocatorAndroid().checkPermission();
@@ -71,9 +81,14 @@ void main() {
       test('Should receive denied if permission is denied', () async {
         // Arrange
         MethodChannelMock(
-            channelName: 'flutter.baseflow.com/geolocator_android',
-            method: 'checkPermission',
-            result: LocationPermission.denied.index);
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          methods: [
+            MethodMock(
+              methodName: 'checkPermission',
+              result: LocationPermission.denied.index,
+            ),
+          ],
+        );
 
         // Act
         final permission = await GeolocatorAndroid().checkPermission();
@@ -89,9 +104,14 @@ void main() {
           () async {
         // Arrange
         MethodChannelMock(
-            channelName: 'flutter.baseflow.com/geolocator_android',
-            method: 'checkPermission',
-            result: LocationPermission.deniedForever.index);
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          methods: [
+            MethodMock(
+              methodName: 'checkPermission',
+              result: LocationPermission.deniedForever.index,
+            ),
+          ],
+        );
 
         // Act
         final permission = await GeolocatorAndroid().checkPermission();
@@ -108,12 +128,16 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'checkPermission',
-          result: PlatformException(
-            code: 'PERMISSION_DEFINITIONS_NOT_FOUND',
-            message: 'Permission definitions are not found.',
-            details: null,
-          ),
+          methods: [
+            MethodMock(
+              methodName: 'checkPermission',
+              result: PlatformException(
+                code: 'PERMISSION_DEFINITIONS_NOT_FOUND',
+                message: 'Permission definitions are not found.',
+                details: null,
+              ),
+            ),
+          ],
         );
 
         // Act
@@ -141,9 +165,14 @@ void main() {
           ' reduced', () async {
         // Arrange
         final methodChannel = MethodChannelMock(
-            channelName: 'flutter.baseflow.com/geolocator_android',
-            method: 'requestTemporaryFullAccuracy',
-            result: 0);
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          methods: const [
+            MethodMock(
+              methodName: 'requestTemporaryFullAccuracy',
+              result: 0,
+            ),
+          ],
+        );
 
         final expectedArguments = <String, dynamic>{
           'purposeKey': 'purposeKeyValue',
@@ -170,9 +199,14 @@ void main() {
           ' to precise location accuracy', () async {
         // Arrange
         MethodChannelMock(
-            channelName: 'flutter.baseflow.com/geolocator_android',
-            method: 'requestTemporaryFullAccuracy',
-            result: 1);
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          methods: const [
+            MethodMock(
+              methodName: 'requestTemporaryFullAccuracy',
+              result: 1,
+            ),
+          ],
+        );
 
         // Act
         final accuracy = await GeolocatorAndroid()
@@ -187,12 +221,16 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'requestTemporaryFullAccuracy',
-          result: PlatformException(
-            code: 'PERMISSION_DEFINITIONS_NOT_FOUND',
-            message: 'Permission definitions are not found.',
-            details: null,
-          ),
+          methods: [
+            MethodMock(
+              methodName: 'requestTemporaryFullAccuracy',
+              result: PlatformException(
+                code: 'PERMISSION_DEFINITIONS_NOT_FOUND',
+                message: 'Permission definitions are not found.',
+                details: null,
+              ),
+            ),
+          ],
         );
 
         // Act
@@ -220,8 +258,12 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'getLocationAccuracy',
-          result: 0,
+          methods: const [
+            MethodMock(
+              methodName: 'getLocationAccuracy',
+              result: 0,
+            ),
+          ],
         );
 
         // Act
@@ -237,8 +279,12 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'getLocationAccuracy',
-          result: 1,
+          methods: const [
+            MethodMock(
+              methodName: 'getLocationAccuracy',
+              result: 1,
+            ),
+          ],
         );
 
         // Act
@@ -257,9 +303,14 @@ void main() {
           () async {
         // Arrange
         MethodChannelMock(
-            channelName: 'flutter.baseflow.com/geolocator_android',
-            method: 'requestPermission',
-            result: LocationPermission.whileInUse.index);
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          methods: [
+            MethodMock(
+              methodName: 'requestPermission',
+              result: LocationPermission.whileInUse.index,
+            ),
+          ],
+        );
 
         // Act
         final permission = await GeolocatorAndroid().requestPermission();
@@ -274,9 +325,14 @@ void main() {
       test('Should receive always if permission is granted always', () async {
         // Arrange
         MethodChannelMock(
-            channelName: 'flutter.baseflow.com/geolocator_android',
-            method: 'requestPermission',
-            result: LocationPermission.always.index);
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          methods: [
+            MethodMock(
+              methodName: 'requestPermission',
+              result: LocationPermission.always.index,
+            ),
+          ],
+        );
 
         // Act
         final permission = await GeolocatorAndroid().requestPermission();
@@ -291,9 +347,14 @@ void main() {
       test('Should receive denied if permission is denied', () async {
         // Arrange
         MethodChannelMock(
-            channelName: 'flutter.baseflow.com/geolocator_android',
-            method: 'requestPermission',
-            result: LocationPermission.denied.index);
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          methods: [
+            MethodMock(
+              methodName: 'requestPermission',
+              result: LocationPermission.denied.index,
+            )
+          ],
+        );
 
         // Act
         final permission = await GeolocatorAndroid().requestPermission();
@@ -309,9 +370,14 @@ void main() {
           () async {
         // Arrange
         MethodChannelMock(
-            channelName: 'flutter.baseflow.com/geolocator_android',
-            method: 'requestPermission',
-            result: LocationPermission.deniedForever.index);
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          methods: [
+            MethodMock(
+              methodName: 'requestPermission',
+              result: LocationPermission.deniedForever.index,
+            ),
+          ],
+        );
 
         // Act
         final permission = await GeolocatorAndroid().requestPermission();
@@ -328,12 +394,16 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'requestPermission',
-          result: PlatformException(
-            code: "PERMISSION_REQUEST_IN_PROGRESS",
-            message: "Permissions already being requested.",
-            details: null,
-          ),
+          methods: [
+            MethodMock(
+              methodName: 'requestPermission',
+              result: PlatformException(
+                code: "PERMISSION_REQUEST_IN_PROGRESS",
+                message: "Permissions already being requested.",
+                details: null,
+              ),
+            ),
+          ],
         );
 
         // Act
@@ -357,12 +427,16 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'requestPermission',
-          result: PlatformException(
-            code: 'PERMISSION_DEFINITIONS_NOT_FOUND',
-            message: 'Permission definitions are not found.',
-            details: null,
-          ),
+          methods: [
+            MethodMock(
+              methodName: 'requestPermission',
+              result: PlatformException(
+                code: 'PERMISSION_DEFINITIONS_NOT_FOUND',
+                message: 'Permission definitions are not found.',
+                details: null,
+              ),
+            ),
+          ],
         );
 
         // Act
@@ -386,12 +460,16 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'requestPermission',
-          result: PlatformException(
-            code: 'ACTIVITY_MISSING',
-            message: 'Activity is missing.',
-            details: null,
-          ),
+          methods: [
+            MethodMock(
+              methodName: 'requestPermission',
+              result: PlatformException(
+                code: 'ACTIVITY_MISSING',
+                message: 'Activity is missing.',
+                details: null,
+              ),
+            ),
+          ],
         );
 
         // Act
@@ -417,8 +495,12 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'isLocationServiceEnabled',
-          result: true,
+          methods: const [
+            MethodMock(
+              methodName: 'isLocationServiceEnabled',
+              result: true,
+            ),
+          ],
         );
 
         // Act
@@ -436,8 +518,12 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'isLocationServiceEnabled',
-          result: false,
+          methods: const [
+            MethodMock(
+              methodName: 'isLocationServiceEnabled',
+              result: false,
+            ),
+          ],
         );
 
         // Act
@@ -457,8 +543,12 @@ void main() {
         // Arrange
         final methodChannel = MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'getLastKnownPosition',
-          result: mockPosition.toJson(),
+          methods: [
+            MethodMock(
+              methodName: 'getLastKnownPosition',
+              result: mockPosition.toJson(),
+            ),
+          ],
         );
 
         final expectedArguments = <String, dynamic>{
@@ -484,12 +574,16 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'getLastKnownPosition',
-          result: PlatformException(
-            code: "PERMISSION_DENIED",
-            message: "Permission denied",
-            details: null,
-          ),
+          methods: [
+            MethodMock(
+              methodName: 'getLastKnownPosition',
+              result: PlatformException(
+                code: "PERMISSION_DENIED",
+                message: "Permission denied",
+                details: null,
+              ),
+            ),
+          ],
         );
 
         // Act
@@ -515,23 +609,36 @@ void main() {
       test('Should receive a position if permissions are granted', () async {
         // Arrange
         final channel = MethodChannelMock(
-            channelName: 'flutter.baseflow.com/geolocator_android',
-            method: 'getCurrentPosition',
-            result: mockPosition.toJson());
-        const expectedArguments =
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          methods: [
+            MethodMock(
+              methodName: 'getCurrentPosition',
+              result: mockPosition.toJson(),
+            ),
+          ],
+        );
+
+        const requestId = 'requestId';
+        const locationSettings =
             LocationSettings(accuracy: LocationAccuracy.low);
+
+        final expectedArguments = <String, dynamic>{
+          ...locationSettings.toJson(),
+          'requestId': requestId,
+        };
 
         // Act
         final position = await GeolocatorAndroid().getCurrentPosition(
-            locationSettings:
-                const LocationSettings(accuracy: LocationAccuracy.low));
+          locationSettings: locationSettings,
+          requestId: requestId,
+        );
 
         // Assert
         expect(position, mockPosition);
         expect(channel.log, <Matcher>[
           isMethodCall(
             'getCurrentPosition',
-            arguments: expectedArguments.toJson(),
+            arguments: expectedArguments,
           ),
         ]);
       });
@@ -540,26 +647,41 @@ void main() {
         // Arrange
         final channel = MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'getCurrentPosition',
-          result: mockPosition.toJson(),
+          methods: [
+            MethodMock(
+              methodName: 'getCurrentPosition',
+              result: mockPosition.toJson(),
+            ),
+          ],
         );
-        const expectedFirstArguments = LocationSettings(
-          accuracy: LocationAccuracy.low,
-        );
-        const expectedSecondArguments = LocationSettings(
-          accuracy: LocationAccuracy.high,
-        );
+
+        const requestIdFirst = 'requestIdFirst';
+        const requestIdSecond = 'requestIdSecond';
+
+        const locationSettingsFirst =
+            LocationSettings(accuracy: LocationAccuracy.low);
+        const locationSettingsSecond =
+            LocationSettings(accuracy: LocationAccuracy.high);
+
+        final expectedFirstArguments = <String, dynamic>{
+          ...locationSettingsFirst.toJson(),
+          'requestId': requestIdFirst,
+        };
+        final expectedSecondArguments = <String, dynamic>{
+          ...locationSettingsSecond.toJson(),
+          'requestId': requestIdSecond,
+        };
 
         // Act
         final plugin = GeolocatorAndroid();
         final firstPosition = await plugin.getCurrentPosition(
-            locationSettings: const LocationSettings(
-          accuracy: LocationAccuracy.low,
-        ));
+          locationSettings: locationSettingsFirst,
+          requestId: requestIdFirst,
+        );
         final secondPosition = await plugin.getCurrentPosition(
-            locationSettings: const LocationSettings(
-          accuracy: LocationAccuracy.high,
-        ));
+          locationSettings: locationSettingsSecond,
+          requestId: requestIdSecond,
+        );
 
         // Assert
         expect(firstPosition, mockPosition);
@@ -567,11 +689,11 @@ void main() {
         expect(channel.log, <Matcher>[
           isMethodCall(
             'getCurrentPosition',
-            arguments: expectedFirstArguments.toJson(),
+            arguments: expectedFirstArguments,
           ),
           isMethodCall(
             'getCurrentPosition',
-            arguments: expectedSecondArguments.toJson(),
+            arguments: expectedSecondArguments,
           ),
         ]);
       });
@@ -581,12 +703,16 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'getCurrentPosition',
-          result: PlatformException(
-            code: 'PERMISSION_DENIED',
-            message: 'Permission denied',
-            details: null,
-          ),
+          methods: [
+            MethodMock(
+              methodName: 'getCurrentPosition',
+              result: PlatformException(
+                code: 'PERMISSION_DENIED',
+                message: 'Permission denied',
+                details: null,
+              ),
+            ),
+          ],
         );
 
         // Act
@@ -612,12 +738,16 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'getCurrentPosition',
-          result: PlatformException(
-            code: 'LOCATION_SERVICES_DISABLED',
-            message: '',
-            details: null,
-          ),
+          methods: [
+            MethodMock(
+              methodName: 'getCurrentPosition',
+              result: PlatformException(
+                code: 'LOCATION_SERVICES_DISABLED',
+                message: '',
+                details: null,
+              ),
+            ),
+          ],
         );
 
         // Act
@@ -635,9 +765,16 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          delay: const Duration(milliseconds: 10),
-          method: 'getCurrentPosition',
-          result: mockPosition.toJson(),
+          methods: [
+            MethodMock(
+              methodName: 'getCurrentPosition',
+              delay: const Duration(milliseconds: 10),
+              result: mockPosition.toJson(),
+            ),
+            const MethodMock(
+              methodName: 'cancelGetCurrentPosition',
+            ),
+          ],
         );
 
         try {
@@ -650,6 +787,36 @@ void main() {
           fail('Expected a TimeoutException and should not reach here.');
         } on TimeoutException catch (e) {
           expect(e, isA<TimeoutException>());
+        }
+      });
+
+      test('Should cancel location stream when timeLimit is reached', () async {
+        // Arrange
+        const cancelMethodName = 'cancelGetCurrentPosition';
+        final methodChannel = MethodChannelMock(
+          channelName: 'flutter.baseflow.com/geolocator_android',
+          methods: const [
+            MethodMock(
+              methodName: 'getCurrentPosition',
+              delay: Duration(milliseconds: 10),
+            ),
+            MethodMock(
+              methodName: cancelMethodName,
+            ),
+          ],
+        );
+
+        // Act
+        try {
+          await GeolocatorAndroid().getCurrentPosition(
+            locationSettings: const LocationSettings(
+              timeLimit: Duration(milliseconds: 5),
+            ),
+          );
+          fail('Expected a TimeoutException and should not reach here.');
+        } on TimeoutException {
+          // Assert
+          expect(methodChannel.calledMethodName(cancelMethodName), isTrue);
         }
       });
     });
@@ -1168,8 +1335,12 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'openAppSettings',
-          result: true,
+          methods: const [
+            MethodMock(
+              methodName: 'openAppSettings',
+              result: true,
+            ),
+          ],
         );
 
         // Act
@@ -1187,8 +1358,12 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'openAppSettings',
-          result: false,
+          methods: const [
+            MethodMock(
+              methodName: 'openAppSettings',
+              result: false,
+            ),
+          ],
         );
 
         // Act
@@ -1208,8 +1383,12 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'openLocationSettings',
-          result: true,
+          methods: const [
+            MethodMock(
+              methodName: 'openLocationSettings',
+              result: true,
+            ),
+          ],
         );
 
         // Act
@@ -1227,8 +1406,12 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'openLocationSettings',
-          result: false,
+          methods: const [
+            MethodMock(
+              methodName: 'openLocationSettings',
+              result: false,
+            ),
+          ],
         );
 
         // Act
@@ -1292,8 +1475,12 @@ void main() {
         // Arrange
         MethodChannelMock(
           channelName: 'flutter.baseflow.com/geolocator_android',
-          method: 'openLocationSettings',
-          result: false,
+          methods: const [
+            MethodMock(
+              methodName: 'openLocationSettings',
+              result: false,
+            ),
+          ],
         );
 
         // Act

--- a/geolocator_android/test/method_channel_mock.dart
+++ b/geolocator_android/test/method_channel_mock.dart
@@ -22,7 +22,7 @@ class MethodChannelMock {
     required String channelName,
     required this.methods,
   }) : methodChannel = MethodChannel(channelName) {
-    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(methodChannel, _handler);
   }
 

--- a/geolocator_android/test/method_channel_mock.dart
+++ b/geolocator_android/test/method_channel_mock.dart
@@ -1,18 +1,26 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class MethodChannelMock {
+class MethodMock {
   final Duration delay;
-  final MethodChannel methodChannel;
-  final String method;
+  final String methodName;
   final dynamic result;
+
+  const MethodMock({
+    required this.methodName,
+    this.delay = Duration.zero,
+    this.result,
+  });
+}
+
+class MethodChannelMock {
+  final List<MethodMock> methods;
+  final MethodChannel methodChannel;
   final log = <MethodCall>[];
 
   MethodChannelMock({
     required String channelName,
-    required this.method,
-    this.delay = Duration.zero,
-    this.result,
+    required this.methods,
   }) : methodChannel = MethodChannel(channelName) {
     TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
         .setMockMethodCallHandler(methodChannel, _handler);
@@ -21,17 +29,28 @@ class MethodChannelMock {
   Future _handler(MethodCall methodCall) async {
     log.add(methodCall);
 
-    if (methodCall.method != method) {
-      throw MissingPluginException('No implementation found for method '
-          '$method on channel ${methodChannel.name}');
-    }
+    final method = methods.firstWhere(
+      (MethodMock methodMock) => methodMock.methodName == methodCall.method,
+      orElse: () => throw MissingPluginException(
+        'No implementation found for '
+        'method ${methodCall.method} on channel ${methodChannel.name}',
+      ),
+    );
 
-    return Future.delayed(delay, () {
-      if (result is Exception) {
-        throw result;
+    return Future.delayed(method.delay, () {
+      if (method.result is Exception) {
+        throw method.result;
       }
 
-      return Future.value(result);
+      return Future.value(method.result);
     });
+  }
+
+  bool calledMethodName(String methodName) {
+    return log.any((MethodCall call) => call.method == methodName);
+  }
+
+  bool calledMethod(MethodCall method) {
+    return log.any((MethodCall call) => call == method);
   }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR fixes a bug where Android kept polling for a location after a request for the current location timed out.
Additionally, it enhances the `MethodChannelMock` class to cater to multiple mock methods.

### :arrow_heading_down: What is the current behavior?
Currently, when calling `getCurrentPosition()` with a provided `timeout`, the plugin will keep polling the gps on Android after the timeout, instead of cancelling the operation.

### :new: What is the new behavior (if this is a feature change)?
After a timeout, Android is instructed to stop polling the gps.

### :boom: Does this PR introduce a breaking change?
This PR does not introduce a breaking change.

### :bug: Recommendations for testing
The PR includes a test that checks whether the cancel request is fired after the request times out. The `MethodChannelMock` class was updated in the process.

### :memo: Links to relevant issues/docs
Closes #1259.

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
