### PR TITLE
fix LocationManager `minUpdateIntervalMillis`

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.1
+
+* Fixes a bug where `getPositionStream` caused an `java.lang.IllegalStateException: passive location requests must have an explicit minimum update interval` because `minUpdateIntervalMillis` property in location request was set to -1 by default
+
 ## 4.4.0
 
 - Adds `color` to `ForegroundNotificationConfig` to set the color of the notification icon.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -181,6 +181,7 @@ class LocationManagerClient implements LocationClient, LocationListenerCompat {
 
     final LocationRequestCompat locationRequest = new LocationRequestCompat.Builder(timeInterval)
         .setMinUpdateDistanceMeters(distanceFilter)
+        .setMinUpdateIntervalMillis(timeInterval)
         .setQuality(quality)
         .build();
 

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.4.0
+version: 4.4.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
`getPositionStream` causes an `java.lang.IllegalStateException: passive location requests must have an explicit minimum update interval`
The problem is that `minUpdateIntervalMillis` property in location request was implicitly set to -1 by default. So the fix is to set this property to the value of `timeInterval` like it is done in `FusedLocationClient`

Fixes #1401 

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
