### PR TITLE
Fix "location services disabled" error on Wear OS

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.0.1+1
 
 - Bump `androidx.core:core` to version 1.16.0
+- Fixes `location service on the device is disabled` bug on Wear OS 
 
 ## 5.0.1
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -16,6 +16,7 @@ import androidx.annotation.Nullable;
 import com.baseflow.geolocator.errors.ErrorCallback;
 import com.baseflow.geolocator.errors.ErrorCodes;
 import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.common.api.ResolvableApiException;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationAvailability;
@@ -240,6 +241,7 @@ class FusedLocationClient implements LocationClient {
             locationSettingsResponse -> requestPositionUpdates(this.locationOptions))
         .addOnFailureListener(
             e -> {
+              Log.w(TAG, "checkLocationSettings error", e);
               if (e instanceof ResolvableApiException) {
                 // When we don't have an activity return an error code explaining the
                 // location services are not enabled
@@ -264,7 +266,9 @@ class FusedLocationClient implements LocationClient {
               } else {
                 ApiException ae = (ApiException) e;
                 int statusCode = ae.getStatusCode();
-                if (statusCode == LocationSettingsStatusCodes.SETTINGS_CHANGE_UNAVAILABLE) {
+                // checkLocationSettings returns DEVELOPER_ERROR on Wear OS.
+                if (statusCode == LocationSettingsStatusCodes.SETTINGS_CHANGE_UNAVAILABLE
+                    || statusCode == CommonStatusCodes.DEVELOPER_ERROR) {
                   requestPositionUpdates(this.locationOptions);
                 } else {
                   // This should not happen according to Android documentation but it has been


### PR DESCRIPTION
getCurrentPosition() was returning "location services disabled" error on Wear OS even though location was actually enabled. Handling this error skips the location setting check and starts fetching the location.

*List at least one fixed issue.*
Fixes #1197 for getCurrentPosition(). I haven't tested Wear OS support for all APIs.

## Pre-launch Checklist

- [X] I made sure the project builds.
- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [X] I updated `CHANGELOG.md` to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I rebased onto `main`.
- [X] I added new tests to check the change I am making, or this PR does not need tests.
- [X] I made sure all existing and new tests are passing.
- [X] I ran `dart format .` and committed any changes.
- [X] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
