### PR TITLE
MRS-2850 Crash if listen/cancel is executed in quick succession

### DIFF
--- a/geolocator_apple/ios/Classes/Handlers/LocationServiceStreamHandler.m
+++ b/geolocator_apple/ios/Classes/Handlers/LocationServiceStreamHandler.m
@@ -37,10 +37,12 @@
   dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     BOOL isEnabled = [CLLocationManager locationServicesEnabled];
     dispatch_async(dispatch_get_main_queue(), ^(void) {
-        if (isEnabled) {
-            self->_eventSink([NSNumber numberWithInt:(ServiceStatus)enabled]);
-        } else {
-            self->_eventSink([NSNumber numberWithInt:(ServiceStatus)disabled]);
+        if (_eventSink != nil) {
+            if (isEnabled) {
+                self->_eventSink([NSNumber numberWithInt:(ServiceStatus) enabled]);
+            } else {
+                self->_eventSink([NSNumber numberWithInt:(ServiceStatus) disabled]);
+            }
         }
     });
   });


### PR DESCRIPTION
The onDidAuthorizationChanged is executed by iOS somewhen afer CLLocationManager is created in onListenWithArguments.

If the the subscription is canceled in the meantime _eventSink (onCancelWithArguments) is set to nil leading to accessing _eventSink when already nil (BAD_ACCESS crash).

*Replace this paragraph with a short description of what issue this pull request (PR) solves and provide a description of the change.  Consider including before/after screenshots.*

*List at least one fixed issue.*

## Pre-launch Checklist

- [ x ] I made sure the project builds.
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
