### PR TITLE
Start position stream after enabling location service

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 4.5.5
 
-* Removes deprecated support for Android V1 embedding as support will be removed from Flutter (see [flutter/flutter#144726](https://github.com/flutter/flutter/pull/144726)).
 * Fixes a bug where location stream is not automatically started when enabling the location services.
 
 ## 4.5.4

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.5.5
+
+* Removes deprecated support for Android V1 embedding as support will be removed from Flutter (see [flutter/flutter#144726](https://github.com/flutter/flutter/pull/144726)).
+* Fixes a bug where location stream is not automatically started when enabling the location services.
+
 ## 4.5.4
 
 * Fixes a bug where the `getPositionStream` was not informed of the location service resolution result. This resulted in a stream that was kept open indefinitely.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -56,9 +56,9 @@ public class GeolocatorPlugin implements FlutterPlugin, ActivityAware {
   @Nullable private ActivityPluginBinding pluginBinding;
 
   public GeolocatorPlugin() {
-    permissionManager = new PermissionManager();
-    geolocationManager = new GeolocationManager();
-    locationAccuracyManager = new LocationAccuracyManager();
+    permissionManager = PermissionManager.getInstance();
+    geolocationManager = GeolocationManager.getInstance();
+    locationAccuracyManager = LocationAccuracyManager.getInstance();
   }
 
   @Override

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/GeolocationManager.java
@@ -18,10 +18,20 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class GeolocationManager
     implements io.flutter.plugin.common.PluginRegistry.ActivityResultListener {
 
+    private static GeolocationManager geolocationManagerInstance = null;
+
   private final List<LocationClient> locationClients;
 
-  public GeolocationManager() {
+  private GeolocationManager() {
     this.locationClients = new CopyOnWriteArrayList<>();
+  }
+
+  public static synchronized GeolocationManager getInstance() {
+      if (geolocationManagerInstance == null) {
+          geolocationManagerInstance = new GeolocationManager();
+      }
+
+      return geolocationManagerInstance;
   }
 
   public void getLastKnownPosition(

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationAccuracyManager.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationAccuracyManager.java
@@ -11,6 +11,18 @@ import com.baseflow.geolocator.errors.ErrorCodes;
 
 public class LocationAccuracyManager {
 
+    private LocationAccuracyManager() {}
+
+  private static LocationAccuracyManager locationAccuracyManagerInstance = null;
+
+  public static synchronized LocationAccuracyManager getInstance() {
+    if (locationAccuracyManagerInstance == null) {
+      locationAccuracyManagerInstance = new LocationAccuracyManager();
+    }
+
+    return locationAccuracyManagerInstance;
+  }
+
   public LocationAccuracyStatus getLocationAccuracy(Context context, ErrorCallback errorCallback) {
     if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
         == PackageManager.PERMISSION_GRANTED) {

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/permission/PermissionManager.java
@@ -16,17 +16,30 @@ import com.baseflow.geolocator.errors.ErrorCallback;
 import com.baseflow.geolocator.errors.ErrorCodes;
 import com.baseflow.geolocator.errors.PermissionUndefinedException;
 
+import java.security.Permission;
 import java.util.*;
 
 @SuppressWarnings("deprecation")
 public class PermissionManager
     implements io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener {
 
+    private PermissionManager() {}
+
   private static final int PERMISSION_REQUEST_CODE = 109;
+
+  private static PermissionManager permissionManagerInstance = null;
 
   @Nullable private Activity activity;
   @Nullable private ErrorCallback errorCallback;
   @Nullable private PermissionResultCallback resultCallback;
+
+  public static synchronized PermissionManager getInstance() {
+      if (permissionManagerInstance == null) {
+          permissionManagerInstance = new PermissionManager();
+      }
+
+      return permissionManagerInstance;
+  }
 
   public LocationPermission checkPermissionStatus(Context context)
       throws PermissionUndefinedException {

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.5.4
+version: 4.5.5
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Fixes a bug where a new instance of the `GeolocationManager` is created and results from the location service resolution process are not delivered to the correct instance, resulting in the location stream to be cancelled or not started at all.

Fixes #1149 

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
