### PR TITLE
[iOS]: Allow arm64 simulator

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.4
 
-* Iphonesimulator arm64 as valid architecture.  
+* Allows the ARM64 architecture as a valid IPhone simulator architecture.
 
 ## 2.3.3
 

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.3.3
 
+* Iphonesimulator arm64 as valid architecture.  
+
+## 2.3.3
+
 * Ensures the `[CLLocationManager locationServicesEnabled]` message is called
 on a background thread when listening for service updates.
 

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.3.3
+## 2.3.4
 
 * Iphonesimulator arm64 as valid architecture.  
 

--- a/geolocator_apple/ios/geolocator_apple.podspec
+++ b/geolocator_apple/ios/geolocator_apple.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, '8.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386'}
 end

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.3.3
+version: 2.3.4
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
We use flutter as module and we are migration our iOS app to SwiftUI and is required to run in the simulator arm64 as a valid architecture.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
