### PR TITLE
Fix spellings in comments of LocationPermission

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.2
+
+- Fixed spellings in comments of LocationPermission
+
 ## 4.1.1
 
 - Updates dependencies to latest versions to prevent conflicts with other packages.
@@ -24,7 +28,7 @@
 
 ## 4.0.4
 
-- Fixes a bug where listening to the position stream immediately after an error, results in listening to a dead stream. 
+- Fixes a bug where listening to the position stream immediately after an error, results in listening to a dead stream.
 
 ## 4.0.3
 

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.1.2
 
-- Fixed spellings in comments of LocationPermission
+- Fix spellings in comments of LocationPermission
 
 ## 4.1.1
 

--- a/geolocator_platform_interface/lib/src/enums/location_permission.dart
+++ b/geolocator_platform_interface/lib/src/enums/location_permission.dart
@@ -4,8 +4,8 @@ enum LocationPermission {
   /// to request permission using the `Geolocator.requestPermission()` method.
   denied,
 
-  /// Permission to access the device's location is permenantly denied. When
-  /// requestiong permissions the permission dialog will not been shown until
+  /// Permission to access the device's location is permanently denied. When
+  /// requesting permissions the permission dialog will not been shown until
   /// the user updates the permission in the App settings.
   deniedForever,
 

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,12 +3,12 @@ description: A common platform interface for the geolocator plugin.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.1.1
+version: 4.1.2
 
 dependencies:
   flutter:
     sdk: flutter
-  
+
   plugin_platform_interface: ^2.1.6
   vector_math: ^2.1.4
   meta: ^1.9.1


### PR DESCRIPTION
Fix spellings in comments of `LocationPermission`

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
