### PR TITLE
Fix build error and warnings for macOS

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.2
+
+* Fixes build error and warnings regarding unused variables and unavailable APIs on macOS.
+
 ## 2.3.1
 
 * Fixes a bug where invalid speed and speed accuracy readings where returned instead of ignored.

--- a/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
+++ b/geolocator_apple/ios/Classes/Handlers/GeolocationHandler.m
@@ -60,11 +60,11 @@ double const kMaxLocationLifeTimeInSeconds = 5.0;
   self.errorHandler = errorHandler;
   self.currentLocationResultHandler = resultHandler;
     
-  CLLocationManager *locationManager = [self getLocationManager];
   BOOL showBackgroundLocationIndicator = NO;
   BOOL allowBackgroundLocationUpdates = NO;
   #if TARGET_OS_IOS
     if (self.isListeningForPositionUpdates) {
+      CLLocationManager *locationManager = [self getLocationManager];
       showBackgroundLocationIndicator = locationManager.showsBackgroundLocationIndicator;
       allowBackgroundLocationUpdates = locationManager.allowsBackgroundLocationUpdates;
     }

--- a/geolocator_apple/ios/Classes/Utils/LocationMapper.m
+++ b/geolocator_apple/ios/Classes/Utils/LocationMapper.m
@@ -59,7 +59,7 @@
     // - https://developer.apple.com/documentation/corelocation/cllocation/3524338-courseaccuracy?language=objc
     double heading = location.course;
     if (heading >= 0.0) {
-        if (@available(iOS 13.4, *)) {
+        if (@available(iOS 13.4, macOS 10.15.4, *)) {
             double headingAccuracy = location.courseAccuracy;
             if (headingAccuracy >= 0.0) {
                 [locationMap setObject:@(heading) forKey: @"heading"];
@@ -70,7 +70,7 @@
         }
     }
     
-    if(@available(iOS 15.0, *)) {
+    if(@available(iOS 15.0, macOS 12.0, *)) {
         [locationMap setObject:@(location.sourceInformation.isSimulatedBySoftware) forKey: @"is_mocked"];
     }
     

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.3.1
+version: 2.3.2
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Currently, the project does not build on macOS due to a build error. Additionally, there are some build warnings when compiling the code. These issues have been resolved by annotating the code with the appropriate `@available` annotations and by moving a line to within a compile time if-statement.

Fixes #1333.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
