### PR TITLE
Fix inaccurate location readings

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 4.2.4
+
+* Fixes a bug where location readings were very inaccurate when using `forceLocationManager: true`.
+
 ## 4.2.3
 
-* Fixes a bug when requesting a position stream where positions are unnecessarily filtered based off their accuracy.
+* Fixes a bug where the position stream was unnecessarily filtered when using `forceLocationManager: true`.
 
 ## 4.2.2
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -153,20 +153,24 @@ class LocationManagerClient implements LocationClient, LocationListenerCompat {
     this.positionChangedCallback = positionChangedCallback;
     this.errorCallback = errorCallback;
 
-    this.currentLocationProvider = getBestProvider(this.locationManager);
-
-    if (this.currentLocationProvider == null) {
-      errorCallback.onError(ErrorCodes.locationServicesDisabled);
-      return;
-    }
-
+    LocationAccuracy accuracy = LocationAccuracy.best;
     long timeInterval = 0;
     float distanceFilter = 0;
     @LocationRequestCompat.Quality int quality = LocationRequestCompat.QUALITY_BALANCED_POWER_ACCURACY;
     if (this.locationOptions != null) {
       timeInterval = locationOptions.getTimeInterval();
       distanceFilter = locationOptions.getDistanceFilter();
-      quality = accuracyToQuality(locationOptions.getAccuracy());
+      accuracy = locationOptions.getAccuracy();
+      quality = accuracyToQuality(accuracy);
+    }
+
+    this.currentLocationProvider = accuracy == LocationAccuracy.lowest
+        ? LocationManager.PASSIVE_PROVIDER
+        : getBestProvider(this.locationManager);
+
+    if (this.currentLocationProvider == null) {
+      errorCallback.onError(ErrorCodes.locationServicesDisabled);
+      return;
     }
 
     final LocationRequestCompat locationRequest = new LocationRequestCompat.Builder(timeInterval)

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -4,22 +4,24 @@ import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
-import android.location.Criteria;
 import android.location.Location;
-import android.location.LocationListener;
 import android.location.LocationManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Looper;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.location.LocationListenerCompat;
+import androidx.core.location.LocationManagerCompat;
+import androidx.core.location.LocationRequestCompat;
 
 import com.baseflow.geolocator.errors.ErrorCallback;
 import com.baseflow.geolocator.errors.ErrorCodes;
 
 import java.util.List;
 
-class LocationManagerClient implements LocationClient, LocationListener {
+class LocationManagerClient implements LocationClient, LocationListenerCompat {
 
   private static final long TWO_MINUTES = 120000;
   private final LocationManager locationManager;
@@ -73,45 +75,35 @@ class LocationManagerClient implements LocationClient, LocationListener {
     return false;
   }
 
-  private static String getBestProvider(
-      LocationManager locationManager, LocationAccuracy accuracy) {
-    Criteria criteria = new Criteria();
+  private static @Nullable String getBestProvider(@NonNull LocationManager locationManager) {
+      final List<String> enabledProviders = locationManager.getProviders(true);
 
-    criteria.setBearingRequired(false);
-    criteria.setAltitudeRequired(false);
-    criteria.setSpeedRequired(false);
+      if (enabledProviders.contains(LocationManager.FUSED_PROVIDER) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+          return LocationManager.FUSED_PROVIDER;
+      } else if (enabledProviders.contains(LocationManager.GPS_PROVIDER)) {
+          return LocationManager.GPS_PROVIDER;
+      } else if (enabledProviders.contains(LocationManager.NETWORK_PROVIDER)) {
+          return LocationManager.NETWORK_PROVIDER;
+      } else if (!enabledProviders.isEmpty()){
+          return enabledProviders.get(0);
+      } else {
+          return null;
+      }
+  }
 
-    switch (accuracy) {
-      case lowest:
-        criteria.setAccuracy(Criteria.NO_REQUIREMENT);
-        criteria.setHorizontalAccuracy(Criteria.NO_REQUIREMENT);
-        criteria.setPowerRequirement(Criteria.NO_REQUIREMENT);
-        break;
-      case low:
-        criteria.setAccuracy(Criteria.ACCURACY_COARSE);
-        criteria.setHorizontalAccuracy(Criteria.ACCURACY_LOW);
-        criteria.setPowerRequirement(Criteria.NO_REQUIREMENT);
-        break;
-      case medium:
-        criteria.setAccuracy(Criteria.ACCURACY_COARSE);
-        criteria.setHorizontalAccuracy(Criteria.ACCURACY_MEDIUM);
-        criteria.setPowerRequirement(Criteria.POWER_MEDIUM);
-        break;
-      default:
-        criteria.setAccuracy(Criteria.ACCURACY_FINE);
-        criteria.setHorizontalAccuracy(Criteria.ACCURACY_HIGH);
-        criteria.setPowerRequirement(Criteria.POWER_HIGH);
-        break;
-    }
-
-    String provider = locationManager.getBestProvider(criteria, true);
-
-    if (provider.trim().isEmpty()) {
-      List<String> providers = locationManager.getProviders(true);
-      if (providers.size() > 0) provider = providers.get(0);
-    }
-
-    return provider;
+  private static @LocationRequestCompat.Quality int accuracyToQuality(@NonNull LocationAccuracy accuracy) {
+      switch (accuracy) {
+          case lowest:
+          case low:
+              return LocationRequestCompat.QUALITY_LOW_POWER;
+          case high:
+          case best:
+          case bestForNavigation:
+              return LocationRequestCompat.QUALITY_HIGH_ACCURACY;
+          case medium:
+          default:
+              return LocationRequestCompat.QUALITY_BALANCED_POWER_ACCURACY;
+      }
   }
 
   @Override
@@ -161,27 +153,36 @@ class LocationManagerClient implements LocationClient, LocationListener {
     this.positionChangedCallback = positionChangedCallback;
     this.errorCallback = errorCallback;
 
-    LocationAccuracy locationAccuracy =
-        this.locationOptions != null ? this.locationOptions.getAccuracy() : LocationAccuracy.best;
+    this.currentLocationProvider = getBestProvider(this.locationManager);
 
-    this.currentLocationProvider = getBestProvider(this.locationManager, locationAccuracy);
-
-    if (this.currentLocationProvider.trim().isEmpty()) {
+    if (this.currentLocationProvider == null) {
       errorCallback.onError(ErrorCodes.locationServicesDisabled);
       return;
     }
 
     long timeInterval = 0;
     float distanceFilter = 0;
+    @LocationRequestCompat.Quality int quality = LocationRequestCompat.QUALITY_BALANCED_POWER_ACCURACY;
     if (this.locationOptions != null) {
       timeInterval = locationOptions.getTimeInterval();
       distanceFilter = locationOptions.getDistanceFilter();
+      quality = accuracyToQuality(locationOptions.getAccuracy());
     }
+
+    final LocationRequestCompat locationRequest = new LocationRequestCompat.Builder(timeInterval)
+        .setMinUpdateDistanceMeters(distanceFilter)
+        .setQuality(quality)
+        .build();
 
     this.isListening = true;
     this.nmeaClient.start();
-    this.locationManager.requestLocationUpdates(
-        this.currentLocationProvider, timeInterval, distanceFilter, this, Looper.getMainLooper());
+
+    LocationManagerCompat.requestLocationUpdates(
+        this.locationManager,
+        this.currentLocationProvider,
+        locationRequest,
+        this,
+        Looper.getMainLooper());
   }
 
   @SuppressLint("MissingPermission")
@@ -206,7 +207,7 @@ class LocationManagerClient implements LocationClient, LocationListener {
 
   @TargetApi(28)
   @Override
-  public void onStatusChanged(String provider, int status, Bundle extras) {
+  public void onStatusChanged(@NonNull String provider, int status, Bundle extras) {
     if (status == android.location.LocationProvider.AVAILABLE) {
       onProviderEnabled(provider);
     } else if (status == android.location.LocationProvider.OUT_OF_SERVICE) {
@@ -215,7 +216,7 @@ class LocationManagerClient implements LocationClient, LocationListener {
   }
 
   @Override
-  public void onProviderEnabled(String provider) {}
+  public void onProviderEnabled(@NonNull String provider) {}
 
   @SuppressLint("MissingPermission")
   @Override

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.2.3
+version: 4.2.4
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Users have reported that locations have an wildly low accuracy on Android 13 since `geolocator_android: 4.2.3`. This seems to be caused by the fact that a different location provider is returned from `getBestProvider()`. Instead of the fused or gps provider, the network provider is used. To remedy this, this PR replaces the use of `getBestProvider()` with a custom implementation that returns the most accurate location provider. Note that `getBestProvider()` will be deprecated starting from API 34 anyway, with no clear replacement. Additionally, the `LocationManagerCompat` class and its associates are used to indicate a `LocationRequestCompat.Quality` to the OS.

Closes #1114.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
