### PR TITLE
Remove unnecessary filter on locations based off their accuracy (Android)

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.3
+
+* Fixes a bug when requesting a position stream where positions are unnecessarily filtered based off their accuracy.
+
 ## 4.2.2
 
 * Adds back the `applicationId` property of the AndroidManifest.xml file to keep backwardscompatibility with older applications that still rely on Gradle version <7.0.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
@@ -15,7 +15,6 @@ import com.google.android.gms.common.GoogleApiAvailability;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-@SuppressWarnings("deprecation")
 public class GeolocationManager
     implements io.flutter.plugin.common.PluginRegistry.ActivityResultListener {
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -114,21 +114,6 @@ class LocationManagerClient implements LocationClient, LocationListener {
     return provider;
   }
 
-  private static float accuracyToFloat(LocationAccuracy accuracy) {
-    switch (accuracy) {
-      case lowest:
-      case low:
-        return 500;
-      case medium:
-        return 250;
-      case best:
-      case bestForNavigation:
-        return 50;
-      default:
-        return 100;
-    }
-  }
-
   @Override
   public void isLocationServiceEnabled(LocationServiceListener listener) {
     if (locationManager == null) {
@@ -209,11 +194,7 @@ class LocationManagerClient implements LocationClient, LocationListener {
 
   @Override
   public synchronized void onLocationChanged(Location location) {
-    float desiredAccuracy =
-        locationOptions != null ? accuracyToFloat(locationOptions.getAccuracy()) : 50;
-
-    if (isBetterLocation(location, currentBestLocation)
-        && location.getAccuracy() <= desiredAccuracy) {
+    if (isBetterLocation(location, currentBestLocation)) {
       this.currentBestLocation = location;
 
       if (this.positionChangedCallback != null) {
@@ -224,7 +205,6 @@ class LocationManagerClient implements LocationClient, LocationListener {
   }
 
   @TargetApi(28)
-  @SuppressWarnings("deprecation")
   @Override
   public void onStatusChanged(String provider, int status, Bundle extras) {
     if (status == android.location.LocationProvider.AVAILABLE) {

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.2.2
+version: 4.2.3
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Users are reporting that they are not receiving positions when they subscribe to the stream when providing `forceLocationManager: true`. This is due to the fact that there is a filter in place that filters out inaccurate locations. We could not find a reason for the filter to be there, as we would like to give developers the opportunity to filter locations themselves. This PR removes the filter.

This closes #1114, #1290.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
