### PR TITLE
Remove < iOS 11 fallback API calls in openSettings:

### DIFF
--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Removed deprecated `-[UIApplication openURL:]` dead code.
+
 ## 2.3.10
 
 * Updated dart sdk to sdk: `^3.5.0`

--- a/geolocator_apple/example/ios/RunnerTests/GeolocatorPluginTests.m
+++ b/geolocator_apple/example/ios/RunnerTests/GeolocatorPluginTests.m
@@ -311,56 +311,20 @@
 #pragma mark - Test open setting related methods
 
 - (void)testOpenAppSettings {
-  if (@available(iOS 10, *))
-  {
-    id mockApplication = OCMClassMock([UIApplication class]);
-    OCMStub([mockApplication openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
-                             options:@{}
-                   completionHandler:([OCMArg invokeBlockWithArgs:@(YES), nil])]);
-    OCMStub(ClassMethod([mockApplication sharedApplication])).andReturn(mockApplication);
-    
-      
-    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"openAppSettings"
-                                                                arguments:@{}];
-    
-    XCTestExpectation *expectation = [self expectationWithDescription:@"openAppSettings should return yes."];
-    GeolocatorPlugin *plugin = [[GeolocatorPlugin alloc] init];
-    [plugin handleMethodCall:call result:^(id  _Nullable result) {
-      XCTAssertTrue(result);
-      [expectation fulfill];
-    }];
-    
-    [self waitForExpectationsWithTimeout:5.0 handler:nil];
-    return;
-  }
-  
-  if (@available(iOS 8, *)) {
-    id mockApplication = OCMClassMock([UIApplication class]);
-    OCMStub([(UIApplication *)mockApplication openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]]).andReturn(YES);
-    OCMStub(ClassMethod([mockApplication sharedApplication])).andReturn(mockApplication);
-    
-      
-    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"openAppSettings"
-                                                                arguments:@{}];
-    
-    XCTestExpectation *expectation = [self expectationWithDescription:@"openAppSettings should return yes."];
-    GeolocatorPlugin *plugin = [[GeolocatorPlugin alloc] init];
-    [plugin handleMethodCall:call result:^(id  _Nullable result) {
-      XCTAssertTrue(result);
-      [expectation fulfill];
-    }];
-    
-    [self waitForExpectationsWithTimeout:5.0 handler:nil];
-    return;
-  }
-  
+  id mockApplication = OCMClassMock([UIApplication class]);
+  OCMStub([mockApplication openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
+                           options:@{}
+                 completionHandler:([OCMArg invokeBlockWithArgs:@(YES), nil])]);
+  OCMStub(ClassMethod([mockApplication sharedApplication])).andReturn(mockApplication);
+
+
   FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"openAppSettings"
                                                               arguments:@{}];
   
   XCTestExpectation *expectation = [self expectationWithDescription:@"openAppSettings should return yes."];
   GeolocatorPlugin *plugin = [[GeolocatorPlugin alloc] init];
   [plugin handleMethodCall:call result:^(id  _Nullable result) {
-    XCTAssertFalse(result);
+    XCTAssertTrue(result);
     [expectation fulfill];
   }];
   
