### PR TITLE
feat(android): support max update age setting

### DIFF
--- a/geolocator_android/CHANGELOG.md
+++ b/geolocator_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.0
+
+- Adds `maxUpdateAge` to `AndroidSettings`, allowing position streams using the Android Fused Location Provider to accept an initial historical location independently of the update interval.
+
 ## 5.0.3
 
 - Updates `flutter_lints` to version 6.0.0.

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/FusedLocationClient.java
@@ -106,6 +106,11 @@ class FusedLocationClient implements LocationClient {
       builder.setIntervalMillis(options.getTimeInterval());
       builder.setMinUpdateIntervalMillis(options.getTimeInterval());
       builder.setMinUpdateDistanceMeters(options.getDistanceFilter());
+
+      Long maxUpdateAgeMillis = options.getMaxUpdateAgeMillis();
+      if (maxUpdateAgeMillis != null) {
+        builder.setMaxUpdateAgeMillis(maxUpdateAgeMillis);
+      }
     }
 
     return builder.build();

--- a/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationOptions.java
+++ b/geolocator_android/android/src/main/java/com/baseflow/geolocator/location/LocationOptions.java
@@ -8,24 +8,31 @@ public class LocationOptions {
   private final LocationAccuracy accuracy;
   private final long distanceFilter;
   private final long timeInterval;
+  private final Long maxUpdateAgeMillis;
   private final boolean useMSLAltitude;
 
   private LocationOptions(
-      LocationAccuracy accuracy, long distanceFilter, long timeInterval, boolean useMSLAltitude) {
+      LocationAccuracy accuracy,
+      long distanceFilter,
+      long timeInterval,
+      Long maxUpdateAgeMillis,
+      boolean useMSLAltitude) {
     this.accuracy = accuracy;
     this.distanceFilter = distanceFilter;
     this.timeInterval = timeInterval;
+    this.maxUpdateAgeMillis = maxUpdateAgeMillis;
     this.useMSLAltitude = useMSLAltitude;
   }
 
   public static LocationOptions parseArguments(Map<String, Object> arguments) {
     if (arguments == null) {
-      return new LocationOptions(LocationAccuracy.best, 0, 5000, false);
+      return new LocationOptions(LocationAccuracy.best, 0, 5000, null, false);
     }
 
     final Integer accuracy = (Integer) arguments.get("accuracy");
     final Integer distanceFilter = (Integer) arguments.get("distanceFilter");
     final Integer timeInterval = (Integer) arguments.get("timeInterval");
+    final Integer maxUpdateAge = (Integer) arguments.get("maxUpdateAge");
     final Boolean useMSLAltitude = (Boolean) arguments.get("useMSLAltitude");
 
     LocationAccuracy locationAccuracy = LocationAccuracy.best;
@@ -57,6 +64,7 @@ public class LocationOptions {
         locationAccuracy,
         distanceFilter != null ? distanceFilter : 0,
         timeInterval != null ? timeInterval : 5000,
+        maxUpdateAge != null ? maxUpdateAge.longValue() : null,
         useMSLAltitude != null && useMSLAltitude);
   }
 
@@ -70,6 +78,10 @@ public class LocationOptions {
 
   public long getTimeInterval() {
     return timeInterval;
+  }
+
+  public Long getMaxUpdateAgeMillis() {
+    return maxUpdateAgeMillis;
   }
 
   public boolean isUseMSLAltitude() {

--- a/geolocator_android/android/src/test/java/com/baseflow/geolocator/location/LocationOptionsTest.java
+++ b/geolocator_android/android/src/test/java/com/baseflow/geolocator/location/LocationOptionsTest.java
@@ -1,0 +1,33 @@
+package com.baseflow.geolocator.location;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LocationOptionsTest {
+  @Test
+  public void parseArguments_setsMaxUpdateAgeMillis() {
+    // Arrange
+    Map<String, Object> arguments = new HashMap<>();
+    arguments.put("maxUpdateAge", 30000);
+
+    // Act
+    LocationOptions options = LocationOptions.parseArguments(arguments);
+
+    // Assert
+    assertEquals(Long.valueOf(30000), options.getMaxUpdateAgeMillis());
+  }
+
+  @Test
+  public void parseArguments_defaultsMaxUpdateAgeMillisToNull() {
+    // Act
+    LocationOptions options = LocationOptions.parseArguments(new HashMap<>());
+
+    // Assert
+    assertNull(options.getMaxUpdateAgeMillis());
+  }
+}

--- a/geolocator_android/lib/src/types/android_settings.dart
+++ b/geolocator_android/lib/src/types/android_settings.dart
@@ -14,6 +14,7 @@ class AndroidSettings extends LocationSettings {
     super.accuracy,
     super.distanceFilter,
     this.intervalDuration,
+    this.maxUpdateAge,
     super.timeLimit,
     this.foregroundNotificationConfig,
     this.useMSLAltitude = false,
@@ -44,6 +45,13 @@ class AndroidSettings extends LocationSettings {
   ///
   /// If this value is `null` an interval duration of 5000ms is applied.
   final Duration? intervalDuration;
+
+  /// The maximum age of an initial historical location delivered for the
+  /// position stream.
+  ///
+  /// If this value is `null` the Android Fused Location Provider uses its
+  /// default behavior.
+  final Duration? maxUpdateAge;
 
   /// If this is set then the services is started as a Foreground service with a persistent notification
   /// showing the user that the service will continue running in the background.
@@ -77,6 +85,7 @@ class AndroidSettings extends LocationSettings {
       ..addAll({
         'forceLocationManager': forceLocationManager,
         'timeInterval': intervalDuration?.inMilliseconds,
+        'maxUpdateAge': maxUpdateAge?.inMilliseconds,
         'foregroundNotificationConfig': foregroundNotificationConfig?.toJson(),
         'useMSLAltitude': useMSLAltitude,
       });

--- a/geolocator_android/pubspec.yaml
+++ b/geolocator_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_android
 description: Geolocation plugin for Flutter. This plugin provides the Android implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_android
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 5.0.3
+version: 5.1.0
 
 environment:
   sdk: ^3.5.0

--- a/geolocator_android/test/geolocator_android_test.dart
+++ b/geolocator_android/test/geolocator_android_test.dart
@@ -1440,6 +1440,7 @@ void main() {
           distanceFilter: 5,
           forceLocationManager: false,
           intervalDuration: const Duration(seconds: 1),
+          maxUpdateAge: const Duration(seconds: 30),
           timeLimit: const Duration(seconds: 1),
           useMSLAltitude: false,
           foregroundNotificationConfig: const ForegroundNotificationConfig(
@@ -1477,6 +1478,10 @@ void main() {
           settings.intervalDuration!.inMilliseconds,
         );
         expect(
+          jsonMap['maxUpdateAge'],
+          settings.maxUpdateAge!.inMilliseconds,
+        );
+        expect(
           jsonMap['useMSLAltitude'],
           settings.useMSLAltitude,
         );
@@ -1511,7 +1516,7 @@ void main() {
         );
         expect(
           jsonMap['foregroundNotificationConfig']['color'],
-          settings.foregroundNotificationConfig!.color!.toARGB32,
+          settings.foregroundNotificationConfig!.color!.toARGB32(),
         );
       });
 


### PR DESCRIPTION
Fixes #1784

Add AndroidSettings maxUpdateAge serialization and pass it through to the Android Fused Location Provider request options.

Add tests covering maxUpdateAge parsing and JSON output.

*Replace this paragraph with a short description of what issue this pull request (PR) solves and provide a description of the change.  Consider including before/after screenshots.*

*List at least one fixed issue.*

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
