### PR TITLE
Platform interface: Updates documentation surrounding location accuracy on Android

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.8
+
+- Updates documentation for `getCurrentPosition()` and `LocationAccuracy`, to clarify the behavior of location accuracy on Android devices.
+
 ## 4.0.7
 
 - Fixed a spelling error in docs.

--- a/geolocator_platform_interface/lib/src/enums/location_accuracy.dart
+++ b/geolocator_platform_interface/lib/src/enums/location_accuracy.dart
@@ -1,28 +1,49 @@
 /// Represent the possible location accuracy values.
 enum LocationAccuracy {
-  /// Location is accurate within a distance of 3000m on iOS and 500m on Android
+  /// Location is accurate within a distance of 3000m on iOS and 500m on Android.
+  ///
+  /// On Android, corresponds to
+  /// [PRIORITY_PASSIVE](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_passive).
   lowest,
 
-  /// Location is accurate within a distance of 1000m on iOS and 500m on Android
+  /// Location is accurate within a distance of 1000m on iOS and 500m on Android.
+  ///
+  /// On Android, corresponds to
+  /// [PRIORITY_LOW_POWER](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_low_power).
   low,
 
   /// Location is accurate within a distance of 100m on iOS and between 100m and
-  /// 500m on Android
+  /// 500m on Android.
+  ///
+  /// On Android, corresponds to
+  /// [PRIORITY_BALANCED_POWER_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_balanced_power_accuracy).
   medium,
 
   /// Location is accurate within a distance of 10m on iOS and between 0m and
-  /// 100m on Android
+  /// 100m on Android.
+  ///
+  /// On Android, corresponds to
+  /// [PRIORITY_HIGH_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_high_accuracy).
   high,
 
   /// Location is accurate within a distance of ~0m on iOS and between 0m and
-  /// 100m on Android
+  /// 100m on Android.
+  ///
+  /// On Android, corresponds to
+  /// [PRIORITY_HIGH_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_high_accuracy).
   best,
 
   /// Location accuracy is optimized for navigation on iOS and matches the
-  /// [LocationAccuracy.best] on Android
+  /// [LocationAccuracy.best] on Android.
+  ///
+  /// On Android, corresponds to
+  /// [PRIORITY_HIGH_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_high_accuracy).
   bestForNavigation,
 
   /// Location accuracy is reduced for iOS 14+ devices, matches the
   /// [LocationAccuracy.lowest] on iOS 13 and below and all other platforms.
+  ///
+  /// On Android, corresponds to
+  /// [PRIORITY_PASSIVE](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_passive).
   reduced,
 }

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -87,27 +87,39 @@ abstract class GeolocatorPlatform extends PlatformInterface {
     );
   }
 
-  /// Returns the current position taking the supplied [desiredAccuracy] into
-  /// account.
+  /// Returns the current position.
   ///
-  /// Calling the `getCurrentPosition` method will request the platform to
-  /// obtain a location fix, depending on the availability of different location
-  /// services this can take several seconds. The recommended use would be to
-  /// call the `getLastKnownPosition` method to receive a cached position and
-  /// update it with the result of the `getCurrentPosition` method.
+  /// You can control the settings used for retrieving the location by supplying
+  /// [locationSettings].
   ///
-  /// On Android you can force the use of the Android LocationManager instead of
-  /// the FusedLocationProvider by setting the [forceLocationManager]
-  /// parameter of [LocationSettings] to true. The [timeLimit] parameter of
-  /// [LocationSettings] allows you to specify a timeout interval (by default no
-  /// time limit is configured).
+  /// Calling the [getCurrentPosition] method will request the platform to
+  /// obtain a location fix. Depending on the availability of different location
+  /// services, this can take several seconds. The recommended use would be to
+  /// call the [getLastKnownPosition] method to receive a cached position and
+  /// update it with the result of the [getCurrentPosition] method.
   ///
