### PR TITLE
Ensure timestamp is not null

### DIFF
--- a/geolocator/example/windows/flutter/generated_plugins.cmake
+++ b/geolocator/example/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,9 @@ list(APPEND FLUTTER_PLUGIN_LIST
   url_launcher_windows
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -15,3 +18,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/geolocator_linux/CHANGELOG.md
+++ b/geolocator_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+1
+
+- Ensures the `Position` instance always contains a timestamp.
+
 ## 0.2.0
 
 - Bumps `geolocator_platform_interface` dependency to `^4.1.0`.

--- a/geolocator_linux/lib/src/geoclue_x.dart
+++ b/geolocator_linux/lib/src/geoclue_x.dart
@@ -23,7 +23,7 @@ extension GeoCluePosition on GeoClueLocation {
       headingAccuracy: 0,
       latitude: latitude,
       longitude: longitude,
-      timestamp: timestamp,
+      timestamp: timestamp ?? DateTime.now(),
       speed: speed ?? 0,
       speedAccuracy: 0,
     );

--- a/geolocator_linux/pubspec.yaml
+++ b/geolocator_linux/pubspec.yaml
@@ -3,7 +3,7 @@ description: Geolocation Linux plugin for Flutter. This plugin provides the
   Linux implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_linux
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 0.2.0
+version: 0.2.0+1
 
 environment:
   sdk: '>=2.15.0 <4.0.0'


### PR DESCRIPTION
This PR ensures the `Position` object always contains a timestamp as required by the latest version of the `geolocator_platform_interface` package.

Solves #1371

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
