### PR TITLE
Suppress deprecation warning on Android build

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.1
+
+- Suppresses a deprecation warning for `LocationListenerCompat.onStatusChanged` when building for Android.
+
 ## 4.3.0
 
 * Includes `altitudeAccuracy` and `headingAccuracy` in `Position`.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -215,6 +215,13 @@ class LocationManagerClient implements LocationClient, LocationListenerCompat {
     }
   }
 
+  /**
+   * This callback will never be invoked on Android Q and above, and providers can be considered as
+   * always in the {@link android.location.LocationProvider#AVAILABLE} state.
+   * See the <a href=https://developer.android.com/reference/android/location/LocationListener#onStatusChanged(java.lang.String,%20int,%20android.os.Bundle)>Android documentation</a>
+   * for more information.
+   */
+  @SuppressWarnings({"deprecation", "RedundantSuppression"})
   @TargetApi(28)
   @Override
   public void onStatusChanged(@NonNull String provider, int status, Bundle extras) {

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.3.0
+version: 4.3.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
The `LocationManager` overrides the method `onStatusChanged`, which is deprecated. This triggers a warning during the Android build process when using the geolocator plugin. According to the documentation, this method is only triggered on Android Q and below, and it is deprecated since Android Q. Therefore, we need to keep overriding this method to support older Android version, but can safely suppress the warning for later versions.

The linter marks the deprecation suppression an unneeded. The build process does trigger the deprecation warning, though. Therefore, a second suppression was added, to suppress the warning that the deprecation suppression is unneeded.

More context is available in the Android documentation at https://developer.android.com/reference/android/location/LocationListener#onStatusChanged(java.lang.String,%20int,%20android.os.Bundle).

*List at least one fixed issue.*

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
