### PR TITLE
[Windows] Handle errors in request access

### DIFF
--- a/geolocator_windows/CHANGELOG.md
+++ b/geolocator_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+* Fixes crash under Windows when RequestAcess is called while the Geolocation Service is disabled. (#1455)
+
 ## 0.2.2
 
 * Fixes crash under Windows when getCurrentPosition method is called. (#1240)

--- a/geolocator_windows/pubspec.yaml
+++ b/geolocator_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_windows
 description: Geolocation Windows plugin for Flutter. This plugin provides the Windows implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocators
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 0.2.2
+version: 0.2.3
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/geolocator_windows/windows/geolocator_plugin.cpp
+++ b/geolocator_windows/windows/geolocator_plugin.cpp
@@ -141,8 +141,12 @@ winrt::fire_and_forget GeolocatorPlugin::RequestAccessAsync(std::unique_ptr<Meth
       result->Success(EncodableValue((int)LocationPermission::Denied));
     else if(access == GeolocationAccessStatus::Unspecified)
       result->Success(EncodableValue((int)LocationPermission::DeniedForever));
-  } catch(const std::exception& ex) {
+  } 
+  catch(const std::exception& ex) {
     result->Error(ErrorCodeToString(ErrorCode::PermissionDefinitionsNotFound), ex.what());
+  }
+  catch (...) {
+    result->Error(ErrorCodeToString(ErrorCode::UnknownError), "RequestAccess failed. Check the Geolocation Service is running.");
   }
 }
 


### PR DESCRIPTION
Fixes crash under Windows when RequestAccess is called while the Geolocation Service is disabled. 
 - this is done by swallowing any error thrown from geolocator.RequestAccessAsync();