### PR TITLE
Added satelliteCount and satellitesUsedInFix to Android

### DIFF
--- a/geolocator/test/geolocator_test.dart
+++ b/geolocator/test/geolocator_test.dart
@@ -12,10 +12,14 @@ Position get mockPosition => Position(
       isUtc: true,
     ),
     altitude: 3000.0,
+    satelliteCount: 3.0,
+    satellitesUsedInFix: 2.0,
     accuracy: 0.0,
     heading: 0.0,
     speed: 0.0,
-    speedAccuracy: 0.0);
+    speedAccuracy: 0.0,
+    altitudeAccuracy: 0.0,
+    headingAccuracy: 0.0);
 
 void main() {
   group('Geolocator', () {

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.0
+
+* Adds the `gnss_satellite_count` and `gnss_satellites_used_in_fix` properties from the GNSS status callback to the Android platform.
+
 ## 4.2.2
 
 * Adds back the `applicationId` property of the AndroidManifest.xml file to keep backwardscompatibility with older applications that still rely on Gradle version <7.0.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationMapper.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationMapper.java
@@ -27,10 +27,18 @@ public class LocationMapper {
       position.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
 
     if (location.getExtras() != null) {
-      if (location.getExtras().containsKey(NmeaClient.NMEA_ALTITUDE_EXTRA)) {
-        Double mslAltitude = location.getExtras().getDouble(NmeaClient.NMEA_ALTITUDE_EXTRA);
-        position.put("altitude", mslAltitude);
-      }
+        if (location.getExtras().containsKey(NmeaClient.NMEA_ALTITUDE_EXTRA)) {
+            Double mslAltitude = location.getExtras().getDouble(NmeaClient.NMEA_ALTITUDE_EXTRA);
+            position.put("altitude", mslAltitude);
+        }
+        if (location.getExtras().containsKey(NmeaClient.GNSS_SATELLITE_COUNT_EXTRA)) {
+            Double mslSatelliteCount = location.getExtras().getDouble(NmeaClient.GNSS_SATELLITE_COUNT_EXTRA);
+            position.put("gnss_satellite_count", mslSatelliteCount);
+        }
+        if (location.getExtras().containsKey(NmeaClient.GNSS_SATELLITES_USED_IN_FIX_EXTRA)) {
+            Double mslSatellitesUsedInFix = location.getExtras().getDouble(NmeaClient.GNSS_SATELLITES_USED_IN_FIX_EXTRA);
+            position.put("gnss_satellites_used_in_fix", mslSatellitesUsedInFix);
+        }
     }
     return position;
   }

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NmeaClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NmeaClient.java
@@ -3,6 +3,7 @@ package com.baseflow.geolocator.location;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.location.GnssStatus;
 import android.location.Location;
 import android.location.LocationManager;
 import android.location.OnNmeaMessageListener;
@@ -17,6 +18,8 @@ import java.util.Calendar;
 public class NmeaClient {
 
   public static final String NMEA_ALTITUDE_EXTRA = "geolocator_mslAltitude";
+  public static final String GNSS_SATELLITE_COUNT_EXTRA = "geolocator_mslSatelliteCount";
+  public static final String GNSS_SATELLITES_USED_IN_FIX_EXTRA = "geolocator_mslSatellitesUsedInFix";
 
   private final Context context;
   private final LocationManager locationManager;
@@ -24,8 +27,12 @@ public class NmeaClient {
 
   @TargetApi(Build.VERSION_CODES.N)
   private OnNmeaMessageListener nmeaMessageListener;
+  @TargetApi(Build.VERSION_CODES.N)
+  private GnssStatus.Callback gnssCallback;
 
   private String lastNmeaMessage;
+  private double gnss_satellite_count;
+  private double gnss_satellites_used_in_fix;
   @Nullable private Calendar lastNmeaMessageTime;
   private boolean listenerAdded = false;
 
@@ -42,6 +49,17 @@ public class NmeaClient {
               lastNmeaMessageTime = Calendar.getInstance();
             }
           };
+
+        gnssCallback = new GnssStatus.Callback() {
+            @Override
+            public void onSatelliteStatusChanged(@NonNull GnssStatus status) {
+                gnss_satellite_count = status.getSatelliteCount();
+                gnss_satellites_used_in_fix = 0;
+                for (int i = 0; i < gnss_satellite_count; ++i)
+                    if (status.usedInFix(i))
+                        ++gnss_satellites_used_in_fix;
+            }
+        };
     }
   }
 
@@ -54,6 +72,7 @@ public class NmeaClient {
     if (locationOptions != null && locationOptions.isUseMSLAltitude()) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && locationManager != null) {
         locationManager.addNmeaListener(nmeaMessageListener, null);
+        locationManager.registerGnssStatusCallback(gnssCallback, null);
         listenerAdded = true;
       }
     }
@@ -63,6 +82,7 @@ public class NmeaClient {
     if (locationOptions != null && locationOptions.isUseMSLAltitude()) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && locationManager != null) {
         locationManager.removeNmeaListener(nmeaMessageListener);
+        locationManager.unregisterGnssStatusCallback(gnssCallback);
         listenerAdded = false;
       }
     }
