### PR TITLE
Check LocationSettingsResponse success before processing

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 - Fixes PlatformException in example app for Android 14 (API level 34) versions and newer by updating manifest permissions.
+- Prevented crash by checking `isSuccessful` before calling `getResult()` in location settings check.
 
 ## 5.0.1+1
 

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -167,17 +167,17 @@ class FusedLocationClient implements LocationClient {
             (response) -> {
               if (!response.isSuccessful()) {
                 listener.onLocationServiceError(ErrorCodes.locationServicesDisabled);
-              }
-
-              LocationSettingsResponse lsr = response.getResult();
-              if (lsr != null) {
-                LocationSettingsStates settingsStates = lsr.getLocationSettingsStates();
-                boolean isGpsUsable = settingsStates != null && settingsStates.isGpsUsable();
-                boolean isNetworkUsable =
-                    settingsStates != null && settingsStates.isNetworkLocationUsable();
-                listener.onLocationServiceResult(isGpsUsable || isNetworkUsable);
               } else {
-                listener.onLocationServiceError(ErrorCodes.locationServicesDisabled);
+                LocationSettingsResponse lsr = response.getResult();
+                if (lsr != null) {
+                    LocationSettingsStates settingsStates = lsr.getLocationSettingsStates();
+                    boolean isGpsUsable = settingsStates != null && settingsStates.isGpsUsable();
+                    boolean isNetworkUsable =
+                            settingsStates != null && settingsStates.isNetworkLocationUsable();
+                    listener.onLocationServiceResult(isGpsUsable || isNetworkUsable);
+                } else {
+                    listener.onLocationServiceError(ErrorCodes.locationServicesDisabled);
+                }
               }
             });
   }


### PR DESCRIPTION
First check if the `LocationSettingsResponse` task was successful before attempting to get the result.

Fix FusedLocationClient.isLocationServiceEnabled crashes.

*List at least one fixed issue.*
https://github.com/Baseflow/flutter-geolocator/issues/1366
https://github.com/Baseflow/flutter-geolocator/issues/1527

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
