### PR TITLE
Returns unsupported errors on web

### DIFF
--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -134,11 +134,12 @@ The second key (in this example called `YourPurposeKey`) should match the purpos
 
 To use the Geolocator plugin on the web you need to be using Flutter 1.20 or higher. Flutter will automatically add the endorsed [geolocator_web]() package to your application when you add the `geolocator: ^6.2.0` dependency to your `pubspec.yaml`.
 
-The following methods of the geolocator API are not supported on the web and will result in a `PlatformException` with the code `UNSUPPORTED_OPERATION`:
+The following methods of the geolocator API are not supported on the web and will result in a `UnsupportedError`:
 
 - `getLastKnownPosition({ bool forceAndroidLocationManager = true })`
 - `openAppSettings()`
 - `openLocationSettings()`
+- `getServiceStatusStream()`
 
 **NOTE**
 

--- a/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
+++ b/geolocator_platform_interface/lib/src/geolocator_platform_interface.dart
@@ -130,8 +130,6 @@ abstract class GeolocatorPlatform extends PlatformInterface {
   ///
   /// An instance of [LocationServiceStatus] will be emitted each time the
   /// location service is enabled or disabled.
-  /// Throws an [UnimplementedError] on the web as the concept of location
-  /// service doesn't exist on the web platform.
   Stream<ServiceStatus> getServiceStatusStream() {
     throw UnimplementedError(
         'getServiceStatusStream() has not been implemented.');

--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0
+
+**BREAKING CHANGE:**
+- `getServiceStatusStream` on web returns a PlatformException i.s.o. UnimplementedError. As the concept of location service doesn't exist on the web platform.
+
 ## 2.2.1
 
 - Migrates tests to support sound null safety.

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -116,6 +116,10 @@ class GeolocatorPlugin extends GeolocatorPlatform {
   }
 
   @override
+  Stream<ServiceStatus> getServiceStatusStream() =>
+      throw _unsupported('getServiceStatusStream');
+
+  @override
   Future<bool> openAppSettings() => throw _unsupported('openAppSettings');
 
   @override

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -143,10 +143,9 @@ class GeolocatorPlugin extends GeolocatorPlatform {
     }
   }
 
-  PlatformException _unsupported(String method) {
-    return PlatformException(
-      code: 'UNSUPPORTED_OPERATION',
-      message: '$method is not supported on the web platform.',
+  UnsupportedError _unsupported(String method) {
+    return UnsupportedError(
+      '$method is not supported on the web platform.',
     );
   }
 }

--- a/geolocator_web/lib/geolocator_web.dart
+++ b/geolocator_web/lib/geolocator_web.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 import 'src/geolocation_manager.dart';

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_web
 description: Official web implementation of the geolocator plugin.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_web
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.2.1
+version: 3.0.0
 
 flutter:
   plugin:

--- a/geolocator_web/test/geolocator_web_test.dart
+++ b/geolocator_web/test/geolocator_web_test.dart
@@ -117,17 +117,22 @@ void main() {
   group('Unsupported exceptions', () {
     test('getLastKnownPosition throws unsupported exception', () async {
       expect(geolocatorPlugin.getLastKnownPosition,
-          throwsA(isA<PlatformException>()));
+          throwsA(isA<UnsupportedError>()));
     });
 
     test('openAppSettings throws unsupported exception', () async {
       expect(
-          geolocatorPlugin.openAppSettings, throwsA(isA<PlatformException>()));
+          geolocatorPlugin.openAppSettings, throwsA(isA<UnsupportedError>()));
     });
 
     test('openLocationSettings throws unsupported exception', () async {
       expect(geolocatorPlugin.openLocationSettings,
-          throwsA(isA<PlatformException>()));
+          throwsA(isA<UnsupportedError>()));
+    });
+
+    test('getServiceStatusStream throws unsupported exception', () async {
+      expect(geolocatorPlugin.getServiceStatusStream,
+          throwsA(isA<UnsupportedError>()));
     });
   });
 }

--- a/geolocator_web/test/geolocator_web_test.dart
+++ b/geolocator_web/test/geolocator_web_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator_web/geolocator_web.dart';
 import 'package:geolocator_web/src/geolocation_manager.dart';


### PR DESCRIPTION
Fixed (https://github.com/Baseflow/flutter-geolocator/issues/1438)

Geolocation web now returns Unsupported is.o. Unimplemented

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
