### PR TITLE
Fix typo

### DIFF
--- a/geolocator_platform_interface/lib/src/errors/permission_definitions_not_found_exception.dart
+++ b/geolocator_platform_interface/lib/src/errors/permission_definitions_not_found_exception.dart
@@ -1,5 +1,5 @@
 /// An exception thrown when the required platform specific permission
-/// definications could not be found (e.g. in the AndroidManifest.xml file on
+/// definitions could not be found (e.g. in the AndroidManifest.xml file on
 /// Android or in the Info.plist file on iOS).
 class PermissionDefinitionsNotFoundException implements Exception {
   /// Constructs the [PermissionDefinitionsNotFoundException]


### PR DESCRIPTION
Fixes a typo in a comment in permission_definitions_not_found_exception.dart
Currently "definications", and it should be "definitions"

## Pre-launch Checklist

- [ ] I made sure the project builds.
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
