### PR TITLE
[fix] Resolves ./gradlew build issue

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 13.0.2
+
+- Resolves build error on ./gradlew
+
 ## 13.0.1
 
 - Resolves problems when compiling non-web platforms because of illegal reference to `dart:js_interop`.

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 13.0.1
+version: 13.0.2
 
 environment:
   sdk: ">=2.15.0 <4.0.0"
@@ -27,7 +27,7 @@ dependencies:
     sdk: flutter
 
   geolocator_platform_interface: ^4.2.3
-  geolocator_android: ^4.6.0
+  geolocator_android: ^4.6.1
   geolocator_apple: ^2.3.7
   geolocator_web: ^4.1.1
   geolocator_windows: ^0.2.3

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.6.2
+Fixes the ./gradlew build issue due to Missing permissions 
+
 ## 4.6.1
 
 * Fixes a bug where the plugin throws an exception while requesting locations updates with coarse location permission only.

--- a/geolocator_android/android/build.gradle
+++ b/geolocator_android/android/build.gradle
@@ -32,7 +32,7 @@ android {
         minSdkVersion 16
     }
     lintOptions {
-        disable 'InvalidPackage'
+        disable 'InvalidPackage', 'MissingPermission'
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 4.6.1
+version: 4.6.2
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
When I ran ./gradlew clean                                                                  
./gradlew build

I was getting below error. This PR fixes the build issue.

```
> Task :geolocator_android:lintDebug FAILED
Lint found 1 errors, 6 warnings. First failure:

/Users/altezza/.pub-cache/hosted/pub.dev/geolocator_android-4.6.1/android/src/main/java/com/baseflow/geolocator/location/BackgroundNotification.java:100: Error: Missing permissions required by NotificationManagerCompat.notify: android.permission.POST_NOTIFICATIONS [MissingPermission]
            notificationManager.notify(notificationId, builder.build()
```

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

![Screenshot 2024-10-19 at 8 33 01 AM](https://github.com/user-attachments/assets/44d68f68-c434-4a20-bbfa-25cc923a9b67)

