### PR TITLE
Return heading and heading accuracy even if the value is negative.

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0
+
+* Previously the plugin filtered out negative values for heading and/or heading accuracy. Now the plugin is returning the heading and/or the heading accuracy even if the they have a negative value (invalid), so that the developer can use it and decide what to do with it.
+
 ## 2.3.2
 
 * Fixes build error and warnings regarding unused variables and unavailable APIs on macOS.

--- a/geolocator_apple/ios/Classes/Utils/LocationMapper.m
+++ b/geolocator_apple/ios/Classes/Utils/LocationMapper.m
@@ -58,16 +58,10 @@
     // - https://developer.apple.com/documentation/corelocation/cllocation/1423832-course?language=objc
     // - https://developer.apple.com/documentation/corelocation/cllocation/3524338-courseaccuracy?language=objc
     double heading = location.course;
-    if (heading >= 0.0) {
-        if (@available(iOS 13.4, macOS 10.15.4, *)) {
-            double headingAccuracy = location.courseAccuracy;
-            if (headingAccuracy >= 0.0) {
-                [locationMap setObject:@(heading) forKey: @"heading"];
-                [locationMap setObject:@(headingAccuracy) forKey: @"heading_accuracy"];
-            }
-        } else {
-            [locationMap setObject:@(heading) forKey: @"heading"];
-        }
+    [locationMap setObject:@(heading) forKey: @"heading"];
+    if (@available(iOS 13.4, macOS 10.15.4, *)) {
+        double headingAccuracy = location.courseAccuracy;
+        [locationMap setObject:@(headingAccuracy) forKey: @"heading_accuracy"];
     }
     
     if(@available(iOS 15.0, macOS 12.0, *)) {

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.3.2
+version: 2.4.0
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Results from issue [2181](https://github.com/Baseflow/flutter-geolocator/issues/1281). The heading and heading accuracy are now returned even if they contain a negative value. Allows the developer to decide what to do with it.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
