### PR TITLE
Updates the dependency on geolocator_windows

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.0.0
+
+- **BREAKING CHANGE:** Updates dependency on geolocator_windows to version 0.2.0. This will synchronize default values for `Position.altitude`, `Position.heading` and `Position.speed` with the other platforms. 
+
 ## 9.0.2
 
 - Updated dependency on geolocator_android to version 4.1.3
@@ -11,8 +15,8 @@
 
 > **IMPORTANT:** when updating to version 9.0.0 make sure to also set the `compileSdkVersion` in the `android/app/build.gradle` file to `33`.
 
-- Updated dependency on geolocator_android to version 4.0.0;
-- Make sure the Android example app compiles against Android SDK 33.
+- Updates dependency on geolocator_android to version 4.0.0;
+- Makes sure the Android example app compiles against Android SDK 33.
 
 ## 8.2.1
 

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 9.0.2
+version: 10.0.0
 
 environment:
   sdk: ">=2.15.0 <3.0.0"
@@ -30,7 +30,7 @@ dependencies:
   geolocator_android: ^4.1.3
   geolocator_apple: ^2.1.1+1
   geolocator_web: ^2.1.3
-  geolocator_windows: ^0.1.0
+  geolocator_windows: ^0.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Updates the geolocator_windows dependency from `^0.1.0` to `^0.2.0`. This will ensure default values on `Position.altitude`, `Position.heading` and `Position.speed` are in sync across all platforms.

Solves #1222 

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
