### PR TITLE
chore: upgrade all dependencies to Flutter 3.44 ceiling versions

### DIFF
--- a/geolocator/CHANGELOG.md
+++ b/geolocator/CHANGELOG.md
@@ -1,3 +1,15 @@
+## NEXT
+
+- Updates dependency on `geolocator_platform_interface` to version `^4.2.6`.
+- Updates dependency on `geolocator_android` to version `^5.0.2`.
+- Updates dependency on `geolocator_apple` to version `^2.3.13`.
+- Updates dependency on `geolocator_web` to version `^4.1.3`.
+- Updates dependency on `geolocator_windows` to version `^0.2.5`.
+- Updates dependency on `geolocator_linux` to version `^0.2.4`.
+- Updates dev dependency on `flutter_lints` to version `^6.0.0`.
+- Updates dev dependency on `mockito` to version `^5.7.0`.
+- Updates dev dependency on `plugin_platform_interface` to version `^2.1.8`.
+
 ## 14.0.2
 
 - Adds section about `UIBackgroundModes` to the README. 

--- a/geolocator/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/geolocator/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,9 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import geolocator_apple
+import package_info_plus
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/geolocator/example/pubspec.yaml
+++ b/geolocator/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
-  baseflow_plugin_template: ^2.1.2
-  
+  baseflow_plugin_template: ^2.2.1
+
   flutter:
     sdk: flutter
 
@@ -24,16 +24,16 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.1+1
+  cupertino_icons: ^1.0.9
 
   # The following adds the URL Launcher plugin which is used by
   # the demo application to open the links in the web browser.
-  url_launcher: ^6.0.0-nullsafety.1
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/geolocator/pubspec.yaml
+++ b/geolocator/pubspec.yaml
@@ -28,16 +28,16 @@ dependencies:
   flutter:
     sdk: flutter
 
-  geolocator_platform_interface: ^4.2.3
-  geolocator_android: ^5.0.0
-  geolocator_apple: ^2.3.8
-  geolocator_web: ^4.1.1
-  geolocator_windows: ^0.2.3
-  geolocator_linux: ^0.2.3
+  geolocator_platform_interface: ^4.2.6
+  geolocator_android: ^5.0.2
+  geolocator_apple: ^2.3.13
+  geolocator_web: ^4.1.3
+  geolocator_windows: ^0.2.5
+  geolocator_linux: ^0.2.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
-  mockito: ^5.0.0-nullsafety.7
+  flutter_lints: ^6.0.0
+  mockito: ^5.7.0
   plugin_platform_interface: ^2.1.8

--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,13 @@
+## NEXT
+
+- Updates dependency on `geolocator_platform_interface` to version `^4.2.6`.
+- Updates dependency on `meta` to version `^1.18.0`.
+- Updates dependency on `uuid` to version `^4.5.3`.
+- Updates dev dependency on `flutter_lints` to version `^6.0.0`.
+- Updates dev dependency on `mockito` to version `^5.7.0`.
+- Updates dev dependency on `plugin_platform_interface` to version `^2.1.8`.
+- Updates dev dependency on `async` to version `^2.13.1`.
+
 ## 5.0.2
 
 - Fixes PlatformException in example app for Android 14 (API level 34) versions and newer by updating manifest permissions.

--- a/geolocator_android/example/pubspec.yaml
+++ b/geolocator_android/example/pubspec.yaml
@@ -9,10 +9,10 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
-  baseflow_plugin_template: ^2.1.2
+  baseflow_plugin_template: ^2.2.1
   flutter:
     sdk: flutter
-  geolocator_platform_interface: ^4.2.4
+  geolocator_platform_interface: ^4.2.6
 
   geolocator_android:
     # When depending on this package from a real application you should use:
@@ -24,16 +24,16 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.1+1
+  cupertino_icons: ^1.0.9
 
   # The following adds the URL Launcher plugin which is used by
   # the demo application to open the links in the web browser.
-  url_launcher: ^6.0.0-nullsafety.1
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -20,14 +20,14 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  geolocator_platform_interface: ^4.1.0
-  meta: ^1.10.0
-  uuid: ">=4.0.0 <6.0.0"
+  geolocator_platform_interface: ^4.2.6
+  meta: ^1.18.0
+  uuid: ^4.5.3
 
 dev_dependencies:
-  async: ^2.8.2
+  async: ^2.13.1
   flutter_test:
     sdk: flutter