@@ -369,61 +333,24 @@
 }
 
 - (void)testOpenLocationSettings {
-  if (@available(iOS 10, *))
-  {
-    id mockApplication = OCMClassMock([UIApplication class]);
-    OCMStub([mockApplication openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
-                             options:@{}
-                   completionHandler:([OCMArg invokeBlockWithArgs:@(YES), nil])]);
-    OCMStub(ClassMethod([mockApplication sharedApplication])).andReturn(mockApplication);
-    
-      
-    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"openLocationSettings"
-                                                                arguments:@{}];
-    
-    XCTestExpectation *expectation = [self expectationWithDescription:@"openLocationSettings should return yes."];
-    GeolocatorPlugin *plugin = [[GeolocatorPlugin alloc] init];
-    [plugin handleMethodCall:call result:^(id  _Nullable result) {
-      XCTAssertTrue(result);
-      [expectation fulfill];
-    }];
-    
-    [self waitForExpectationsWithTimeout:5.0 handler:nil];
-    return;
-  }
-  
-  if (@available(iOS 8, *)) {
-    id mockApplication = OCMClassMock([UIApplication class]);
-    OCMStub([(UIApplication *)mockApplication openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]]).andReturn(YES);
-    OCMStub(ClassMethod([mockApplication sharedApplication])).andReturn(mockApplication);
-    
-      
-    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"openLocationSettings"
-                                                                arguments:@{}];
-    
-    XCTestExpectation *expectation = [self expectationWithDescription:@"openLocationSettings should return yes."];
-    GeolocatorPlugin *plugin = [[GeolocatorPlugin alloc] init];
-    [plugin handleMethodCall:call result:^(id  _Nullable result) {
-      XCTAssertTrue(result);
-      [expectation fulfill];
-    }];
-    
-    [self waitForExpectationsWithTimeout:5.0 handler:nil];
-    return;
-  }
-  
+  id mockApplication = OCMClassMock([UIApplication class]);
+  OCMStub([mockApplication openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
+                           options:@{}
+                 completionHandler:([OCMArg invokeBlockWithArgs:@(YES), nil])]);
+  OCMStub(ClassMethod([mockApplication sharedApplication])).andReturn(mockApplication);
+
+
   FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"openLocationSettings"
                                                               arguments:@{}];
   
   XCTestExpectation *expectation = [self expectationWithDescription:@"openLocationSettings should return yes."];
   GeolocatorPlugin *plugin = [[GeolocatorPlugin alloc] init];
   [plugin handleMethodCall:call result:^(id  _Nullable result) {
-    XCTAssertFalse(result);
+    XCTAssertTrue(result);
     [expectation fulfill];
   }];
   
   [self waitForExpectationsWithTimeout:5.0 handler:nil];
-  return;
 }
 
 @end

--- a/geolocator_apple/ios/Classes/GeolocatorPlugin.m
+++ b/geolocator_apple/ios/Classes/GeolocatorPlugin.m
@@ -175,20 +175,12 @@
   BOOL success = [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:urlString]];
   result([[NSNumber alloc] initWithBool:success]);
 #else
-  if (@available(iOS 10, *)) {
-    [[UIApplication sharedApplication]
-     openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
-     options:[[NSDictionary alloc] init]
-     completionHandler:^(BOOL success) {
-      result([[NSNumber alloc] initWithBool:success]);
-    }];
-  } else if (@available(iOS 8.0, *)) {
-    BOOL success = [[UIApplication sharedApplication]
-                    openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
+  [[UIApplication sharedApplication]
+   openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
+   options:[[NSDictionary alloc] init]
+   completionHandler:^(BOOL success) {
     result([[NSNumber alloc] initWithBool:success]);
-  } else {
-    result([[NSNumber alloc] initWithBool:NO]);
-  }
+  }];
 #endif
 }
 @end


### PR DESCRIPTION
geolocator_apple runs on a minimum of iOS 11
https://github.com/Baseflow/flutter-geolocator/blob/df61d4c55992fa9f49a65b919f1541ab31fd41d5/geolocator_apple/ios/geolocator_apple.podspec#L20

This means that `if (@available(iOS 10, *))` will never be false. Remove the dead fallback.  See my explanation in https://github.com/Baseflow/flutter-geolocator/issues/1652#issuecomment-2707699017 why I'm limiting the availability cleanup to this one `-[UIApplication openURL:]` method.

Remove fallbacks in tests as well.

On this PR:
```
Test Case '-[GeolocatorPluginTests testOpenAppSettings]' started.
Test Case '-[GeolocatorPluginTests testOpenAppSettings]' passed (0.001 seconds).
```

Part of https://github.com/Baseflow/flutter-geolocator/issues/1652

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
