### PR TITLE
Include altitude accuracy and heading accuracy in `Position` object

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.0
+
+- Includes `altitudeAccuracy` and `headingAccuracy` in `Position`.
+
 ## 10.0.1
 
 - Updates documentation for `getCurrentPosition()`, to clarify the behavior of location accuracy on Android devices.

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 10.0.1
+version: 10.1.0
 
 environment:
   sdk: ">=2.15.0 <4.0.0"
@@ -26,11 +26,11 @@ dependencies:
   flutter:
     sdk: flutter
 
-  geolocator_platform_interface: ^4.0.3
-  geolocator_android: ^4.1.3
-  geolocator_apple: ^2.1.1+1
-  geolocator_web: ^2.1.3
-  geolocator_windows: ^0.2.0
+  geolocator_platform_interface: ^4.1.0
+  geolocator_android: ^4.3.0
+  geolocator_apple: ^2.3.0
+  geolocator_web: ^2.2.0
+  geolocator_windows: ^0.2.1
 
 dev_dependencies:
   flutter_test:

--- a/geolocator/test/geolocator_test.dart
+++ b/geolocator/test/geolocator_test.dart
@@ -12,8 +12,10 @@ Position get mockPosition => Position(
       isUtc: true,
     ),
     altitude: 3000.0,
+    altitudeAccuracy: 0.0,
     accuracy: 0.0,
     heading: 0.0,
+    headingAccuracy: 0.0,
     speed: 0.0,
     speedAccuracy: 0.0);
 


### PR DESCRIPTION
Includes the latest releases of the platform specific packages, exposing the `altitudeAccuracy` and `headingAccuracy` fields in the `Position` object. Depending on the platform, these values may come back as 0.0 if they are not supported.

Closes #1248.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