-  flutter_lints: ">=3.0.0 <5.0.0"
-  mockito: ^5.2.0
-  plugin_platform_interface: ^2.1.2
+  flutter_lints: ^6.0.0
+  mockito: ^5.7.0
+  plugin_platform_interface: ^2.1.8

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,11 @@
+## NEXT
+
+* Updates dependency on `geolocator_platform_interface` to version `^4.2.6`.
+* Updates dev dependency on `flutter_lints` to version `^6.0.0`.
+* Updates dev dependency on `mockito` to version `^5.7.0`.
+* Updates dev dependency on `plugin_platform_interface` to version `^2.1.8`.
+* Updates dev dependency on `async` to version `^2.13.1`.
+
 ## 2.3.13
 
 * Adds Swift Package Manager compatibility.

--- a/geolocator_apple/example/pubspec.yaml
+++ b/geolocator_apple/example/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
-  baseflow_plugin_template: ^2.1.2
+  baseflow_plugin_template: ^2.2.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.1+1
-  
+  cupertino_icons: ^1.0.9
+
   geolocator_apple:
     # When depending on this package from a real application you should use:
     #   geolocator_apple: ^x.y.z
@@ -23,19 +23,19 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
 
-  geolocator_platform_interface: ^4.2.0
+  geolocator_platform_interface: ^4.2.6
 
   flutter:
     sdk: flutter
 
   # The following adds the URL Launcher plugin which is used by
   # the demo application to open the links in the web browser.
-  url_launcher: ^6.0.0-nullsafety.1
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -24,12 +24,12 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  geolocator_platform_interface: ^4.1.0
+  geolocator_platform_interface: ^4.2.6
 
 dev_dependencies:
-  async: ^2.8.2
+  async: ^2.13.1
   flutter_test:
     sdk: flutter
-  flutter_lints: ">=3.0.1 <5.0.0"
-  mockito: ^5.2.0
-  plugin_platform_interface: ^2.1.2
+  flutter_lints: ^6.0.0
+  mockito: ^5.7.0
+  plugin_platform_interface: ^2.1.8

--- a/geolocator_linux/CHANGELOG.md
+++ b/geolocator_linux/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 - Updates dependency on `package_info_plus` to version `^10.1.0` (major bump).
 - Updates dependency on `geolocator_platform_interface` to version `^4.2.6`.
-- Updates dependency on `dbus` to version `^0.7.13`.
 - Updates dependency on `gsettings` to version `^0.2.8`.
 - Updates dev dependency on `build_runner` to version `^2.15.0`.
 - Updates dev dependency on `flutter_lints` to version `^6.0.0`.

--- a/geolocator_linux/CHANGELOG.md
+++ b/geolocator_linux/CHANGELOG.md
@@ -1,3 +1,14 @@
+## NEXT
+
+- Updates dependency on `package_info_plus` to version `^10.1.0` (major bump).
+- Updates dependency on `geolocator_platform_interface` to version `^4.2.6`.
+- Updates dependency on `dbus` to version `^0.7.13`.
+- Updates dependency on `gsettings` to version `^0.2.8`.
+- Updates dev dependency on `build_runner` to version `^2.15.0`.
+- Updates dev dependency on `flutter_lints` to version `^6.0.0`.
+- Updates dev dependency on `mockito` to version `^5.7.0`.
+- Updates dev dependency on `plugin_platform_interface` to version `^2.1.8`.
+
 ## 0.2.4
 
 - Updates dependency on package_info_plus to version 9.0.0.

--- a/geolocator_linux/example/pubspec.yaml
+++ b/geolocator_linux/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
-  baseflow_plugin_template: ^2.1.2
+  baseflow_plugin_template: ^2.2.1
   flutter:
     sdk: flutter
 
@@ -23,17 +23,17 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.1+1
+  cupertino_icons: ^1.0.9
 
   # The following adds the URL Launcher plugin which is used by
   # the demo application to open the links in the web browser.
-  url_launcher: ^6.0.18
-  geolocator_platform_interface: ^4.2.0
+  url_launcher: ^6.3.2
+  geolocator_platform_interface: ^4.2.6
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/geolocator_linux/pubspec.yaml
+++ b/geolocator_linux/pubspec.yaml
@@ -17,18 +17,18 @@ flutter:
         dartPluginClass: GeolocatorLinux
 
 dependencies:
-  dbus: ^0.7.3
+  dbus: ^0.7.13
   flutter:
     sdk: flutter
   geoclue: ^0.1.1
-  geolocator_platform_interface: ^4.1.0
-  gsettings: ^0.2.5
-  package_info_plus: "^9.0.0"
+  geolocator_platform_interface: ^4.2.6
+  gsettings: ^0.2.8
+  package_info_plus: ^10.1.0
 
 dev_dependencies:
