### PR TITLE
App facing: Updates documentation surrounding location accuracy on Android

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.0.1
+
+- Updates documentation for `getCurrentPosition()`, to clarify the behavior of location accuracy on Android devices.
+
 ## 10.0.0
 
 - **BREAKING CHANGE:** Updates dependency on geolocator_windows to version 0.2.0. This will synchronize default values for `Position.altitude`, `Position.heading` and `Position.speed` with the other platforms. 

--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -411,14 +411,25 @@ double bearing = Geolocator.bearingBetween(52.2165157, 6.9437819, 52.3546274, 4.
 
 The table below outlines the accuracy options per platform:
 
-|            | Android    | iOS   |
-|------------|-----------:|------:|
-| **lowest** | 500m       | 3000m |
-| **low**    | 500m       | 1000m |    
-| **medium** | 100 - 500m | 100m  |
-| **high**   | 0 - 100m   | 10m   |
-| **best**   | 0 - 100m   | ~0m   |
-| **bestForNavigation** | 0 - 100m | [Optimized for navigation](https://developer.apple.com/documentation/corelocation/kcllocationaccuracybestfornavigation) |
+| Location accuracy     | Android    | iOS   |
+|-----------------------|-----------:|------:|
+| **lowest**            | 500m       | 3000m |
+| **low**               | 500m       | 1000m |    
+| **medium**            | 100 - 500m | 100m  |
+| **high**              | 0 - 100m   | 10m   |
+| **best**              | 0 - 100m   | ~0m   |
+| **bestForNavigation** | 0 - 100m   | [Optimized for navigation](https://developer.apple.com/documentation/corelocation/kcllocationaccuracybestfornavigation) |
+
+#### Location priority (Android)
+On Android, the location accuracy also influences the
+[location priority](https://developers.google.com/android/reference/com/google/android/gms/location/Priority). This can be confusing, as a priority of **lowest** might not return any location. The table below outlines the priority and its meaning per accuracy option:
+
+| Location accuracy | Android priority | Description |
+|-------------------|------------------|-------------|
+| **lowest**        | [PRIORITY_PASSIVE](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_passive) | Ensures that no extra power will be used to derive locations. This enforces that the request will act as a passive listener that will only receive "free" locations calculated on behalf of other clients, and no locations will be calculated on behalf of only this request. |
+| **low**           | [PRIORITY_LOW_POWER](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_low_power) | Requests a tradeoff that favors low power usage at the possible expense of location accuracy. |
+| **medium**        | [PRIORITY_BALANCED_POWER_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_balanced_power_accuracy) | Requests a tradeoff that is balanced between location accuracy and power usage. |
+| **high**+         | [PRIORITY_HIGH_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_high_accuracy) | Requests a tradeoff that favors highly accurate locations at the possible expense of additional power usage. |
 
 ## Issues
 

--- a/geolocator/lib/geolocator.dart
+++ b/geolocator/lib/geolocator.dart
@@ -54,20 +54,48 @@ class Geolocator {
       GeolocatorPlatform.instance.getLastKnownPosition(
           forceLocationManager: forceAndroidLocationManager);
 
-  /// Returns the current position taking the supplied [desiredAccuracy] into
-  /// account.
+  /// Returns the current position.
   ///
   /// You can control the precision of the location updates by supplying the
-  /// [desiredAccuracy] parameter (defaults to "best"). On Android you can
-  /// force the use of the Android LocationManager instead of the
-  /// FusedLocationProvider by setting the [forceAndroidLocationManager]
+  /// [desiredAccuracy] parameter (defaults to "best").
+  /// On Android you can force the use of the Android LocationManager instead of
+  /// the FusedLocationProvider by setting the [forceAndroidLocationManager]
   /// parameter to true. The [timeLimit] parameter allows you to specify a
   /// timeout interval (by default no time limit is configured).
+  ///
+  /// Calling the [getCurrentPosition] method will request the platform to
+  /// obtain a location fix. Depending on the availability of different location
+  /// services, this can take several seconds. The recommended use would be to
+  /// call the [getLastKnownPosition] method to receive a cached position and
+  /// update it with the result of the [getCurrentPosition] method.
   ///
   /// Throws a [TimeoutException] when no location is received within the
   /// supplied [timeLimit] duration.
   /// Throws a [LocationServiceDisabledException] when the user allowed access,
   /// but the location services of the device are disabled.
+  ///
+  ///
+  /// **Note**: On Android the location *accuracy* is interpreted as
+  /// [location *priority*](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#constants).
+  /// The interpretation works as follows:
+  ///
+  /// [LocationAccuracy.lowest] -> [PRIORITY_PASSIVE](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_passive):
+  /// Ensures that no extra power will be used to derive locations. This
+  /// enforces that the request will act as a passive listener that will only
+  /// receive "free" locations calculated on behalf of other clients, and no
+  /// locations will be calculated on behalf of only this request.
+  ///
+  /// [LocationAccuracy.low] -> [PRIORITY_LOW_POWER](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_low_power):
+  /// Requests a tradeoff that favors low power usage at the possible expense of
+  /// location accuracy.
+  ///
+  /// [LocationAccuracy.medium] -> [PRIORITY_BALANCED_POWER_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_balanced_power_accuracy):
+  /// Requests a tradeoff that is balanced between location accuracy and power
+  /// usage.
+  ///
+  /// [LocationAccuracy.high]+ -> [PRIORITY_HIGH_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#public-static-final-int-priority_high_accuracy):
+  /// Requests a tradeoff that favors highly accurate locations at the possible
+  /// expense of additional power usage.
   static Future<Position> getCurrentPosition({
     LocationAccuracy desiredAccuracy = LocationAccuracy.best,
     bool forceAndroidLocationManager = false,

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 10.0.0
+version: 10.0.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
On Android, location accuracy is interpreted in a rather unintuitive way. Users of the plugin get confused, resulting in reports coming in where users complain about not receiving positions. The problem sometimes lies in the fact that they use `LocationAccuracy.lowest`. While this accuracy option might suggest that location updates come in quicker, or at least at the same rate as higher accuracy options, this is not the case. Location accuracy on Android is mapped in the following way:

| Location accuracy | Android priority | Description |
| --- | --- | --- |
| lowest | PRIORITY_PASSIVE | Ensures that no extra power will be used to derive locations. This enforces that the request will act as a passive listener that will only receive "free" locations calculated on behalf of other clients, and no locations will be calculated on behalf of only this request. |
| low | PRIORITY_LOW_POWER | Requests a tradeoff that favors low power usage at the possible expense of location accuracy. |
| medium | PRIORITY_BALANCED_POWER_ACCURACY | Requests a tradeoff that is balanced between location accuracy and power usage. |
| high+ | PRIORITY_HIGH_ACCURACY | Requests a tradeoff that favors highly accurate locations at the possible expense of additional power usage. |

This means that when using `LocationAccuracy.lowest`, the update frequency of the position stream becomes 0, unless another app asks for a location update.

In the future, we might want to separate the iOS and Android implementations in such a way that the API is not confusing to users in the way that it is now. This is quite the undertaking, however, and therefore we want to start by adding a note in the documentation. This PR adds the note in several locations where users may look during development.

Closes #1315.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
