### PR TITLE
Synchronize default position values

### DIFF
--- a/geolocator_windows/CHANGELOG.md
+++ b/geolocator_windows/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0
+
+* **BREAKING CHANGE:** Synchronizes the default values of `Position.altitude`, `Position.heading` and `Position.speed` with the other platforms and return 0.0 is the value is not known.
+* Migrates the `target_compile_options` to use `/await:strict` to make the options compatible with C++ 20.
+
 ## 0.1.2
 
 * Adds improved Flutter analysis and resolved warnings.

--- a/geolocator_windows/CHANGELOG.md
+++ b/geolocator_windows/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.0
 
-* **BREAKING CHANGE:** Synchronizes the default values of `Position.altitude`, `Position.heading` and `Position.speed` with the other platforms and return 0.0 is the value is not known.
+* **BREAKING CHANGE:** Synchronizes the default values of `Position.altitude`, `Position.heading` and `Position.speed` with the other platforms and return 0.0 if the value is not known.
 * Migrates the `target_compile_options` to use `/await:strict` to make the options compatible with C++ 20.
 
 ## 0.1.2

--- a/geolocator_windows/example/lib/main.dart
+++ b/geolocator_windows/example/lib/main.dart
@@ -177,7 +177,7 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
     final position = await geolocatorWindows.getCurrentPosition();
     _updatePositionList(
       _PositionItemType.position,
-      position.toString(),
+      '$position (Heading: ${position.heading}, Speed: ${position.speed})',
     );
   }
 

--- a/geolocator_windows/pubspec.yaml
+++ b/geolocator_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_windows
 description: Geolocation Windows plugin for Flutter. This plugin provides the Windows implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocators
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 0.1.2
+version: 0.2.0
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/geolocator_windows/windows/CMakeLists.txt
+++ b/geolocator_windows/windows/CMakeLists.txt
@@ -53,7 +53,7 @@ add_library(${PLUGIN_NAME} SHARED
 apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_20)
-target_compile_options(${PLUGIN_NAME} PRIVATE /await)
+target_compile_options(${PLUGIN_NAME} PRIVATE /await:strict)
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/geolocator_windows/windows/geolocator_plugin.cpp
+++ b/geolocator_windows/windows/geolocator_plugin.cpp
@@ -251,18 +251,22 @@ EncodableMap GeolocatorPlugin::LocationToEncodableMap(Geoposition const& locatio
   position.insert(std::make_pair(EncodableValue("longitude"), EncodableValue(location.Coordinate().Longitude())));
   position.insert(std::make_pair(EncodableValue("timestamp"), EncodableValue(clock::to_time_t(location.Coordinate().Timestamp()))));
 
-  if (location.Coordinate().Altitude() != nullptr) {
-    position.insert(std::make_pair(EncodableValue("altitude"), EncodableValue(location.Coordinate().Altitude().GetDouble())));
-  }
-
+  double altitude = location.Coordinate().Altitude() != nullptr && !std::isnan(location.Coordinate().Altitude().GetDouble())
+    ? location.Coordinate().Altitude().GetDouble()
+    : 0;
+  position.insert(std::make_pair(EncodableValue("altitude"), EncodableValue(altitude)));
+  
   position.insert(std::make_pair(EncodableValue("accuracy"), EncodableValue(location.Coordinate().Accuracy())));
   
-  if (location.Coordinate().Heading() != nullptr) {
-    position.insert(std::make_pair(EncodableValue("heading"), EncodableValue(location.Coordinate().Heading().GetDouble())));
-  }
-  if (location.Coordinate().Speed() != nullptr) {
-    position.insert(std::make_pair(EncodableValue("speed"), EncodableValue(location.Coordinate().Speed().GetDouble())));
-  }
+  double heading = location.Coordinate().Heading() != nullptr && !std::isnan(location.Coordinate().Heading().GetDouble())
+    ? location.Coordinate().Heading().GetDouble()
+    : 0;
+  position.insert(std::make_pair(EncodableValue("heading"), EncodableValue(heading)));
+  
+  double speed = location.Coordinate().Speed() != nullptr && !std::isnan(location.Coordinate().Speed().GetDouble())
+    ? location.Coordinate().Speed().GetDouble()
+    : 0;
+  position.insert(std::make_pair(EncodableValue("speed"), EncodableValue(speed)));
 
   position.insert(std::make_pair(EncodableValue("is_mocked"), EncodableValue(false)));
 


### PR DESCRIPTION
Synchronizes the default values of `Position.altitude`, `Position.heading` and `Position.speed` with the other platforms. This means that is one of these values is unknown it will return 0 instead of NaN.

This PR also sets the `target_compile_options` to `/await:strict` so the application is compatible with C++ 20.
 
Solves #1222 and solves #1045.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