-  build_runner: ^2.1.8
-  flutter_lints: ^5.0.0
+  build_runner: ^2.15.0
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.17
-  plugin_platform_interface: ^2.1.2
+  mockito: ^5.7.0
+  plugin_platform_interface: ^2.1.8

--- a/geolocator_linux/pubspec.yaml
+++ b/geolocator_linux/pubspec.yaml
@@ -17,7 +17,7 @@ flutter:
         dartPluginClass: GeolocatorLinux
 
 dependencies:
-  dbus: ^0.7.13
+  dbus: ^0.7.3
   flutter:
     sdk: flutter
   geoclue: ^0.1.1

--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## NEXT
 
-- Updated `flutter_lints` to version `^5.0.0`.
+- Updates dependency on `meta` to version `^1.18.0`.
+- Updates dependency on `vector_math` to version `^2.2.0`.
+- Updates dependency on `plugin_platform_interface` to version `^2.1.8`.
+- Updates dev dependency on `flutter_lints` to version `^6.0.0`.
+- Updates dev dependency on `mockito` to version `^5.7.0`.
+- Updates dev dependency on `async` to version `^2.13.1`.
 
 ## 4.2.6
 

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -9,17 +9,17 @@ version: 4.2.6
 dependencies:
   flutter:
     sdk: flutter
-  
-  plugin_platform_interface: ^2.1.6
-  vector_math: ^2.1.4
-  meta: ^1.9.1
+
+  plugin_platform_interface: ^2.1.8
+  vector_math: ^2.2.0
+  meta: ^1.18.0
 
 dev_dependencies:
-  async: ^2.11.0
+  async: ^2.13.1
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
-  mockito: ^5.4.2
+  flutter_lints: ^6.0.0
+  mockito: ^5.7.0
 
 environment:
   sdk: ^3.5.0

--- a/geolocator_web/CHANGELOG.md
+++ b/geolocator_web/CHANGELOG.md
@@ -1,3 +1,11 @@
+## NEXT
+
+- Updates dependency on `geolocator_platform_interface` to version `^4.2.6`.
+- Updates dependency on `web` to version `^1.1.1`.
+- Updates dev dependency on `build_runner` to version `^2.15.0`.
+- Updates dev dependency on `flutter_lints` to version `^6.0.0`.
+- Updates dev dependency on `mockito` to version `^5.7.0`.
+
 ## 4.1.3
 
 - Bump `flutter_lints` to version 5.0.0

--- a/geolocator_web/example/pubspec.yaml
+++ b/geolocator_web/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
-  baseflow_plugin_template: ^2.1.2
+  baseflow_plugin_template: ^2.2.1
   flutter:
     sdk: flutter
 
@@ -23,16 +23,16 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.1+1
+  cupertino_icons: ^1.0.9
 
   # The following adds the URL Launcher plugin which is used by
   # the demo application to open the links in the web browser.
-  url_launcher: ^6.0.9
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/geolocator_web/pubspec.yaml
+++ b/geolocator_web/pubspec.yaml
@@ -17,15 +17,15 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  geolocator_platform_interface: ^4.2.3
-  web: ^1.0.0
+  geolocator_platform_interface: ^4.2.6
+  web: ^1.1.1
 
 dev_dependencies:
-  build_runner: ^2.4.8
+  build_runner: ^2.15.0
   flutter_test:
     sdk: flutter
-  flutter_lints: ">=3.0.1 <5.0.0"
-  mockito: ^5.4.0
+  flutter_lints: ^6.0.0
+  mockito: ^5.7.0
 
 environment:
   sdk: ^3.5.0

--- a/geolocator_windows/CHANGELOG.md
+++ b/geolocator_windows/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## NEXT
 
-- Bump `flutter_lints` of package to version 5.0.0.
+- Updates dependency on `geolocator_platform_interface` to version `^4.2.6`.
+- Updates dev dependency on `flutter_lints` to version `^6.0.0`.
+- Updates dev dependency on `mockito` to version `^5.7.0`.
+- Updates dev dependency on `plugin_platform_interface` to version `^2.1.8`.
 
 ## 0.2.5
 

--- a/geolocator_windows/example/pubspec.yaml
+++ b/geolocator_windows/example/pubspec.yaml
@@ -9,11 +9,11 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
-  baseflow_plugin_template: ^2.1.2
+  baseflow_plugin_template: ^2.2.1
   flutter:
     sdk: flutter
 
