### PR TITLE
Fix position property bug

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.5.1
+
+* Fixes a bug where the Position class properties were not set correctly.
+
 ## 4.5.0
 
 * Creates `AndroidPosition`, a child class of `Position` with Android specific properties.

--- a/geolocator_android/lib/src/types/android_position.dart
+++ b/geolocator_android/lib/src/types/android_position.dart
@@ -28,12 +28,15 @@ class AndroidPosition extends Position {
             latitude: latitude,
             timestamp: timestamp,
             accuracy: accuracy,
-            altitude: 0.0,
-            altitudeAccuracy: 0.0,
-            heading: 0.0,
-            headingAccuracy: 0.0,
-            speed: 0.0,
-            speedAccuracy: 0.0);
+            altitude: altitude,
+            altitudeAccuracy: altitudeAccuracy,
+            heading: heading,
+            headingAccuracy: headingAccuracy,
+            speed: speed,
+            speedAccuracy: speedAccuracy,
+            floor: floor,
+            isMocked: isMocked,
+  );
 
   /// If available it returns the number of GNSS satellites.
   ///
@@ -48,40 +51,36 @@ class AndroidPosition extends Position {
   @override
   bool operator ==(Object other) {
     var areEqual = other is AndroidPosition &&
+        super == other &&
         other.satelliteCount == satelliteCount &&
         other.satellitesUsedInFix == satellitesUsedInFix;
     return areEqual;
   }
 
   @override
-  String toString() {
-    return 'Latitude: $latitude, Longitude: $longitude, Satellite count: $satelliteCount, Satellites used in fix: $satellitesUsedInFix';
-  }
-
-  @override
-  int get hashCode => satelliteCount.hashCode ^ satellitesUsedInFix.hashCode;
+  int get hashCode => satelliteCount.hashCode ^ satellitesUsedInFix.hashCode ^ super.hashCode;
 
   /// Converts the supplied [Map] to an instance of the [AndroidPosition] class.
   static AndroidPosition fromMap(dynamic message) {
     final Map<dynamic, dynamic> positionMap = message;
+    // Call the Position fromMap method so future changes to the Position class are automatically picked up.
+    final position = Position.fromMap(positionMap);
 
     return AndroidPosition(
       satelliteCount: positionMap['gnss_satellite_count'] ?? 0.0,
       satellitesUsedInFix: positionMap['gnss_satellites_used_in_fix'] ?? 0.0,
-      latitude: positionMap['latitude'],
-      longitude: positionMap['longitude'],
-      timestamp: DateTime.fromMillisecondsSinceEpoch(
-          positionMap['timestamp'].toInt(),
-          isUtc: true),
-      altitude: positionMap['altitude'] ?? 0.0,
-      altitudeAccuracy: positionMap['altitude_accuracy'] ?? 0.0,
-      accuracy: positionMap['accuracy'] ?? 0.0,
-      heading: positionMap['heading'] ?? 0.0,
-      headingAccuracy: positionMap['heading_accuracy'] ?? 0.0,
-      floor: positionMap['floor'],
-      speed: positionMap['speed'] ?? 0.0,
-      speedAccuracy: positionMap['speed_accuracy'] ?? 0.0,
-      isMocked: positionMap['is_mocked'] ?? false,
+      latitude: position.latitude,
+      longitude: position.longitude,
+      timestamp: position.timestamp,
+      accuracy: position.accuracy,
+      altitude: position.altitude,
+      altitudeAccuracy: position.altitudeAccuracy,
+      heading: position.heading,
+      headingAccuracy: position.headingAccuracy,
+      speed: position.speed,
+      speedAccuracy: position.speedAccuracy,
+      floor: position.floor,
+      isMocked: position.isMocked,
     );
   }
 

--- a/geolocator_android/lib/src/types/android_position.dart
+++ b/geolocator_android/lib/src/types/android_position.dart
@@ -24,19 +24,19 @@ class AndroidPosition extends Position {
     int? floor,
     isMocked = false,
   }) : super(
-            longitude: longitude,
-            latitude: latitude,
-            timestamp: timestamp,
-            accuracy: accuracy,
-            altitude: altitude,
-            altitudeAccuracy: altitudeAccuracy,
-            heading: heading,
-            headingAccuracy: headingAccuracy,
-            speed: speed,
-            speedAccuracy: speedAccuracy,
-            floor: floor,
-            isMocked: isMocked,
-  );
+          longitude: longitude,
+          latitude: latitude,
+          timestamp: timestamp,
+          accuracy: accuracy,
+          altitude: altitude,
+          altitudeAccuracy: altitudeAccuracy,
+          heading: heading,
+          headingAccuracy: headingAccuracy,
+          speed: speed,
+          speedAccuracy: speedAccuracy,
+          floor: floor,
+          isMocked: isMocked,
+        );
 
   /// If available it returns the number of GNSS satellites.
   ///
@@ -58,7 +58,8 @@ class AndroidPosition extends Position {
   }
 
   @override
-  int get hashCode => satelliteCount.hashCode ^ satellitesUsedInFix.hashCode ^ super.hashCode;
+  int get hashCode =>
+      satelliteCount.hashCode ^ satellitesUsedInFix.hashCode ^ super.hashCode;
 
   /// Converts the supplied [Map] to an instance of the [AndroidPosition] class.
   static AndroidPosition fromMap(dynamic message) {

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.5.0
+version: 4.5.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
This fixes a bug introduced in the previous release where all GPS properties except latitude/longitude was zeroed out
## Pre-launch Checklist

- [X] I made sure the project builds.
- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [X] I updated `CHANGELOG.md` to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I rebased onto `main`.
- [X] I added new tests to check the change I am making, or this PR does not need tests.
- [X] I made sure all existing and new tests are passing.
- [X] I ran `dart format .` and committed any changes.
- [X] I ran `flutter analyze` and fixed any errors.

