### PR TITLE
Adds option to configure notification channel name.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
       - "mvanbeusekom"
     open-pull-requests-limit: 10
     ignore:
+      - dependency-name: "com.google.android.gms:play-services-location"
+        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "com.android.tools.build:gradle"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "junit:junit"

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.5.3
+
+* Adds the `notificationChannelName` field to the `ForegroundNotificationConfig` class, allowing to override the channel name.
+* Reverts `com.google.android.gms:play-services-location` to version `21.0.1`. Version `21.1.0` forces users to update AGP to version 8.0.0 and Kotlin to 1.9.0 which is not inline with stable Flutter version.
+
 ## 4.5.2
 
 * Fixes a bug where the Android `activity` is leaked when the `activiy` is detached from the Flutter application. 

--- a/geolocator_android/android/build.gradle
+++ b/geolocator_android/android/build.gradle
@@ -26,7 +26,7 @@ android {
         namespace("com.baseflow.geolocator")
     }
 
-    compileSdkVersion 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 16
@@ -41,8 +41,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-location:21.1.0'
-    implementation 'androidx.core:core:1.9.0'
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
+    implementation 'androidx.core:core:1.12.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.1.1'

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorLocationService.java
@@ -85,8 +85,8 @@ public class GeolocatorLocationService extends Service {
   }
 
   public boolean canStopLocationService(boolean cancellationRequested) {
-    if(cancellationRequested) {
-       return listenerCount == 1;
+    if (cancellationRequested) {
+      return listenerCount == 1;
     }
     return connectedEngines == 0;
   }
@@ -143,7 +143,7 @@ public class GeolocatorLocationService extends Service {
       backgroundNotification =
           new BackgroundNotification(
               this.getApplicationContext(), CHANNEL_ID, ONGOING_NOTIFICATION_ID, options);
-      backgroundNotification.updateChannel("Background Location");
+      backgroundNotification.updateChannel(options.getNotificationChannelName());
       Notification notification = backgroundNotification.build();
       startForeground(ONGOING_NOTIFICATION_ID, notification);
       isForeground = true;
@@ -204,11 +204,19 @@ public class GeolocatorLocationService extends Service {
       WifiManager wifiManager =
           (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
       if (wifiManager != null) {
-        wifiLock = wifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, WIFILOCK_TAG);
+        wifiLock = wifiManager.createWifiLock(getWifiLockType(), WIFILOCK_TAG);
         wifiLock.setReferenceCounted(false);
         wifiLock.acquire();
       }
     }
+  }
+
+  @SuppressWarnings("deprecation")
+  private int getWifiLockType() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      return WifiManager.WIFI_MODE_FULL_HIGH_PERF;
+    }
+    return WifiManager.WIFI_MODE_FULL_LOW_LATENCY;
   }
 
   class LocalBinder extends Binder {

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/ForegroundNotificationOptions.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/ForegroundNotificationOptions.java
@@ -13,6 +13,8 @@ public class ForegroundNotificationOptions {
     @NonNull
     private final String notificationText;
     @NonNull
+    private final String notificationChannelName;
+    @NonNull
     private final AndroidIconResource notificationIcon;
     private final boolean enableWifiLock;
     private final boolean enableWakeLock;
@@ -28,6 +30,7 @@ public class ForegroundNotificationOptions {
 
     final AndroidIconResource notificationIcon = AndroidIconResource.parseArguments((Map<String, Object>)arguments.get("notificationIcon"));
     final String notificationTitle = (String) arguments.get("notificationTitle");
+    final String notificationChannelName = (String) arguments.get("notificationChannelName");
     final String notificationText = (String) arguments.get("notificationText");
     final Boolean enableWifiLock = (Boolean) arguments.get("enableWifiLock");
     final Boolean enableWakeLock = (Boolean) arguments.get("enableWakeLock");
@@ -42,6 +45,7 @@ public class ForegroundNotificationOptions {
     return new ForegroundNotificationOptions(
             notificationTitle,
             notificationText,
+            notificationChannelName,
             notificationIcon,
             enableWifiLock,
             enableWakeLock,
@@ -52,6 +56,7 @@ public class ForegroundNotificationOptions {
     private ForegroundNotificationOptions(
         @NonNull String notificationTitle,
         @NonNull String notificationText,
+        @NonNull String notificationChannelName,
         @NonNull AndroidIconResource notificationIcon,
         boolean enableWifiLock,
         boolean enableWakeLock,
@@ -59,6 +64,7 @@ public class ForegroundNotificationOptions {
         @Nullable Integer color) {
         this.notificationTitle = notificationTitle;
         this.notificationText = notificationText;
+        this.notificationChannelName = notificationChannelName;
         this.notificationIcon = notificationIcon;
         this.enableWifiLock = enableWifiLock;
         this.enableWakeLock = enableWakeLock;
@@ -74,6 +80,11 @@ public class ForegroundNotificationOptions {
     @NonNull
     public String getNotificationText() {
         return notificationText;
+    }
+
+    @NonNull
+    public String getNotificationChannelName() {
+        return notificationChannelName;
     }
 
     @NonNull

--- a/geolocator_android/example/android/app/build.gradle
+++ b/geolocator_android/example/android/app/build.gradle
@@ -1,14 +1,14 @@
+plugins {
+    id "com.android.application"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -27,12 +27,14 @@ project.getTasks().withType(JavaCompile) {
     options.compilerArgs.addAll(args)
 }
 
-apply plugin: 'com.android.application'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 android {
     namespace 'com.baseflow.geolocator_example'
-    compileSdkVersion 33
+    compileSdkVersion flutter.compileSdkVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 
     lintOptions {
         disable 'InvalidPackage'
@@ -41,8 +43,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.baseflow.geolocator_example"
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
 
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/geolocator_android/example/android/build.gradle
+++ b/geolocator_android/example/android/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/geolocator_android/example/android/settings.gradle
+++ b/geolocator_android/example/android/settings.gradle
@@ -1,15 +1,24 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-def plugins = new Properties()
-def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
-if (pluginsFile.exists()) {
-    pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 
-plugins.each { name, path ->
-    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
-    include ":$name"
-    project(":$name").projectDir = pluginDirectory
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "7.4.2" apply false
 }
+
+include ":app"

--- a/geolocator_android/lib/src/types/foreground_settings.dart
+++ b/geolocator_android/lib/src/types/foreground_settings.dart
@@ -27,11 +27,52 @@ class AndroidResource {
 
 /// Configuration for the foreground notification. When this is provided the location service will run as a foreground service.
 class ForegroundNotificationConfig {
+  /// Creates an Android specific configuration for the [FlutterBackground] plugin.
+  ///
+  /// [notificationTitle] is the title used for the foreground service
+  /// notification.
+  /// [notificationText] is the body used for the foreground service
+  /// notification.
+  /// [notificationChannelName] is the name of the notification channel as it is
+  /// displayed in the system settings.
+  /// [notificationIcon] must be a drawable resource.
+  /// E. g. if the icon with name "background_icon" is in the "drawable"
+  /// resource folder, it should be of value
+  /// `AndroidResource(name: 'background_icon', defType: 'drawable').
+  /// [enableWifiLock] indicates wether or not a WifiLock is acquired, when the
+  /// background execution is started. This allows the application to keep the
+  /// Wi-Fi radio awake, even when the user has not used the device in a while.
+  /// [enableWakeLock] indicates wether or not a Wakelock is acquired, when the
+  /// background execution is started. If this is false then the system can
+  /// still sleep and all location events will be received at once when the
+  /// system wakes up again.
+  /// [setOngoing] indicates wether or not the displayed notification is
+  /// persistent and the user cannot dismiss it.
+  /// [color] is the accent color that is applied to the [notificationIcon].
+  const ForegroundNotificationConfig({
+    required this.notificationTitle,
+    required this.notificationText,
+    this.notificationChannelName = 'Background Location',
+    this.notificationIcon =
+        const AndroidResource(name: 'ic_launcher', defType: 'mipmap'),
+    this.enableWifiLock = false,
+    this.enableWakeLock = false,
+    this.setOngoing = false,
+    this.color,
+  });
+
   /// The title used for the foreground service notification.
   final String notificationTitle;
 
   /// The body used for the foreground service notification.
   final String notificationText;
+
+  /// The user visible name of the notification channel.
+  ///
+  /// The notification channel name will be displayed in the system settings.
+  /// The maximum recommended length is 40 characters, the name might be
+  /// truncated if it is to long. Default value: "Background Location".
+  final String notificationChannelName;
 
   /// The resource name of the icon to be used for the foreground notification.
   final AndroidResource notificationIcon;
@@ -68,37 +109,6 @@ class ForegroundNotificationConfig {
   /// If this color is null, a system default color is used.
   final Color? color;
 
-  /// Creates an Android specific configuration for the [FlutterBackground] plugin.
-  ///
-  /// [notificationTitle] is the title used for the foreground service
-  /// notification.
-  /// [notificationText] is the body used for the foreground service
-  /// notification.
-  /// [notificationIcon] must be a drawable resource.
-  /// E. g. if the icon with name "background_icon" is in the "drawable"
-  /// resource folder, it should be of value
-  /// `AndroidResource(name: 'background_icon', defType: 'drawable').
-  /// [enableWifiLock] indicates wether or not a WifiLock is acquired, when the
-  /// background execution is started. This allows the application to keep the
-  /// Wi-Fi radio awake, even when the user has not used the device in a while.
-  /// [enableWakeLock] indicates wether or not a Wakelock is acquired, when the
-  /// background execution is started. If this is false then the system can
-  /// still sleep and all location events will be received at once when the
-  /// system wakes up again.
-  /// [setOngoing] indicates wether or not the displayed notification is
-  /// persistent and the user cannot dismiss it.
-  /// [color] is the accent color that is applied to the [notificationIcon].
-  const ForegroundNotificationConfig({
-    required this.notificationTitle,
-    required this.notificationText,
-    this.notificationIcon =
-        const AndroidResource(name: 'ic_launcher', defType: 'mipmap'),
-    this.enableWifiLock = false,
-    this.enableWakeLock = false,
-    this.setOngoing = false,
-    this.color,
-  });
-
   /// Returns a JSON representation of this class.
   Map<String, dynamic> toJson() {
     return {
@@ -107,6 +117,7 @@ class ForegroundNotificationConfig {
       'notificationTitle': notificationTitle,
       'notificationIcon': notificationIcon.toJson(),
       'notificationText': notificationText,
+      'notificationChannelName': notificationChannelName,
       'setOngoing': setOngoing,
       'color': color?.value,
     };

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.5.2
+version: 4.5.3
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Adds the option to set the notification channel name through the `notificationChannelName` field of the `ForegroundNotificationConfig` class:

```dart
final LocationSettings settings = locationSetting = AndroidSettings(
    accuracy: LocationAccuracy.bestForNavigation,
    foregroundNotificationConfig: const ForegroundNotificationConfig(
        notificationText:
        'Example app will continue to receive your location even when you aren\'t using it', 
        notificationTitle: 'Running in Background',
        enableWakeLock: true,
        notificationChannelName: 'Location in background'
    ),
  );
);
```

This PR also reverts `com.google.android.gms:play-services-location` to version `21.0.1`. Version `21.1.0` forces users to update AGP to version 8.0.0 and Kotlin to 1.9.0 which is not inline with stable Flutter version.

Resolves #1441, resolves #1443.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
