### PR TITLE
Fixes wrong constant for stopForeground method

### DIFF
--- a/.github/workflows/geolocator.yaml
+++ b/.github/workflows/geolocator.yaml
@@ -30,10 +30,12 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
+
+      # Ensures JAVA 17 is installed on the build agent.
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
       
       # Make sure the stable version of Flutter is available
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/geolocator.yaml
+++ b/.github/workflows/geolocator.yaml
@@ -31,11 +31,11 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
-      # Ensures JAVA 17 is installed on the build agent.
+      # Ensures JAVA 11 is installed on the build agent.
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       
       # Make sure the stable version of Flutter is available
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/geolocator_android.yaml
+++ b/.github/workflows/geolocator_android.yaml
@@ -31,6 +31,12 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       
+      # Ensures JAVA 17 is installed on the build agent.
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       # Make sure the stable version of Flutter is available
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/geolocator_android.yaml
+++ b/.github/workflows/geolocator_android.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
 
       # Make sure the stable version of Flutter is available
       - uses: subosito/flutter-action@v2

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.2.1
+
+* Fixes a bug where the `stopForeground` method was called with the wrong constant, resulting in a build time error.
+* Fixes deprecation warnings on Android API 33.
+
 ## 4.2.0
 
 * Introduces the `setOngoing` flag in `ForegroundNotificationConfig` to make notification persistent.

--- a/geolocator_android/android/build.gradle
+++ b/geolocator_android/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 

--- a/geolocator_android/android/build.gradle
+++ b/geolocator_android/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:8.0.2'
     }
 }
 

--- a/geolocator_android/android/src/main/AndroidManifest.xml
+++ b/geolocator_android/android/src/main/AndroidManifest.xml
@@ -1,7 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.baseflow.geolocator">
-
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <service

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -156,7 +156,7 @@ public class GeolocatorLocationService extends Service {
     if (isForeground) {
       Log.d(TAG, "Stop service in foreground.");
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        stopForeground(ONGOING_NOTIFICATION_ID);
+        stopForeground(Service.STOP_FOREGROUND_REMOVE);
       } else {
         stopForeground(true);
       }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/errors/PermissionUndefinedException.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/errors/PermissionUndefinedException.java
@@ -1,3 +1,6 @@
 package com.baseflow.geolocator.errors;
 
+import android.annotation.SuppressLint;
+
+@SuppressWarnings("serial")
 public class PermissionUndefinedException extends Exception {}

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.IntentSender;
 import android.location.Location;
+import android.os.Build;
 import android.os.Looper;
 import android.util.Log;
 
@@ -83,6 +84,24 @@ class FusedLocationClient implements LocationClient {
   }
 
   private static LocationRequest buildLocationRequest(@Nullable LocationOptions options) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      return buildLocationRequestDeprecated(options);
+    }
+
+    LocationRequest.Builder builder = new LocationRequest.Builder(0);
+
+    if (options != null) {
+      builder.setPriority(toPriority(options.getAccuracy()));
+      builder.setIntervalMillis(options.getTimeInterval());
+      builder.setMinUpdateIntervalMillis(options.getTimeInterval());
+      builder.setMinUpdateDistanceMeters(options.getDistanceFilter());
+    }
+
+    return builder.build();
+  }
+
+  @SuppressWarnings("deprecation")
+  private static LocationRequest buildLocationRequestDeprecated(@Nullable LocationOptions options) {
     LocationRequest locationRequest = LocationRequest.create();
 
     if (options != null) {

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationMapper.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationMapper.java
@@ -17,6 +17,7 @@ public class LocationMapper {
     position.put("latitude", location.getLatitude());
     position.put("longitude", location.getLongitude());
     position.put("timestamp", location.getTime());
+    position.put("is_mocked", isMocked(location));
 
     if (location.hasAltitude()) position.put("altitude", location.getAltitude());
     if (location.hasAccuracy()) position.put("accuracy", (double) location.getAccuracy());
@@ -25,14 +26,6 @@ public class LocationMapper {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && location.hasSpeedAccuracy())
       position.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-      position.put("is_mocked", location.isMock());
-    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-      position.put("is_mocked", location.isFromMockProvider());
-    } else {
-      position.put("is_mocked", false);
-    }
-
     if (location.getExtras() != null) {
       if (location.getExtras().containsKey(NmeaClient.NMEA_ALTITUDE_EXTRA)) {
         Double mslAltitude = location.getExtras().getDouble(NmeaClient.NMEA_ALTITUDE_EXTRA);
@@ -40,5 +33,16 @@ public class LocationMapper {
       }
     }
     return position;
+  }
+
+  @SuppressWarnings("deprecation")
+  private static boolean isMocked(Location location) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      return location.isMock();
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+      return location.isFromMockProvider();
+    } else {
+      return false;
+    }
   }
 }

--- a/geolocator_android/example/android/app/build.gradle
+++ b/geolocator_android/example/android/app/build.gradle
@@ -31,7 +31,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    namespace 'com.baseflow.geolocator.example'
+    namespace 'com.baseflow.geolocator_example'
     compileSdkVersion 33
 
     lintOptions {

--- a/geolocator_android/example/android/app/src/debug/AndroidManifest.xml
+++ b/geolocator_android/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.baseflow.geolocator_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/geolocator_android/example/android/app/src/main/AndroidManifest.xml
+++ b/geolocator_android/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.baseflow.geolocator_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide
@@ -10,6 +9,8 @@
     <!-- Permissions options for the `location` group -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name="${applicationName}"

--- a/geolocator_android/example/android/app/src/profile/AndroidManifest.xml
+++ b/geolocator_android/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.baseflow.geolocator_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/geolocator_android/example/android/build.gradle
+++ b/geolocator_android/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:8.0.2'
     }
 }
 
@@ -26,4 +26,16 @@ subprojects {
 
 tasks.register("clean", Delete) {
     delete rootProject.buildDir
+}
+
+// Build the plugin project with warnings enabled. This is here rather than
+// in the plugin itself to avoid breaking clients that have different
+// warnings (e.g., deprecation warnings from a newer SDK than this project
+// builds with).
+gradle.projectsEvaluated {
+    project(":geolocator_android") {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:all"
+        }
+    }
 }

--- a/geolocator_android/example/android/build.gradle
+++ b/geolocator_android/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 

--- a/geolocator_android/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/geolocator_android/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/geolocator_android/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/geolocator_android/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.2.0
+version: 4.2.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Fixes an issue where the wrong constant is supplied to the `stopForeground` method (see [documentation](https://developer.android.com/reference/android/app/Service#stopForeground(int))).

This PR also addresses some deprecation warnings that showed up when running Android lint against `compileSdkVersion 33`.

Resolves #1199 

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
