### PR TITLE
fix(web): improve js_interop safety and add error handling in geolocation callbacks

### DIFF
--- a/geolocator_web/lib/src/html_geolocation_manager.dart
+++ b/geolocator_web/lib/src/html_geolocation_manager.dart
@@ -24,11 +24,16 @@ class HtmlGeolocationManager implements GeolocationManager {
     Completer<Position> completer = Completer();
     try {
       _geolocation.getCurrentPosition(
-        (web.GeolocationPosition position) {
-          completer.complete(toPosition(position));
+        (JSAny position) {
+          try {
+            completer.complete(toPosition(position as web.GeolocationPosition));
+          } catch (e, st) {
+            completer.completeError(e, st);
+          }
         }.toJS,
-        (web.GeolocationPositionError error) {
-          completer.completeError(convertPositionError(error));
+        (JSAny error) {
+          completer.completeError(
+              convertPositionError(error as web.GeolocationPositionError));
         }.toJS,
         web.PositionOptions(
           enableHighAccuracy: enableHighAccuracy ?? false,
@@ -62,11 +67,12 @@ class HtmlGeolocationManager implements GeolocationManager {
     controller.onListen = () {
       assert(watchId == null);
       watchId = _geolocation.watchPosition(
-        (web.GeolocationPosition position) {
-          controller.add(toPosition(position));
+        (JSAny position) {
+          controller.add(toPosition(position as web.GeolocationPosition));
         }.toJS,
-        (web.GeolocationPositionError error) {
-          controller.addError(convertPositionError(error));
+        (JSAny error) {
+          controller.addError(
+              convertPositionError(error as web.GeolocationPositionError));
         }.toJS,
         web.PositionOptions(
           enableHighAccuracy: enableHighAccuracy ?? false,


### PR DESCRIPTION
This PR introduces stability and strict JS interop improvements to the HtmlGeolocationManager implementation for web.

# Changes Included:

- JSAny Interop Compatibility: Adjusted the closure parameters for JS interoperability (the .toJS callbacks) to accept JSAny instead of the typed web.GeolocationPosition and web.GeolocationPositionError. This guarantees compatibility with stricter dart2wasm compilations and newer versions of package:web, avoiding JS interop type mismatches.
- Safer Async Behavior: Added a try/catch block around toPosition inside the getCurrentPosition success callback. Previously, if malformed data was returned from the browser and toPosition threw an exception, the Completer would hang indefinitely. It now gracefully forwards any framework or parsing errors to completer.completeError.