### PR TITLE
Fix: Add POST_NOTIFICATIONS permission

### DIFF
--- a/geolocator_android/android/src/main/AndroidManifest.xml
+++ b/geolocator_android/android/src/main/AndroidManifest.xml
@@ -1,11 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.baseflow.geolocator">
+    package="com.baseflow.geolocator">
+
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application>
         <service
-                android:enabled="true"
-                android:exported="false"
-                android:foregroundServiceType="location"
-                android:name=".GeolocatorLocationService"/>
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="location"
+            android:name=".GeolocatorLocationService"/>
     </application>
 </manifest>


### PR DESCRIPTION
This PR adds the 'android.permission.POST_NOTIFICATIONS' permission to the Android manifest. This is required for apps targeting API 33 (Android 13) and above to use NotificationManagerCompat.notify without build failures related to missing permissions.