### PR TITLE
[geolocator_web]: Bump web from 0.5.1 to 1.0.0 in /geolocator_web

### DIFF
--- a/geolocator_apple/example/lib/main.dart
+++ b/geolocator_apple/example/lib/main.dart
@@ -118,7 +118,7 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
           ExamplePage(
             Icons.location_on,
             (context) => Scaffold(
-              backgroundColor: Theme.of(context).colorScheme.background,
+              backgroundColor: Theme.of(context).colorScheme.surface,
               body: ListView.builder(
                 itemCount: _positionItems.length,
                 itemBuilder: (context, index) {

--- a/geolocator_linux/example/lib/main.dart
+++ b/geolocator_linux/example/lib/main.dart
@@ -52,7 +52,7 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
     );
 
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.background,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       body: ListView.builder(
         itemCount: _positionItems.length,
         itemBuilder: (context, index) {

--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,12 +1,18 @@
+## 4.0.1
+
+- Upgrade the `web` dependency to version 1.0.0.
+
 ## 4.0.0
 
 **BREAKING CHANGE:**
-  - Migrates from dart:html to package:web and dart:js_interop
-  - Migrates to Dart SDK 3.3.0 and Flutter 3.16.0.
+
+- Migrates from dart:html to package:web and dart:js_interop
+- Migrates to Dart SDK 3.3.0 and Flutter 3.16.0.
 
 ## 3.0.0
 
 **BREAKING CHANGE:**
+
 - `getServiceStatusStream` on web returns a PlatformException i.s.o. UnimplementedError. As the concept of location service doesn't exist on the web platform.
 
 ## 2.2.1
@@ -19,7 +25,7 @@
 
 ## 2.1.7
 
-- Mark `geolocator_web` as implementation of `geolocator` 
+- Mark `geolocator_web` as implementation of `geolocator`
 
 ## 2.1.6
 
@@ -35,7 +41,7 @@
 
 ## 2.1.3
 
-- Updated to the latest version of the `geolocator_platform_interface': `4.0.0`.
+- Updated to the latest version of the `geolocator_platform_interface':`4.0.0`.
 
 ## 2.1.2
 
@@ -47,7 +53,7 @@
 
 ## 2.1.0
 
-- Made changes to the implementation of the `getCurrentPosition` and `getPositionStream` method to match new platform interface. 
+- Made changes to the implementation of the `getCurrentPosition` and `getPositionStream` method to match new platform interface.
 - Fixes issues where geolocator doesn't work on Safari due to missing implementation of `query` method in the browser.
 
 ## 2.0.6
@@ -72,7 +78,7 @@
 
 ## 2.0.1
 
-- Solve bug causing error when requesting permissions (see issue [#673](https://github.com/Baseflow/flutter-geolocator/issues/673)). 
+- Solve bug causing error when requesting permissions (see issue [#673](https://github.com/Baseflow/flutter-geolocator/issues/673)).
 
 ## 2.0.0
 

--- a/geolocator_web/lib/src/utils.dart
+++ b/geolocator_web/lib/src/utils.dart
@@ -1,23 +1,24 @@
 import 'dart:async';
-import 'package:web/web.dart' as web;
+
 import 'package:flutter/services.dart';
 import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
+import 'package:web/web.dart' as web;
 
 /// Converts the Geoposition object into a [Position] object.
 Position toPosition(web.GeolocationPosition webPosition) {
   final coords = webPosition.coords;
 
   return Position(
-    latitude: coords.latitude as double,
-    longitude: coords.longitude as double,
+    latitude: coords.latitude,
+    longitude: coords.longitude,
     timestamp: DateTime.fromMillisecondsSinceEpoch(webPosition.timestamp),
-    altitude: coords.altitude as double? ?? 0.0,
-    altitudeAccuracy: coords.altitudeAccuracy as double? ?? 0.0,
+    altitude: coords.altitude ?? 0.0,
+    altitudeAccuracy: coords.altitudeAccuracy ?? 0.0,
     accuracy: coords.accuracy as double? ?? 0.0,
-    heading: coords.heading as double? ?? 0.0,
+    heading: coords.heading ?? 0.0,
     headingAccuracy: 0.0,
     floor: null,
-    speed: coords.speed as double? ?? 0.0,
+    speed: coords.speed ?? 0.0,
     speedAccuracy: 0.0,
     isMocked: false,
   );

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   geolocator_platform_interface: ^4.2.2
-  web: ^0.5.1
+  web: ^1.0.0
 
 dev_dependencies:
   build_runner: ^2.4.8
@@ -27,7 +27,6 @@ dev_dependencies:
   flutter_lints: ">=3.0.1 <5.0.0"
   mockito: ^5.4.0
 
-
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: ">=3.3.0 <4.0.0"
   flutter: ">=3.16.0"

--- a/geolocator_windows/example/lib/main.dart
+++ b/geolocator_windows/example/lib/main.dart
@@ -105,7 +105,7 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
           ExamplePage(
             Icons.location_on,
             (context) => Scaffold(
-              backgroundColor: Theme.of(context).colorScheme.background,
+              backgroundColor: Theme.of(context).colorScheme.surface,
               body: ListView.builder(
                 itemCount: _positionItems.length,
                 itemBuilder: (context, index) {


### PR DESCRIPTION
chore: Update background color in geolocator examples

'background' is deprecated and shouldn't be used. Use surface instead. This feature was deprecated after v3.18.0-0.1.

*Replace this paragraph with a short description of what issue this pull request (PR) solves and provide a description of the change.  Consider including before/after screenshots.*

*List at least one fixed issue.*

## Pre-launch Checklist

- [ ] I made sure the project builds.
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
