### PR TITLE
docs: clarify that Position.heading carries course over ground (#1187)

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Updated `flutter_lints` to version `^5.0.0`.
 
+## 4.2.7
+
+- Clarifies the documentation of `Position.heading` to explain that it carries the course over ground (direction of travel, from `Location.getBearing()` on Android and `CLLocation.course` on iOS), which is distinct from compass heading. The field keeps the `heading` name for backward compatibility. Resolves [#1187](https://github.com/Baseflow/flutter-geolocator/issues/1187).
+
 ## 4.2.6
 
 - Updates documentation `isMocked` to bring it in line with the functionality. `isMocked` for iOS 15 and higher depends on the result from isSimulatedBySoftware.

--- a/geolocator_platform_interface/lib/src/models/position.dart
+++ b/geolocator_platform_interface/lib/src/models/position.dart
@@ -50,10 +50,22 @@ class Position {
   /// 0.0.
   final double accuracy;
 
-  /// The heading in which the device is traveling in degrees.
+  /// The course over ground (direction of travel) in degrees.
   ///
-  /// The heading is not available on all devices. In these cases the value is
-  /// 0.0.
+  /// This reports the direction in which the device is *moving* across the
+  /// ground, in degrees clockwise relative to true north (0.0 to 360.0). It is
+  /// derived from the platform's GPS-based value: `Location.getBearing()` on
+  /// Android and `CLLocation.course` on iOS.
+  ///
+  /// This is distinct from compass heading: it does *not* report the direction
+  /// the device is physically pointing (the magnetometer/compass reading). A
+  /// stationary device has no meaningful course over ground.
+  ///
+  /// The field is named `heading` for backward compatibility; despite the name
+  /// it carries the course-over-ground value described above.
+  ///
+  /// The course is not available on all devices, and may be unavailable while
+  /// the device is not moving. In these cases the value is 0.0.
   final double heading;
 
   /// The estimated heading accuracy of the position in degrees.

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.2.6
+version: 4.2.7
 
 
 dependencies:


### PR DESCRIPTION
Resolves #1187.

As discussed in #1187, `Position.heading` is named "heading" but actually carries **course over ground** (the direction of travel), not compass heading. In the issue, @mvanbeusekom proposed a documentation clarification rather than a breaking rename, and invited a PR.

This updates the dartdoc of `Position.heading` in `geolocator_platform_interface` to explain that the value is course over ground (distinct from compass heading), and that the `heading` name is retained for backward compatibility.

The documented native sources are accurate:
- Android: `geolocator_android/.../LocationMapper.java` maps `heading` from `Location.getBearing()`.
- iOS: `geolocator_apple/.../LocationMapper.m` maps `heading` from `CLLocation.course`.

This is **documentation-only** — no code, signature, or serialization changes; the `heading` field name and behaviour are unchanged, so it is non-breaking.

Per your request in the issue:
- Bumped `geolocator_platform_interface` `4.2.6` → `4.2.7`.
- Added a `## 4.2.7` CHANGELOG entry. I left the existing `## NEXT` `flutter_lints ^5.0.0` entry under `NEXT` so you can cut that on your own cadence — happy to fold it into this release instead if you'd prefer.

Verification (`geolocator_platform_interface`, Flutter 3.45 / Dart 3.11):
- `dart format` — clean (no changes)
- `flutter analyze` — No issues found!
- `flutter test` — All tests passed! (115/115)

Branched from `main` per your note that the repo no longer uses a `develop` branch.
