### PR TITLE
Ensure the isLocationServicesEnabled method runs on a background thread.

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.6
+
+* Ensures the `isLocationServicesEnabled` method is executed in a background thread.
+
 ## 2.2.5
 
 * Fixes a bug where iOS location manager background geolocation settings are overridden by calls to the `getCurrentPosition` method.

--- a/geolocator_apple/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/geolocator_apple/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/geolocator_apple/example/ios/Podfile
+++ b/geolocator_apple/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+# platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -31,7 +31,7 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   
   target 'RunnerTests' do
-    platform :ios, '9.0'
+    platform :ios, '11.0'
     inherit! :search_paths
     # Pods for testing
     pod 'OCMock', '~> 3.8.1'

--- a/geolocator_apple/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/geolocator_apple/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -282,10 +282,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -340,6 +342,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -445,7 +448,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -527,7 +530,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -576,7 +579,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -653,7 +656,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -680,7 +683,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.baseflow.geolocatorExample.RunnerTests;
@@ -706,7 +709,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.baseflow.geolocatorExample.RunnerTests;

--- a/geolocator_apple/example/ios/Runner/Info.plist
+++ b/geolocator_apple/example/ios/Runner/Info.plist
@@ -48,5 +48,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/geolocator_apple/example/lib/main.dart
+++ b/geolocator_apple/example/lib/main.dart
@@ -173,6 +173,11 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
                     child: const Icon(Icons.bookmark),
                     onPressed: _getLastKnownPosition,
                   ),
+                  sizedBox,
+                  FloatingActionButton(
+                    child: const Icon(Icons.question_mark),
+                    onPressed: _isLocationServiceEnabled,
+                  ),
                 ],
               ),
             ),
@@ -364,6 +369,16 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
         'No last known position available',
       );
     }
+  }
+
+  Future<void> _isLocationServiceEnabled() async {
+    final bool isLocationServiceEnabled =
+        await geolocatorApple.isLocationServiceEnabled();
+    final String displayValue = isLocationServiceEnabled
+        ? 'Location services are enabled.'
+        : 'Location services are disabled.';
+
+    _updatePositionList(_PositionItemType.log, displayValue);
   }
 
   void _getLocationAccuracy() async {

--- a/geolocator_apple/example/pubspec.yaml
+++ b/geolocator_apple/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
-  baseflow_plugin_template: ^2.1.1
+  baseflow_plugin_template: ^2.1.2
   flutter:
     sdk: flutter
 
@@ -45,5 +45,3 @@ flutter:
   assets:
     - res/images/baseflow_logo_def_light-02.png
     - res/images/poweredByBaseflowLogoLight@3x.png
-    - packages/baseflow_plugin_template/logo.png
-    - packages/baseflow_plugin_template/poweredByBaseflow.png

--- a/geolocator_apple/ios/Classes/GeolocatorPlugin.m
+++ b/geolocator_apple/ios/Classes/GeolocatorPlugin.m
@@ -86,8 +86,7 @@
   } else if ([@"requestPermission" isEqualToString:call.method]) {
     [self onRequestPermission:result];
   } else if ([@"isLocationServiceEnabled" isEqualToString:call.method]) {
-    BOOL isEnabled = [CLLocationManager locationServicesEnabled];
-    result([NSNumber numberWithBool:isEnabled]);
+    [self onIsLocationServiceEnabled:result];
   } else if ([@"getLastKnownPosition" isEqualToString:call.method]) {
     [self onGetLastKnownPosition:result];
   } else if ([@"getCurrentPosition" isEqualToString:call.method]) {
@@ -123,6 +122,15 @@
                                message: errorDescription
                                details: nil]);
   }];
+}
+
+- (void)onIsLocationServiceEnabled:(FlutterResult)result {
+  dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    BOOL isEnabled = [CLLocationManager locationServicesEnabled];
+    dispatch_async(dispatch_get_main_queue(), ^(void) {
+        result([NSNumber numberWithBool:isEnabled]);
+    });
+  });
 }
 
 - (void)onGetLastKnownPosition:(FlutterResult)result {

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.2.5
+version: 2.2.6
 
 environment:
   sdk: ">=2.15.0 <3.0.0"


### PR DESCRIPTION
The current version of the plugin executes the `CLLocationManager isLocationServicesEnabled` method on the main thread which results in an exception since iOS 16 (Xcode 14).

This PR ensures the `CLLocationManager isLocationServicesEnabled` is executed on a background thread and only returns the result on the main thread.

Related issues:
- Resolves #1128 
- Resolves #1151 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `main`.
