### PR TITLE
Add altitude accuracy and heading accuracy to Position [Apple]

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0
+
+* Includes `altitudeAccuracy` and `headingAccuracy` in `Position`.
+
 ## 2.2.7
 
 * Fixes the propagation of the activity type setting.

--- a/geolocator_apple/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/geolocator_apple/example/ios/Runner.xcodeproj/project.pbxproj
@@ -227,7 +227,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/geolocator_apple/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/geolocator_apple/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/geolocator_apple/ios/Classes/Utils/LocationMapper.m
+++ b/geolocator_apple/ios/Classes/Utils/LocationMapper.m
@@ -30,12 +30,23 @@
     [locationMap setObject:@(location.speed) forKey: @"speed"];
     [locationMap setObject:@(speedAccuracy) forKey: @"speed_accuracy"];
     
+    // When verticalAccuracy contains 0 or a negative number, the value of altitude is invalid.
+    //
+    // Relevant documentation:
+    // - https://developer.apple.com/documentation/corelocation/cllocation/1423820-altitude?language=objc
+    // - https://developer.apple.com/documentation/corelocation/cllocation/1423550-verticalaccuracy?language=objc
     double altitudeAccuracy = location.verticalAccuracy;
     if (altitudeAccuracy > 0.0) {
         [locationMap setObject:@(location.altitude) forKey: @"altitude"];
         [locationMap setObject:@(altitudeAccuracy) forKey: @"altitude_accuracy"];
     }
     
+    // A negative course value indicates that the course information is invalid.
+    // When courseAccuracy contains a negative number, the value in the course property is invalid.
+    //
+    // Relevant documentation:
+    // - https://developer.apple.com/documentation/corelocation/cllocation/1423832-course?language=objc
+    // - https://developer.apple.com/documentation/corelocation/cllocation/3524338-courseaccuracy?language=objc
     double heading = location.course;
     if (heading >= 0.0) {
         if (@available(iOS 13.4, *)) {

--- a/geolocator_apple/ios/Classes/Utils/LocationMapper.m
+++ b/geolocator_apple/ios/Classes/Utils/LocationMapper.m
@@ -26,11 +26,28 @@
     [locationMap setObject:@(location.coordinate.latitude) forKey: @"latitude"];
     [locationMap setObject:@(location.coordinate.longitude) forKey: @"longitude"];
     [locationMap setObject:@(timestamp) forKey: @"timestamp"];
-    [locationMap setObject:@(location.altitude) forKey: @"altitude"];
     [locationMap setObject:@(location.horizontalAccuracy) forKey: @"accuracy"];
     [locationMap setObject:@(location.speed) forKey: @"speed"];
     [locationMap setObject:@(speedAccuracy) forKey: @"speed_accuracy"];
-    [locationMap setObject:@(location.course) forKey: @"heading"];
+    
+    double altitudeAccuracy = location.verticalAccuracy;
+    if (altitudeAccuracy > 0.0) {
+        [locationMap setObject:@(location.altitude) forKey: @"altitude"];
+        [locationMap setObject:@(altitudeAccuracy) forKey: @"altitude_accuracy"];
+    }
+    
+    double heading = location.course;
+    if (heading >= 0.0) {
+        if (@available(iOS 13.4, *)) {
+            double headingAccuracy = location.courseAccuracy;
+            if (headingAccuracy >= 0.0) {
+                [locationMap setObject:@(heading) forKey: @"heading"];
+                [locationMap setObject:@(headingAccuracy) forKey: @"heading_accuracy"];
+            }
+        } else {
+            [locationMap setObject:@(heading) forKey: @"heading"];
+        }
+    }
     
     if(@available(iOS 15.0, *)) {
         [locationMap setObject:@(location.sourceInformation.isSimulatedBySoftware) forKey: @"is_mocked"];

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.2.7
+version: 2.3.0
 
 environment:
   sdk: ">=2.15.0 <4.0.0"
@@ -22,8 +22,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-
-  geolocator_platform_interface: ^4.0.5
+  geolocator_platform_interface: ^4.1.0
 
 dev_dependencies:
   async: ^2.8.2

--- a/geolocator_apple/test/geolocator_apple_test.dart
+++ b/geolocator_apple/test/geolocator_apple_test.dart
@@ -16,8 +16,10 @@ Position get mockPosition => Position(
       isUtc: true,
     ),
     altitude: 3000.0,
+    altitudeAccuracy: 0.0,
     accuracy: 0.0,
     heading: 0.0,
+    headingAccuracy: 0.0,
     speed: 0.0,
     speedAccuracy: 0.0,
     isMocked: false);


### PR DESCRIPTION
Offers the altitude accuracy and heading accuracy from the iOS and macOS location readings to the Dart `Position` class.

Requires a merge of #1330.
Part of #1248.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x]  I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