@@ -73,6 +93,12 @@ public class NmeaClient {
     if (location == null) {
       return;
     }
+
+    if (location.getExtras() == null) {
+      location.setExtras(Bundle.EMPTY);
+    }
+    location.getExtras().putDouble(GNSS_SATELLITE_COUNT_EXTRA, gnss_satellite_count);
+    location.getExtras().putDouble(GNSS_SATELLITES_USED_IN_FIX_EXTRA, gnss_satellites_used_in_fix);
 
     if (lastNmeaMessage != null && locationOptions != null && listenerAdded) {
 

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.2.2
+version: 4.3.0
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/geolocator_android/test/geolocator_android_test.dart
+++ b/geolocator_android/test/geolocator_android_test.dart
@@ -9,18 +9,21 @@ import 'event_channel_mock.dart';
 import 'method_channel_mock.dart';
 
 Position get mockPosition => Position(
-    latitude: 52.561270,
-    longitude: 5.639382,
-    timestamp: DateTime.fromMillisecondsSinceEpoch(
-      500,
-      isUtc: true,
-    ),
-    altitude: 3000.0,
-    accuracy: 0.0,
-    heading: 0.0,
-    speed: 0.0,
-    speedAccuracy: 0.0,
-    isMocked: false);
+      latitude: 52.561270,
+      longitude: 5.639382,
+      timestamp: DateTime.fromMillisecondsSinceEpoch(
+        500,
+        isUtc: true,
+      ),
+      altitude: 3000.0,
+      satelliteCount: 2.0,
+      satellitesUsedInFix: 2.0,
+      accuracy: 0.0,
+      heading: 0.0,
+      speed: 0.0,
+      speedAccuracy: 0.0,
+      isMocked: false,
+    );
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.0
+
+- Added satellite count and satellite used in fix.
+
 ## 4.0.7
 
 - Fixed a spelling error in docs.

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.1.0
 
-- Added satellite count and satellite used in fix.
+- Added `satelliteCount` and `satellitesUsedInFix` to `Position`.
 
 ## 4.0.7
 

--- a/geolocator_platform_interface/lib/src/models/position.dart
+++ b/geolocator_platform_interface/lib/src/models/position.dart
@@ -12,6 +12,8 @@ class Position {
     required this.timestamp,
     required this.accuracy,
     required this.altitude,
+    required this.satelliteCount,
+    required this.satellitesUsedInFix,
     required this.heading,
     required this.speed,
     required this.speedAccuracy,
@@ -35,6 +37,18 @@ class Position {
   /// The altitude is not available on all devices. In these cases the returned
   /// value is 0.0.
   final double altitude;
+
+  /// On Android: if available it resturns the number of GNSS satellites.
+  /// On other platforms: the number of satellites is not available.
+  ///
+  /// If the number of satellites is not available it returns the default value: 0.0.
+  final double satelliteCount;
+
+  /// On Android: if available it returns the number of GNSS satellites used in fix.
+  /// On other platforms: the number of satellites used in fix is not available.
+  ///
+  /// If the number of satellites used in fix is not available it returns the default value: 0.0.
+  final double satellitesUsedInFix;
 
   /// The estimated horizontal accuracy of the position in meters.
   ///
@@ -79,6 +93,8 @@ class Position {
     var areEqual = other is Position &&
         other.accuracy == accuracy &&
         other.altitude == altitude &&
+        other.satelliteCount == satelliteCount &&
+        other.satellitesUsedInFix == satellitesUsedInFix &&
         other.heading == heading &&
         other.latitude == latitude &&
         other.longitude == longitude &&
@@ -95,6 +111,8 @@ class Position {
   int get hashCode =>
       accuracy.hashCode ^
       altitude.hashCode ^
+      satelliteCount.hashCode ^
+      satellitesUsedInFix.hashCode ^
       heading.hashCode ^
       latitude.hashCode ^
       longitude.hashCode ^
@@ -133,6 +151,8 @@ class Position {
       longitude: positionMap['longitude'],
       timestamp: timestamp,
       altitude: positionMap['altitude'] ?? 0.0,
+      satelliteCount: positionMap['gnss_satellite_count'] ?? 0.0,
+      satellitesUsedInFix: positionMap['gnss_satellites_used_in_fix'] ?? 0.0,
       accuracy: positionMap['accuracy'] ?? 0.0,
       heading: positionMap['heading'] ?? 0.0,
       floor: positionMap['floor'],
@@ -150,6 +170,8 @@ class Position {
         'timestamp': timestamp?.millisecondsSinceEpoch,
         'accuracy': accuracy,
         'altitude': altitude,
+        'gnss_satellite_count': satelliteCount,
+        'gnss_satellites_used_in_fix': satellitesUsedInFix,
         'floor': floor,
         'heading': heading,
         'speed': speed,

--- a/geolocator_platform_interface/lib/src/models/position.dart
+++ b/geolocator_platform_interface/lib/src/models/position.dart
@@ -38,7 +38,7 @@ class Position {
   /// value is 0.0.
   final double altitude;
 
-  /// On Android: if available it resturns the number of GNSS satellites.
+  /// On Android: if available it returns the number of GNSS satellites.
   /// On other platforms: the number of satellites is not available.
   ///
   /// If the number of satellites is not available it returns the default value: 0.0.

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.0.7
+version: 4.1.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
Adds satelliteCount and satellitesUsedInFix from the GNSS callback in Android. 

It partly resolves [#561](https://github.com/Baseflow/flutter-geolocator/issues/561).

## Pre-launch Checklist

- [ ] I made sure the project builds.
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
