### PR TITLE
[geolocator_android] Introduce option to force a specific location provider   Issue/1171

### DIFF
--- a/geolocator/lib/geolocator.dart
+++ b/geolocator/lib/geolocator.dart
@@ -8,6 +8,7 @@ import 'package:geolocator_platform_interface/geolocator_platform_interface.dart
 export 'package:geolocator_android/geolocator_android.dart'
     show
         AndroidSettings,
+        AndroidLocationProvider,
         ForegroundNotificationConfig,
         AndroidResource,
         AndroidPosition;

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/errors/ErrorCodes.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/errors/ErrorCodes.java
@@ -34,7 +34,7 @@ public enum ErrorCodes {
       case errorWhileAcquiringPosition:
         return "An unexpected error occurred while trying to acquire the device's position.";
       case locationServicesDisabled:
-        return "Location services are disabled. To receive location updates the location services should be enabled.";
+        return "Location services are disabled or requested location provider is unavailable. To receive location updates the location services must be enabled. When forcing a specific provider, it must be available on the device.";
       case permissionDefinitionsNotFound:
         return "No location permissions are defined in the manifest. Make sure at least ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION are defined in the manifest.";
       case permissionDenied:

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationManagerClient.java
@@ -77,11 +77,14 @@ class LocationManagerClient implements LocationClient, LocationListenerCompat {
 
   private static @Nullable String determineProvider(
       @NonNull LocationManager locationManager,
-      @NonNull LocationAccuracy accuracy) {
+      @NonNull LocationAccuracy accuracy,
+      @Nullable String forceProvider) {
 
       final List<String> enabledProviders = locationManager.getProviders(true);
 
-      if (accuracy == LocationAccuracy.lowest) {
+      if (forceProvider != null) {
+          return enabledProviders.contains(forceProvider) ? forceProvider : null;
+      } else if (accuracy == LocationAccuracy.lowest) {
           return LocationManager.PASSIVE_PROVIDER;
       } else if (enabledProviders.contains(LocationManager.FUSED_PROVIDER) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
           return LocationManager.FUSED_PROVIDER;
@@ -172,7 +175,10 @@ class LocationManagerClient implements LocationClient, LocationListenerCompat {
       quality = accuracyToQuality(accuracy);
     }
 
-    this.currentLocationProvider = determineProvider(this.locationManager, accuracy);
+    this.currentLocationProvider = determineProvider(
+            this.locationManager,
+            accuracy,
+            locationOptions != null ? locationOptions.getForceProvider() : null);
 
     if (this.currentLocationProvider == null) {
       errorCallback.onError(ErrorCodes.locationServicesDisabled);

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationOptions.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationOptions.java
@@ -1,5 +1,7 @@
 package com.baseflow.geolocator.location;
 
+import androidx.annotation.Nullable;
+
 import java.util.Map;
 
 public class LocationOptions {
@@ -9,24 +11,27 @@ public class LocationOptions {
   private final long distanceFilter;
   private final long timeInterval;
   private final boolean useMSLAltitude;
+  private final String forceProvider;
 
   private LocationOptions(
-      LocationAccuracy accuracy, long distanceFilter, long timeInterval, boolean useMSLAltitude) {
+      LocationAccuracy accuracy, long distanceFilter, long timeInterval, boolean useMSLAltitude, String provider) {
     this.accuracy = accuracy;
     this.distanceFilter = distanceFilter;
     this.timeInterval = timeInterval;
     this.useMSLAltitude = useMSLAltitude;
+    this.forceProvider = provider;
   }
 
   public static LocationOptions parseArguments(Map<String, Object> arguments) {
     if (arguments == null) {
-      return new LocationOptions(LocationAccuracy.best, 0, 5000, false);
+      return new LocationOptions(LocationAccuracy.best, 0, 5000, false, null);
     }
 
     final Integer accuracy = (Integer) arguments.get("accuracy");
     final Integer distanceFilter = (Integer) arguments.get("distanceFilter");
     final Integer timeInterval = (Integer) arguments.get("timeInterval");
     final Boolean useMSLAltitude = (Boolean) arguments.get("useMSLAltitude");
+    final String provider = (String) arguments.get("forceProvider");
 
     LocationAccuracy locationAccuracy = LocationAccuracy.best;
 
@@ -54,10 +59,11 @@ public class LocationOptions {
     }
 
     return new LocationOptions(
-        locationAccuracy,
-        distanceFilter != null ? distanceFilter : 0,
-        timeInterval != null ? timeInterval : 5000,
-        useMSLAltitude != null && useMSLAltitude);
+            locationAccuracy,
+            distanceFilter != null ? distanceFilter : 0,
+            timeInterval != null ? timeInterval : 5000,
+            useMSLAltitude != null && useMSLAltitude,
+            provider);
   }
 
   public LocationAccuracy getAccuracy() {
@@ -74,5 +80,10 @@ public class LocationOptions {
 
   public boolean isUseMSLAltitude() {
     return useMSLAltitude;
+  }
+
+  @Nullable
+  public String getForceProvider() {
+    return forceProvider;
   }
 }

--- a/geolocator_android/lib/geolocator_android.dart
+++ b/geolocator_android/lib/geolocator_android.dart
@@ -16,7 +16,7 @@ export 'package:geolocator_platform_interface/geolocator_platform_interface.dart
         ServiceStatus;
 
 export 'src/geolocator_android.dart';
-export 'src/types/android_settings.dart' show AndroidSettings;
+export 'src/types/android_settings.dart' show AndroidSettings, AndroidLocationProvider;
 export 'src/types/android_position.dart' show AndroidPosition;
 export 'src/types/foreground_settings.dart'
     show AndroidResource, ForegroundNotificationConfig;

--- a/geolocator_android/lib/src/types/android_settings.dart
+++ b/geolocator_android/lib/src/types/android_settings.dart
@@ -17,7 +17,7 @@ class AndroidSettings extends LocationSettings {
     Duration? timeLimit,
     this.foregroundNotificationConfig,
     this.useMSLAltitude = false,
-    this.forceLocationProvider,
+    this.forceProvider,
   }) : super(
             accuracy: accuracy,
             distanceFilter: distanceFilter,
@@ -78,7 +78,7 @@ class AndroidSettings extends LocationSettings {
   /// Set this to use a specific [AndroidLocationProvider].
   /// Set this value only in conjunction with [forceLocationManager] set to true. Be sure the provider is available on your targeted devices.
   /// Defaults to null.
-  final AndroidLocationProvider? forceLocationProvider;
+  final AndroidLocationProvider? forceProvider;
 
   @override
   Map<String, dynamic> toJson() {
@@ -88,7 +88,7 @@ class AndroidSettings extends LocationSettings {
         'timeInterval': intervalDuration?.inMilliseconds,
         'foregroundNotificationConfig': foregroundNotificationConfig?.toJson(),
         'useMSLAltitude': useMSLAltitude,
-        'forceLocationProvider': forceLocationProvider?.name,
+        'forceProvider': forceProvider?.name,
       });
   }
 }

--- a/geolocator_android/lib/src/types/android_settings.dart
+++ b/geolocator_android/lib/src/types/android_settings.dart
@@ -17,6 +17,7 @@ class AndroidSettings extends LocationSettings {
     Duration? timeLimit,
     this.foregroundNotificationConfig,
     this.useMSLAltitude = false,
+    this.forceLocationProvider,
   }) : super(
             accuracy: accuracy,
             distanceFilter: distanceFilter,
@@ -74,6 +75,11 @@ class AndroidSettings extends LocationSettings {
   /// Defaults to false
   final bool useMSLAltitude;
 
+  /// Set this to use a specific [AndroidLocationProvider].
+  /// Set this value only in conjunction with [forceLocationManager] set to true. Be sure the provider is available on your targeted devices.
+  /// Defaults to null.
+  final AndroidLocationProvider? forceLocationProvider;
+
   @override
   Map<String, dynamic> toJson() {
     return super.toJson()
@@ -82,6 +88,19 @@ class AndroidSettings extends LocationSettings {
         'timeInterval': intervalDuration?.inMilliseconds,
         'foregroundNotificationConfig': foregroundNotificationConfig?.toJson(),
         'useMSLAltitude': useMSLAltitude,
+        'forceLocationProvider': forceLocationProvider?.name,
       });
   }
+}
+
+/// Represents the different [Android location providers](https://developer.android.com/reference/android/location/LocationManager#constants_1)
+enum AndroidLocationProvider {
+  /// [GPS_PROVIDER](https://developer.android.com/reference/android/location/LocationManager#GPS_PROVIDER)
+  gps,
+  /// [FUSED_PROVIDER](https://developer.android.com/reference/android/location/LocationManager#FUSED_PROVIDER)
+  fused,
+  /// [NETWORK_PROVIDER](https://developer.android.com/reference/android/location/LocationManager#NETWORK_PROVIDER)
+  network,
+  /// [PASSIVE_PROVIDER](https://developer.android.com/reference/android/location/LocationManager#PASSIVE_PROVIDER)
+  passive,
 }


### PR DESCRIPTION
Added an option `AndroidSettings.forceProvider` that forces the plugin to use a specific provider out of the currently four available Android location providers. As discussed with @mvanbeusekom, this option is to be used in conjunction with `forceLocationManager = true`.

Example use case: An app needs to ensure locations are derived exclusively from GNSS and hence has to make sure no other sources like mobile networks are used.

#1171 

## Pre-launch Checklist

- [ ] I made sure the project builds.
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
