### PR TITLE
Stop emitting invalid speed(accuracy) values on Apple devices

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+* Fixes a bug where invalid speed and speed accuracy readings where returned instead of ignored.
+
 ## 2.3.0
 
 * Includes `altitudeAccuracy` and `headingAccuracy` in `Position`.

--- a/geolocator_apple/ios/Classes/Utils/LocationMapper.m
+++ b/geolocator_apple/ios/Classes/Utils/LocationMapper.m
@@ -13,22 +13,32 @@
         return nil;
     }
     
-    double timestamp = [LocationMapper currentTimeInMilliSeconds:location.timestamp];
-    double speedAccuracy = 0.0;
+    NSMutableDictionary *locationMap = [[NSMutableDictionary alloc]initWithCapacity:13];
     
+    [locationMap setObject:@(location.coordinate.latitude) forKey: @"latitude"];
+    [locationMap setObject:@(location.coordinate.longitude) forKey: @"longitude"];
+    [locationMap setObject:@(location.horizontalAccuracy) forKey: @"accuracy"];
+    
+    double timestamp = [LocationMapper currentTimeInMilliSeconds:location.timestamp];
+    [locationMap setObject:@(timestamp) forKey: @"timestamp"];
+    
+    // A negative speed value indicates an invalid speed.
+    // When the speedAccuracy contains a negative number, the value in the speed property is invalid.
+    //
+    // Relevant documentation:
+    // - https://developer.apple.com/documentation/corelocation/cllocation/1423798-speed?language=objc
+    // - https://developer.apple.com/documentation/corelocation/cllocation/3524340-speedaccuracy?language=objc
+    double speed = location.speed;
+    double speedAccuracy = 0.0;
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
     if (@available(iOS 10.0, *)) {
         speedAccuracy = location.speedAccuracy;
     }
 #endif
-    
-    NSMutableDictionary *locationMap = [[NSMutableDictionary alloc]initWithCapacity:9];
-    [locationMap setObject:@(location.coordinate.latitude) forKey: @"latitude"];
-    [locationMap setObject:@(location.coordinate.longitude) forKey: @"longitude"];
-    [locationMap setObject:@(timestamp) forKey: @"timestamp"];
-    [locationMap setObject:@(location.horizontalAccuracy) forKey: @"accuracy"];
-    [locationMap setObject:@(location.speed) forKey: @"speed"];
-    [locationMap setObject:@(speedAccuracy) forKey: @"speed_accuracy"];
+    if (speed >= 0 && speedAccuracy >= 0) {
+        [locationMap setObject:@(speed) forKey: @"speed"];
+        [locationMap setObject:@(speedAccuracy) forKey: @"speed_accuracy"];
+    }
     
     // When verticalAccuracy contains 0 or a negative number, the value of altitude is invalid.
     //

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.3.0
+version: 2.3.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
On iOS, the plugin returns negative speed values. According to Apple's documentation, negative values indicate that the speed value is invalid. We should therefore not pass any negative speed values to the Dart side. This PR checks the speed and speed accuracy values and only emits values that are valid.

Fixes #1329

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
