### PR TITLE
Fix activity type propagation

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.7
 
-* Fix activity type setting propagation.
+* Fixes the propagation of the activity type setting.
 
 ## 2.2.6
 

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.7
+
+* Fix activity type setting propagation.
+
 ## 2.2.6
 
 * Ensures the `isLocationServicesEnabled` method is executed in a background thread.

--- a/geolocator_apple/lib/src/types/apple_settings.dart
+++ b/geolocator_apple/lib/src/types/apple_settings.dart
@@ -55,7 +55,7 @@ class AppleSettings extends LocationSettings {
     return super.toJson()
       ..addAll({
         'pauseLocationUpdatesAutomatically': pauseLocationUpdatesAutomatically,
-        'this.activityType': activityType.index,
+        'activityType': activityType.index,
         'showBackgroundLocationIndicator': showBackgroundLocationIndicator,
         'allowBackgroundLocationUpdates': allowBackgroundLocationUpdates,
       });

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.2.6
+version: 2.2.7
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
`activityType` in `AppleSettings` does nothing and location service is always started with `CLActivityType.other` type which is quite serious since it affects iOS power management. 

### :new: What is the new behavior (if this is a feature change)?
`activityType` is properly propagated to the native side.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