-  /// Throws a [TimeoutException] when no location is received within the
-  /// supplied [timeLimit] duration.
-  /// Throws a [PermissionDeniedException] when trying to request the device's
-  /// location when the user denied access.
-  /// Throws a [LocationServiceDisabledException] when the user allowed access,
-  /// but the location services of the device are disabled.
+  /// **Note**: On Android, when setting the location accuracy, the location
+  /// *accuracy* is interpreted as
+  /// [location *priority*](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#constants).
+  /// The interpretation works as follows:
+  ///
+  /// [LocationAccuracy.lowest] -> [PRIORITY_PASSIVE](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_passive):
+  /// Ensures that no extra power will be used to derive locations. This
+  /// enforces that the request will act as a passive listener that will only
+  /// receive "free" locations calculated on behalf of other clients, and no
+  /// locations will be calculated on behalf of only this request.
+  ///
+  /// [LocationAccuracy.low] -> [PRIORITY_LOW_POWER](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_low_power):
+  /// Requests a tradeoff that favors low power usage at the possible expense of
+  /// location accuracy.
+  ///
+  /// [LocationAccuracy.medium] -> [PRIORITY_BALANCED_POWER_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_balanced_power_accuracy):
+  /// Requests a tradeoff that is balanced between location accuracy and power
+  /// usage.
+  ///
+  /// [LocationAccuracy.high]+ -> [PRIORITY_HIGH_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_high_accuracy):
+  /// Requests a tradeoff that favors highly accurate locations at the possible
+  /// expense of additional power usage.
   Future<Position> getCurrentPosition({
     LocationSettings? locationSettings,
   }) {

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.0.7
+version: 4.0.8
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/test/src/implementations/event_channel_mock.dart
+++ b/geolocator_platform_interface/test/src/implementations/event_channel_mock.dart
@@ -14,7 +14,7 @@ class EventChannelMock {
     required String channelName,
     required this.stream,
   }) : _methodChannel = MethodChannel(channelName) {
-    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(_methodChannel, _handler);
   }
 
@@ -76,11 +76,7 @@ class EventChannelMock {
   }
 
   void _sendEnvelope(ByteData? envelope) {
-    if (TestDefaultBinaryMessengerBinding.instance == null) {
-      return;
-    }
-
-    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .handlePlatformMessage(
       _methodChannel.name,
       envelope,

--- a/geolocator_platform_interface/test/src/implementations/method_channel_mock.dart
+++ b/geolocator_platform_interface/test/src/implementations/method_channel_mock.dart
@@ -14,7 +14,7 @@ class MethodChannelMock {
     this.delay = Duration.zero,
     this.result,
   }) : methodChannel = MethodChannel(channelName) {
-    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(methodChannel, _handler);
   }
 


### PR DESCRIPTION
On Android, location accuracy is interpreted in a rather unintuitive way. Users of the plugin get confused, resulting in reports coming in where users complain about not receiving positions. The problem sometimes lies in the fact that they use `LocationAccuracy.lowest`. While this accuracy option might suggest that location updates come in quicker, or at least at the same rate as higher accuracy options, this is not the case. Location accuracy on Android is mapped in the following way:

| Location accuracy | Android priority | Description |
| --- | --- | --- |
| lowest | PRIORITY_PASSIVE | Ensures that no extra power will be used to derive locations. This enforces that the request will act as a passive listener that will only receive "free" locations calculated on behalf of other clients, and no locations will be calculated on behalf of only this request. |
| low | PRIORITY_LOW_POWER | Requests a tradeoff that favors low power usage at the possible expense of location accuracy. |
| medium | PRIORITY_BALANCED_POWER_ACCURACY | Requests a tradeoff that is balanced between location accuracy and power usage. |
| high+ | PRIORITY_HIGH_ACCURACY | Requests a tradeoff that favors highly accurate locations at the possible expense of additional power usage. |

This means that when using `LocationAccuracy.lowest`, the update frequency of the position stream becomes 0, unless another app asks for a location update.

In the future, we might want to separate the iOS and Android implementations in such a way that the API is not confusing to users in the way that it is now. This is quite the undertaking, however, and therefore we want to start by adding a note in the documentation. This PR adds the note in several locations where users may look during development.

Closes #1315.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
