### PR TITLE
Expose AndroidPosition from geolocator

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.1.0
+
+- Expose `AndroidPosition` from geolocator.
+
 ## 11.0.0
 
 - **BREAKING CHANGE:** Updates dependency on geolocator_web to version [3.0.0](https://pub.dev/packages/geolocator_web/changelog).

--- a/geolocator/lib/geolocator.dart
+++ b/geolocator/lib/geolocator.dart
@@ -6,7 +6,11 @@ import 'package:geolocator_apple/geolocator_apple.dart';
 import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 
 export 'package:geolocator_android/geolocator_android.dart'
-    show AndroidSettings, ForegroundNotificationConfig, AndroidResource;
+    show
+        AndroidSettings,
+        ForegroundNotificationConfig,
+        AndroidResource,
+        AndroidPosition;
 export 'package:geolocator_apple/geolocator_apple.dart'
     show AppleSettings, ActivityType;
 export 'package:geolocator_platform_interface/geolocator_platform_interface.dart';

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 11.0.0
+version: 11.1.0
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Expose `AndroidPosition` directly from `geolocator`. This makes it no longer necessary to depend on `geolocator_android` directly when using `AndroidPosition` (similary to `AndroidSettings`).

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
