### PR TITLE
Fix malformed FOREGROUND_SERVICE_LOCATION permission in README

### DIFF
--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -72,7 +72,7 @@ Starting from Android 14 (SDK 34) you need to add the `FOREGROUND_SERVICE_LOCATI
  [FOREGROUND_SERVICE_LOCATION](https://developer.android.com/reference/android/Manifest.permission#FOREGROUND_SERVICE_LOCATION) 
 
  ``` xml
- <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION">
+ <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
  ```
 
 > **NOTE:** Specifying the `ACCESS_COARSE_LOCATION` permission results in location updates with an accuracy approximately equivalent to a city block. It might take a long time (minutes) before you will get your first locations fix as `ACCESS_COARSE_LOCATION` will only use the network services to calculate the position of the device. More information can be found [here](https://developer.android.com/training/location/retrieve-current#permissions). 


### PR DESCRIPTION
Fixes an invalid AndroidManifest XML snippet in the README where the
FOREGROUND_SERVICE_LOCATION <uses-permission> tag was not self-closed.

This caused the example to be malformed XML. The README now uses the
correct self-closing tag syntax.

## Pre-launch Checklist

- [ ] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
