### PR TITLE
NmeaClient: check ACCESS_FINE_LOCATION permission

### DIFF
--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NmeaClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/NmeaClient.java
@@ -1,8 +1,10 @@
 package com.baseflow.geolocator.location;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.location.GnssStatus;
 import android.location.Location;
 import android.location.LocationManager;
@@ -73,9 +75,12 @@ public class NmeaClient {
 
     if (locationOptions != null) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && locationManager != null) {
-        locationManager.addNmeaListener(nmeaMessageListener, null);
-        locationManager.registerGnssStatusCallback(gnssCallback, null);
-        listenerAdded = true;
+        if (context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+            == PackageManager.PERMISSION_GRANTED) {
+          locationManager.addNmeaListener(nmeaMessageListener, null);
+          locationManager.registerGnssStatusCallback(gnssCallback, null);
+          listenerAdded = true;
+        }
       }
     }
   }

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.6.0
+version: 4.6.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
I've deleted my repo and that automatically closed https://github.com/Baseflow/flutter-geolocator/pull/1522

The issue is still open, so here's a second attempt.

`locationManager.addNmeaListener()` requires the ACCESS_FINE_LOCATION permission. With only reduced locations enabled this would cause an exception.

Fixes #1520
Fixes #1515

## Pre-launch Checklist

- [ ] I made sure the project builds.
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning