### PR TITLE
fix(macos): resolve deprecated authorizationStatus warnings in geolocator_apple

### DIFF
--- a/geolocator_apple/darwin/geolocator_apple/Sources/geolocator_apple/Handlers/LocationServiceStreamHandler.m
+++ b/geolocator_apple/darwin/geolocator_apple/Sources/geolocator_apple/Handlers/LocationServiceStreamHandler.m
@@ -33,7 +33,7 @@
   return nil;
 }
 
-- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status{
+- (void)_notifyServiceStatus {
   dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     BOOL isEnabled = [CLLocationManager locationServicesEnabled];
     dispatch_async(dispatch_get_main_queue(), ^(void) {
@@ -45,5 +45,18 @@
     });
   });
 }
+
+// iOS 14+ / macOS 11+: preferred delegate callback
+- (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
+  [self _notifyServiceStatus];
+}
+
+// Fallback for iOS < 14 / macOS < 11
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status{
+  [self _notifyServiceStatus];
+}
+#pragma clang diagnostic pop
 
 @end

--- a/geolocator_apple/darwin/geolocator_apple/Sources/geolocator_apple/Handlers/PermissionHandler.m
+++ b/geolocator_apple/darwin/geolocator_apple/Sources/geolocator_apple/Handlers/PermissionHandler.m
@@ -46,8 +46,13 @@
 
 - (void) requestPermission:(PermissionConfirmation)confirmationHandler
               errorHandler:(PermissionError)errorHandler {
-  // When we already have permission we don't have to request it again
-  CLAuthorizationStatus authorizationStatus = [self checkPermission];
+  // When we already have permission we don't have to request it again.
+  // Use the class method directly (with warning suppression) to avoid
+  // lazily creating and retaining a CLLocationManager on the early-return path.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  CLAuthorizationStatus authorizationStatus = CLLocationManager.authorizationStatus;
+#pragma clang diagnostic pop
   if (authorizationStatus != kCLAuthorizationStatusNotDetermined) {
     confirmationHandler(authorizationStatus);
     return;

--- a/geolocator_apple/darwin/geolocator_apple/Sources/geolocator_apple/Handlers/PermissionHandler.m
+++ b/geolocator_apple/darwin/geolocator_apple/Sources/geolocator_apple/Handlers/PermissionHandler.m
@@ -107,6 +107,23 @@
 }
 #endif
 
+// iOS 14+ / macOS 11+: preferred delegate callback
+- (void) locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
+  CLAuthorizationStatus status = [self checkPermission];
+  if (status == kCLAuthorizationStatusNotDetermined) {
+    return;
+  }
+
+  if (self.confirmationHandler) {
+    self.confirmationHandler(status);
+  }
+
+  [self cleanUp];
+}
+
+// Fallback for iOS < 14 / macOS < 11
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void) locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
   if (status == kCLAuthorizationStatusNotDetermined) {
     return;
@@ -118,6 +135,7 @@
   
   [self cleanUp];
 }
+#pragma clang diagnostic pop
 
 - (void) cleanUp {
   self.locationManager = nil;

--- a/geolocator_apple/darwin/geolocator_apple/Sources/geolocator_apple/Handlers/PermissionHandler.m
+++ b/geolocator_apple/darwin/geolocator_apple/Sources/geolocator_apple/Handlers/PermissionHandler.m
@@ -37,14 +37,17 @@
   if (@available(iOS 14, macOS 11, *)) {
     return [self.getLocationManager authorizationStatus];
   } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return [CLLocationManager authorizationStatus];
+#pragma clang diagnostic pop
   }
 }
 
 - (void) requestPermission:(PermissionConfirmation)confirmationHandler
               errorHandler:(PermissionError)errorHandler {
   // When we already have permission we don't have to request it again
-  CLAuthorizationStatus authorizationStatus = CLLocationManager.authorizationStatus;
+  CLAuthorizationStatus authorizationStatus = [self checkPermission];
   if (authorizationStatus != kCLAuthorizationStatusNotDetermined) {
     confirmationHandler(authorizationStatus);
     return;


### PR DESCRIPTION
## Summary

Fixes deprecated `CLLocationManager.authorizationStatus` warnings on macOS 11+ builds in `geolocator_apple`.

## Problem

When building for macOS, Xcode emits deprecation warnings:

```
'authorizationStatus' was deprecated in macOS 11.0
```

There are two call sites in `PermissionHandler.m`:

1. **`checkPermission`** (line ~42): The `else` branch of an `@available(iOS 14, macOS 11, *)` check calls the deprecated class method `[CLLocationManager authorizationStatus]`. This is correct behavior for older OS versions but triggers a warning on modern SDKs.

2. **`requestPermission:errorHandler:`** (line ~53): Uses `CLLocationManager.authorizationStatus` without any `@available` guard.

See #1732.

## Solution

1. **`checkPermission`**: Wrap the deprecated call in `#pragma clang diagnostic push/ignored/pop` to suppress the warning in the `else` branch, since we already know we're on an older OS version at that point.

2. **`requestPermission:errorHandler:`**: Replace the unguarded `CLLocationManager.authorizationStatus` with `[self checkPermission]`, which already has the proper `@available` guard and returns the same `CLAuthorizationStatus` value.

## Testing

- No behavioral change — the same authorization status values are returned
- Eliminates all macOS deprecation warnings from `PermissionHandler.m`

Closes #1732
