### PR TITLE
platform: Correctly handle integer-like numbers from JSON

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.4
+
+- Correctly handle integer-like numbers when decoding `Position` from JSON.
+
 ## 4.2.3
 
 - Fixes several grammar mistakes in the API documentation.

--- a/geolocator_platform_interface/lib/src/models/position.dart
+++ b/geolocator_platform_interface/lib/src/models/position.dart
@@ -154,14 +154,14 @@ class Position {
       latitude: positionMap['latitude'],
       longitude: positionMap['longitude'],
       timestamp: timestamp,
-      altitude: positionMap['altitude'] ?? 0.0,
-      altitudeAccuracy: positionMap['altitude_accuracy'] ?? 0.0,
-      accuracy: positionMap['accuracy'] ?? 0.0,
-      heading: positionMap['heading'] ?? 0.0,
-      headingAccuracy: positionMap['heading_accuracy'] ?? 0.0,
+      altitude: _toDouble(positionMap['altitude']),
+      altitudeAccuracy: _toDouble(positionMap['altitude_accuracy']),
+      accuracy: _toDouble(positionMap['accuracy']),
+      heading: _toDouble(positionMap['heading']),
+      headingAccuracy: _toDouble(positionMap['heading_accuracy']),
       floor: positionMap['floor'],
-      speed: positionMap['speed'] ?? 0.0,
-      speedAccuracy: positionMap['speed_accuracy'] ?? 0.0,
+      speed: _toDouble(positionMap['speed']),
+      speedAccuracy: _toDouble(positionMap['speed_accuracy']),
       isMocked: positionMap['is_mocked'] ?? false,
     );
   }
@@ -182,4 +182,12 @@ class Position {
         'speed_accuracy': speedAccuracy,
         'is_mocked': isMocked,
       };
+
+  static double _toDouble(dynamic value) {
+    if (value == null) {
+      return 0.0;
+    }
+
+    return value.toDouble();
+  }
 }

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.2.3
+version: 4.2.4
 
 dependencies:
   flutter:

--- a/geolocator_platform_interface/test/src/models/position_test.dart
+++ b/geolocator_platform_interface/test/src/models/position_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
 
@@ -511,6 +513,22 @@ void main() {
 
       // Act & Assert
       expect(() => Position.fromMap(map), throwsArgumentError);
+    });
+
+    test('fromMap should handle a map returned by jsonDecode', () {
+      // Arrange
+      const json = '''{
+        "is_mocked": true,
+        "longitude": -122.406417,
+        "timestamp": 1718643179305.9131,
+        "latitude": 37.785834000000001,
+        "heading_accuracy": -1,
+        "accuracy": 5,
+        "heading": -1.5
+      }''';
+
+      // Act & Assert
+      expect(() => Position.fromMap(jsonDecode(json)), returnsNormally);
     });
   });
 


### PR DESCRIPTION
In JSON, an allowed representation for doubles without a fractional part like `1.0` is actually `1`. This is, for example, the behavior of [JSONEncoder][1].

When using `jsonDecode`, a `0` or `1` is deserialized to an `int`, which would then cause `Position.fromMap` to crash. Instead, use `toDouble()` to ensure that the value is converted to a `double`.

[1]: https://developer.apple.com/documentation/foundation/jsonencoder

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
