### PR TITLE
Use 'dart format' instead of 'flutter format'.

### DIFF
--- a/.github/workflows/geolocator.yaml
+++ b/.github/workflows/geolocator.yaml
@@ -43,7 +43,7 @@ jobs:
 
       # Run Flutter Format to ensure formatting is valid
       - name: Run Flutter Format
-        run: flutter format --set-exit-if-changed .
+        run: dart format --set-exit-if-changed .
         working-directory: ${{env.source-directory}}
      
       # Run Flutter Analyzer

--- a/.github/workflows/geolocator_android.yaml
+++ b/.github/workflows/geolocator_android.yaml
@@ -43,7 +43,7 @@ jobs:
 
       # Run Flutter Format to ensure formatting is valid
       - name: Run Flutter Format
-        run: flutter format --set-exit-if-changed .
+        run: dart format --set-exit-if-changed .
         working-directory: ${{env.source-directory}}
 
       # Run Flutter Analyzer

--- a/.github/workflows/geolocator_apple.yaml
+++ b/.github/workflows/geolocator_apple.yaml
@@ -43,7 +43,7 @@ jobs:
 
       # Run Flutter Format to ensure formatting is valid
       - name: Run Flutter Format
-        run: flutter format --set-exit-if-changed .
+        run: dart format --set-exit-if-changed .
         working-directory: ${{env.source-directory}}
 
       # Run Flutter Analyzer

--- a/.github/workflows/geolocator_linux.yaml
+++ b/.github/workflows/geolocator_linux.yaml
@@ -48,7 +48,7 @@ jobs:
 
       # Run Flutter Format to ensure formatting is valid
       - name: Run Flutter Format
-        run: flutter format --set-exit-if-changed .
+        run: dart format --set-exit-if-changed .
         working-directory: ${{env.source-directory}}
 
       # Run Flutter Analyzer

--- a/.github/workflows/geolocator_platform_interface.yaml
+++ b/.github/workflows/geolocator_platform_interface.yaml
@@ -17,7 +17,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   ci:
-    name: Format
+    name: Geolocator Platform Interface
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
 
       # Run Flutter Format to ensure formatting is valid
       - name: Run Flutter Format
-        run: flutter format --set-exit-if-changed .
+        run: dart format --set-exit-if-changed .
         working-directory: ${{env.source-directory}}
    
       # Run Flutter Analyzer

--- a/.github/workflows/geolocator_web.yaml
+++ b/.github/workflows/geolocator_web.yaml
@@ -16,7 +16,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   format:
-    name: Format
+    name: Web Platform Package
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -41,31 +41,7 @@ jobs:
 
       # Run Flutter Format to ensure formatting is valid
       - name: Run Flutter Format
-        run: flutter format --set-exit-if-changed .
-        working-directory: ${{env.source-directory}}
-        
-  analyze:
-    name: Analyze
-    
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    env:
-      source-directory: ./geolocator_web
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-      
-      # Make sure the stable version of Flutter is available
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-
-      # Download all Flutter packages
-      - name: Download dependencies
-        run: flutter pub get
+        run: dart format --set-exit-if-changed .
         working-directory: ${{env.source-directory}}
      
       # Run Flutter Analyzer
@@ -73,31 +49,6 @@ jobs:
         run: flutter analyze
         working-directory: ${{env.source-directory}}
         
-  build_web:
-    name: Build Web App
-    
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    env:
-      source-directory: ./geolocator_web 
-      example-directory: ./geolocator_web/example
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-      
-      # Make sure the stable version of Flutter is available
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-
-      # Download all Flutter packages
-      - name: Download dependencies
-        run: flutter pub get
-        working-directory: ${{env.source-directory}}
-
       # Build Web version of the example App
       - name: Run Web build
         run: flutter build web --release --no-sound-null-safety

--- a/.github/workflows/geolocator_windows.yaml
+++ b/.github/workflows/geolocator_windows.yaml
@@ -47,7 +47,7 @@ jobs:
 
       # Run Flutter Format to ensure formatting is valid
       - name: Run Flutter Format
-        run: flutter format --set-exit-if-changed .
+        run: dart format --set-exit-if-changed .
         working-directory: ${{env.source-directory}}
 
       # Run Flutter Analyzer


### PR DESCRIPTION
Updates the CI build configuration to use the `dart format` command instead of the deprecated `flutter format` command.

Resolves #1266 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
