### PR TITLE
Bump platform interface to `4.1.0` [Linux]

### DIFF
--- a/geolocator_linux/CHANGELOG.md
+++ b/geolocator_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Bumps `geolocator_platform_interface` dependency to `^4.1.0`.
+
 ## 0.1.3
 
 - Improves GNOME detection.

--- a/geolocator_linux/example/pubspec.yaml
+++ b/geolocator_linux/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
-  baseflow_plugin_template: ^2.1.1
+  baseflow_plugin_template: ^2.1.2
   flutter:
     sdk: flutter
 
@@ -41,9 +41,3 @@ dev_dependencies:
 flutter:
 
   uses-material-design: true
-
-  assets:
-    - res/images/baseflow_logo_def_light-02.png
-    - res/images/poweredByBaseflowLogoLight@3x.png
-    - packages/baseflow_plugin_template/logo.png
-    - packages/baseflow_plugin_template/poweredByBaseflow.png

--- a/geolocator_linux/lib/src/geoclue_x.dart
+++ b/geolocator_linux/lib/src/geoclue_x.dart
@@ -18,7 +18,9 @@ extension GeoCluePosition on GeoClueLocation {
     return Position(
       accuracy: accuracy,
       altitude: altitude ?? 0,
+      altitudeAccuracy: 0,
       heading: heading ?? 0,
+      headingAccuracy: 0,
       latitude: latitude,
       longitude: longitude,
       timestamp: timestamp,

--- a/geolocator_linux/pubspec.yaml
+++ b/geolocator_linux/pubspec.yaml
@@ -3,7 +3,7 @@ description: Geolocation Linux plugin for Flutter. This plugin provides the
   Linux implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_linux
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 0.1.3
+version: 0.2.0
 
 environment:
   sdk: ">=2.15.0 <3.0.0"
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   geoclue: ^0.1.1
-  geolocator_platform_interface: ^4.0.0
+  geolocator_platform_interface: ^4.1.0
   gsettings: ^0.2.5
   package_info_plus: ">=1.4.2 <5.0.0"
 

--- a/geolocator_linux/test/geoclue_x_test.dart
+++ b/geolocator_linux/test/geoclue_x_test.dart
@@ -49,7 +49,9 @@ final dummyLocation = GeoClueLocation(
 final dummyPosition = Position(
   accuracy: 1,
   altitude: 2,
+  altitudeAccuracy: 0,
   heading: 3,
+  headingAccuracy: 0,
   latitude: 4,
   longitude: 5,
   speed: 6,
@@ -67,7 +69,9 @@ final dummyLocationNull = GeoClueLocation(
 final dummyPositionNull = Position(
   accuracy: 1,
   altitude: 0,
+  altitudeAccuracy: 0,
   heading: 0,
+  headingAccuracy: 0,
   latitude: 4,
   longitude: 5,
   speed: 0,

--- a/geolocator_linux/test/geolocator_linux_test.dart
+++ b/geolocator_linux/test/geolocator_linux_test.dart
@@ -159,7 +159,9 @@ final dummyLocation = GeoClueLocation(
 final dummyPosition = Position(
   accuracy: 1,
   altitude: 2,
+  altitudeAccuracy: 0,
   heading: 3,
+  headingAccuracy: 0,
   latitude: 4,
   longitude: 5,
   speed: 6,


### PR DESCRIPTION
Aligns the Linux code base with the latest changes where both altitude accuracy and heading accuracy are exposed. Unfortunately, the GeoClue API that is used for the Linux implementation does not expose these values. Therefore, this PR is pretty straightforward; the values of 0 are returned to indicate that no readings are present.

Part of #1248.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