-  geolocator_platform_interface: ^4.0.7
+  geolocator_platform_interface: ^4.2.6
   geolocator_windows:
     # When depending on this package from a real application you should use:
     #   geolocator_windows: ^x.y.z
@@ -24,16 +24,16 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.1+1
+  cupertino_icons: ^1.0.9
 
   # The following adds the URL Launcher plugin which is used by
   # the demo application to open the links in the web browser.
-  url_launcher: ^6.0.18
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/geolocator_windows/pubspec.yaml
+++ b/geolocator_windows/pubspec.yaml
@@ -18,11 +18,11 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  geolocator_platform_interface: ^4.1.0
-  
+  geolocator_platform_interface: ^4.2.6
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
-  mockito: ^5.0.17
-  plugin_platform_interface: ^2.1.2
+  flutter_lints: ^6.0.0
+  mockito: ^5.7.0
+  plugin_platform_interface: ^2.1.8


### PR DESCRIPTION
## Summary

Upgrades every dependency across all 7 packages and 6 example apps to the maximum versions resolvable on the current Flutter stable (3.44.0 / Dart 3.12.0). All pubspec constraints are now caret-locked to the resolved versions.

## Notable bumps

| Where | Package | Old | New |
|---|---|---|---|
| `geolocator_linux` | `package_info_plus` | `^9.0.0` | `^10.1.0` (major) |
| all | `flutter_lints` | `^5.0.0` / `>=3.0.0 <5.0.0` | `^6.0.0` (major) |
| `geolocator_platform_interface`, `geolocator_android` | `meta` | `^1.9.1` / `^1.10.0` | `^1.18.0` |
| `geolocator_platform_interface` | `vector_math` | `^2.1.4` | `^2.2.0` |
| all | `plugin_platform_interface` | mixed | `^2.1.8` |
| `geolocator_android` | `uuid` | `>=4.0.0 <6.0.0` | `^4.5.3` |
| `geolocator_linux` | `dbus`, `gsettings` | `^0.7.3`, `^0.2.5` | `^0.7.13`, `^0.2.8` |
| dev (web, linux) | `build_runner` | `^2.1.8` / `^2.4.8` | `^2.15.0` |
| dev (all) | `mockito` | mixed | `^5.7.0` |
| dev (platform_interface) | `async` | `^2.11.0` | `^2.13.1` |
| examples | `baseflow_plugin_template` | `^2.1.2` | `^2.2.1` |
| examples | `cupertino_icons` | `^1.0.1+1` | `^1.0.9` |
| examples | `url_launcher` | varied | `^6.3.2` |

## Held back by the Flutter SDK pin (cannot upgrade until next stable)

- `meta` 1.18.0 (1.18.2 available)
- `vector_math` 2.2.0 (2.3.0 available)
- `matcher` 0.12.19 (0.12.20 available, transitive dev)
- `test_api` 0.7.11 (0.7.12 available, transitive dev)

## Trade-offs to be aware of

1. **`meta` constraint narrowing** (`^1.9.1` -> `^1.18.0`) in `geolocator_platform_interface` and `geolocator_android` cuts off consumers on Flutter SDKs that pin `meta` below 1.18 (i.e. Flutter < 3.44). If you want to keep broader compat, you can revert just the `meta` constraint in those two pubspecs - the resolved version stays the same either way.
2. **`uuid` constraint narrowing** (`>=4.0.0 <6.0.0` -> `^4.5.3`) in `geolocator_android` blocks future v5 adoption. Revert to `">=4.5.3 <6.0.0"` if you want forward room.
3. **`package_info_plus` v9 -> v10** is a runtime major bump for `geolocator_linux`. API usage is limited to `PackageInfo.fromPlatform()` and survives unchanged. This follows the same pattern as #1754 which bumped v8 -> v9.

## Verification

- `flutter analyze` passes with zero errors across all 7 packages and all 6 example apps.
- `flutter test` passes for `geolocator`, `geolocator_platform_interface`, `geolocator_apple` (full suite).
- Two pre-existing failures encountered, both unrelated to this PR:
  - `geolocator_android` line 1512 compares JSON int to a method tearoff (`.color!.toARGB32` missing parens, introduced in PR #1648).
  - `geolocator_linux` `registerWith` / `open location settings` tests need a real Linux DBus session and fail by design on non-Linux runners.

## Test plan

- [ ] CI matrix passes on all platforms
- [ ] Spot-check example apps build on Android, iOS, web, Linux, Windows
- [ ] Verify `package_info_plus` v10 works at runtime on `geolocator_linux`