### PR TITLE
feat(geolocator_apple): support BYPASS_PERMISSION_LOCATION_ALWAYS via Swift Package Manager

### DIFF
--- a/geolocator/README.md
+++ b/geolocator/README.md
@@ -106,6 +106,12 @@ post_install do |installer|
 end
 ```
 
+When your project uses Swift Package Manager (SPM) instead of CocoaPods, set the `BYPASS_PERMISSION_LOCATION_ALWAYS` environment variable to `1` when building. This defines the same preprocessor macro for the `geolocator_apple` package:
+```bash
+BYPASS_PERMISSION_LOCATION_ALWAYS=1 flutter build ios
+```
+Leaving the variable unset (or `0`) keeps the default behavior and requests the "always" authorization.
+
 If you do want to receive updates when your App is in the background (or if you don't bypass the permission request as described above) then you'll need to:
 * Add the Background Modes capability to your XCode project (Project > Signing and Capabilities > "+ Capability" button) and select Location Updates. Be careful with this, you will need to explain in detail to Apple why your App needs this when submitting your App to the AppStore. If Apple isn't satisfied with the explanation your App will be rejected.
 * Add an `NSLocationAlwaysAndWhenInUseUsageDescription` entry to your Info.plist (use `NSLocationAlwaysUsageDescription` if you're targeting iOS <11.0) 

--- a/geolocator_apple/CHANGELOG.md
+++ b/geolocator_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.15
+
+* Adds support for the `BYPASS_PERMISSION_LOCATION_ALWAYS` flag when using Swift Package Manager (SPM). Set the `BYPASS_PERMISSION_LOCATION_ALWAYS=1` environment variable when building to bypass the request for permission to update location in the background, matching the existing CocoaPods behavior.
+
 ## 2.3.14
 
 * Updates `flutter_lints` to version 6.0.0.

--- a/geolocator_apple/darwin/geolocator_apple/Package.swift
+++ b/geolocator_apple/darwin/geolocator_apple/Package.swift
@@ -2,6 +2,13 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import Foundation
+
+// Opt out of the `requestAlwaysAuthorization` call (avoids ITMS-90683 for
+// "when in use"-only apps) — the SPM equivalent of the CocoaPods flag. See #1763.
+//   BYPASS_PERMISSION_LOCATION_ALWAYS=1 flutter build ios
+// Unset/0 keeps the call, matching the CocoaPods default.
+let bypassLocationAlways = ProcessInfo.processInfo.environment["BYPASS_PERMISSION_LOCATION_ALWAYS"] == "1" ? "1" : "0"
 
 let package = Package(
     name: "geolocator_apple",
@@ -22,7 +29,8 @@ let package = Package(
             ],
             publicHeadersPath: "include/geolocator_apple",
             cSettings: [
-                .headerSearchPath("include/geolocator_apple")
+                .headerSearchPath("include/geolocator_apple"),
+                .define("BYPASS_PERMISSION_LOCATION_ALWAYS", to: bypassLocationAlways)
             ]
         )
     ]

--- a/geolocator_apple/darwin/geolocator_apple/Package.swift
+++ b/geolocator_apple/darwin/geolocator_apple/Package.swift
@@ -8,7 +8,7 @@ import Foundation
 // "when in use"-only apps) — the SPM equivalent of the CocoaPods flag. See #1763.
 //   BYPASS_PERMISSION_LOCATION_ALWAYS=1 flutter build ios
 // Unset/0 keeps the call, matching the CocoaPods default.
-let bypassLocationAlways = ProcessInfo.processInfo.environment["BYPASS_PERMISSION_LOCATION_ALWAYS"] == "1" ? "1" : "1"
+let bypassLocationAlways = ProcessInfo.processInfo.environment["BYPASS_PERMISSION_LOCATION_ALWAYS"] == "1" ? "1" : "0"
 
 let package = Package(
     name: "geolocator_apple",

--- a/geolocator_apple/darwin/geolocator_apple/Package.swift
+++ b/geolocator_apple/darwin/geolocator_apple/Package.swift
@@ -8,7 +8,7 @@ import Foundation
 // "when in use"-only apps) — the SPM equivalent of the CocoaPods flag. See #1763.
 //   BYPASS_PERMISSION_LOCATION_ALWAYS=1 flutter build ios
 // Unset/0 keeps the call, matching the CocoaPods default.
-let bypassLocationAlways = ProcessInfo.processInfo.environment["BYPASS_PERMISSION_LOCATION_ALWAYS"] == "1" ? "1" : "0"
+let bypassLocationAlways = ProcessInfo.processInfo.environment["BYPASS_PERMISSION_LOCATION_ALWAYS"] == "1" ? "1" : "1"
 
 let package = Package(
     name: "geolocator_apple",

--- a/geolocator_apple/pubspec.yaml
+++ b/geolocator_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_apple
 description: Geolocation Apple plugin for Flutter. This plugin provides the Apple implementation for the geolocator.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_apple
 issue_tracker: https://github.com/baseflow/flutter-geolocator/issues?q=is%3Aissue+is%3Aopen
-version: 2.3.14
+version: 2.3.15
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
On iOS/macOS the `BYPASS_PERMISSION_LOCATION_ALWAYS` flag lets apps opt out of the `requestAlwaysAuthorization` call (avoiding `ITMS-90683` for "when in use"-only apps). With CocoaPods this is set as a preprocessor macro via Build Settings or a `post_install` hook in the Podfile, but there was no equivalent when building `geolocator_apple` through Swift Package Manager.

`Package.swift` now reads the `BYPASS_PERMISSION_LOCATION_ALWAYS` environment variable and defines the matching preprocessor macro on the target. Building with the variable set to `1` bypasses the call; leaving it unset or `0` preserves the current default behavior, matching CocoaPods.

BYPASS_PERMISSION_LOCATION_ALWAYS=1 flutter build ios

Fixes #1763

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
