### PR TITLE
Added PositionStatus::Initializing status to trigger statusGeolocator.StatusChanged notification

### DIFF
--- a/geolocator_windows/CHANGELOG.md
+++ b/geolocator_windows/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.3
+
+* Added PositionStatus::Initializing status consideration since it triggers the state change 
+if "Let apps access your location" toggle option is switched ON from OFF
+
 ## 0.1.2
 
 * Adds improved Flutter analysis and resolved warnings.

--- a/geolocator_windows/CHANGELOG.md
+++ b/geolocator_windows/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.1.3
 
-* Added PositionStatus::Initializing status consideration since it triggers the state change 
-if "Let apps access your location" toggle option is switched ON from OFF
+* Adds a `PositionStatus::Initializing` status consideration since it triggers the state change 
+if "Let apps access your location" toggle option is switched ON from OFF.
 
 ## 0.1.2
 

--- a/geolocator_windows/pubspec.yaml
+++ b/geolocator_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_windows
 description: Geolocation Windows plugin for Flutter. This plugin provides the Windows implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocators
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 0.1.2
+version: 0.1.3
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/geolocator_windows/windows/geolocator_plugin.cpp
+++ b/geolocator_windows/windows/geolocator_plugin.cpp
@@ -223,7 +223,8 @@ std::unique_ptr<StreamHandlerError<EncodableValue>> GeolocatorPlugin::OnServiceL
     [events = std::move(events), this](Geolocator const& geolocator, StatusChangedEventArgs e)
     {
       if (m_currentStatus != PositionStatus::Disabled && e.Status() == PositionStatus::Disabled
-        || m_currentStatus != PositionStatus::Ready && e.Status() == PositionStatus::Ready) {
+        || m_currentStatus != PositionStatus::Ready && e.Status() == PositionStatus::Ready
+        || m_currentStatus != PositionStatus::Initializing && e.Status() == PositionStatus::Initializing ) {
         auto status = e.Status() == PositionStatus::NotAvailable
           ? ServiceStatus::Disabled
           : ServiceStatus::Enabled;


### PR DESCRIPTION
Added PositionStatus::Initializing status consideration since it triggers the state change if "Let apps access your location" toggle option is switched ON from OFF

This change is necessary because for windows, when "Let apps access your location" toggle option is switched ON from OFF, there is no status change being received since there is only restriction for PositionStatus::Ready and PositionStatus::Disabled change. 

Fix is done by adding another condition to trigger statusGeolocator.StatusChanged notification.

This will fix [Bug]: Not receiving status updates when Let apps access your location is toggled ON #1305

## Pre-launch Checklist

- [X] I made sure the project builds.
- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [X] I updated `CHANGELOG.md` to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I rebased onto `main`.
- [X] I added new tests to check the change I am making, or this PR does not need tests.
- [X] I made sure all existing and new tests are passing.
- [X] I ran `dart format .` and committed any changes.
- [X] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
