### PR TITLE
Updates the Android example app FOREGROUND_SERVICE_LOCATION manifest permission

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 - Bump `androidx.core:core` to version 1.15.0
+- Fixes PlatformException in example app for Android 14 (API level 34) versions and newer by updating manifest permissions.
 
 ## 5.0.1
 

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 5.0.1+1
+## 5.0.2
 
 - Fixes PlatformException in example app for Android 14 (API level 34) versions and newer by updating manifest permissions.
+
+## 5.0.1+1
+
 - Bump `androidx.core:core` to version 1.16.0
 
 ## 5.0.1

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.2
+## NEXT
 
 - Fixes PlatformException in example app for Android 14 (API level 34) versions and newer by updating manifest permissions.
 

--- a/geolocator_android/example/android/app/src/main/AndroidManifest.xml
+++ b/geolocator_android/example/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <!-- Permissions options for the `location` group -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 5.0.1+1
+version: 5.0.2
 
 environment:
   sdk: ^3.5.0

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 5.0.2
+version: 5.0.1+1
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
Updates the Android example app manifest by adding required permissions to run on SDK 34 and above. This version does not need to be released.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
