### PR TITLE
feat: distinguish an unmeasured Position value from a measured 0.0

### DIFF
--- a/geolocator_platform_interface/CHANGELOG.md
+++ b/geolocator_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.0
+
+- Adds `hasAccuracy`, `hasAltitude`, `hasAltitudeAccuracy`, `hasHeading`, `hasHeadingAccuracy`, `hasSpeed` and `hasSpeedAccuracy` to `Position`, so a value the platform could not measure is distinguishable from the same value measured as `0.0`. The Android platform channel already omits a key when its `Location.hasX()` predicate is false; `Position.fromMap` substituted `0.0` for the missing value, and the distinction was lost. The reported numeric values are unchanged and every field defaults to `false`, so existing code is unaffected. Resolves [#1733](https://github.com/Baseflow/flutter-geolocator/issues/1733) and [#1525](https://github.com/Baseflow/flutter-geolocator/issues/1525).
+
 ## 4.2.8
 
 - Updates dependencies to their latest versions.

--- a/geolocator_platform_interface/lib/src/models/position.dart
+++ b/geolocator_platform_interface/lib/src/models/position.dart
@@ -19,6 +19,13 @@ class Position {
     required this.speedAccuracy,
     this.floor,
     this.isMocked = false,
+    this.hasAccuracy = false,
+    this.hasAltitude = false,
+    this.hasAltitudeAccuracy = false,
+    this.hasHeading = false,
+    this.hasHeadingAccuracy = false,
+    this.hasSpeed = false,
+    this.hasSpeedAccuracy = false,
   });
 
   /// The latitude of this position in degrees normalized to the interval -90.0
@@ -102,6 +109,53 @@ class Position {
   /// When not available the default value is false.
   final bool isMocked;
 
+  /// Whether the platform actually reported [accuracy].
+  ///
+  /// When this is `false`, [accuracy] carries no measurement: the platform
+  /// could not determine it and `0.0` is a placeholder, not zero metres of
+  /// error. Filtering on `accuracy` without checking this treats an unmeasured
+  /// position as a perfectly accurate one.
+  ///
+  /// On Android this mirrors `Location.hasAccuracy()`.
+  final bool hasAccuracy;
+
+  /// Whether the platform actually reported [altitude].
+  ///
+  /// When `false`, [altitude] is `0.0` as a placeholder. Mirrors
+  /// `Location.hasAltitude()` on Android.
+  final bool hasAltitude;
+
+  /// Whether the platform actually reported [altitudeAccuracy].
+  ///
+  /// When `false`, [altitudeAccuracy] is `0.0` as a placeholder. Mirrors
+  /// `Location.hasVerticalAccuracy()` on Android (API 26+).
+  final bool hasAltitudeAccuracy;
+
+  /// Whether the platform actually reported [heading].
+  ///
+  /// When `false`, [heading] is `0.0` as a placeholder — which is also a valid
+  /// course of due north, so the two are otherwise indistinguishable. Mirrors
+  /// `Location.hasBearing()` on Android.
+  final bool hasHeading;
+
+  /// Whether the platform actually reported [headingAccuracy].
+  ///
+  /// When `false`, [headingAccuracy] is `0.0` as a placeholder. Mirrors
+  /// `Location.hasBearingAccuracy()` on Android (API 26+).
+  final bool hasHeadingAccuracy;
+
+  /// Whether the platform actually reported [speed].
+  ///
+  /// When `false`, [speed] is `0.0` as a placeholder, which is also a valid
+  /// stationary reading. Mirrors `Location.hasSpeed()` on Android.
+  final bool hasSpeed;
+
+  /// Whether the platform actually reported [speedAccuracy].
+  ///
+  /// When `false`, [speedAccuracy] is `0.0` as a placeholder. Mirrors
+  /// `Location.hasSpeedAccuracy()` on Android (API 26+).
+  final bool hasSpeedAccuracy;
+
   @override
   bool operator ==(Object other) {
     var areEqual = other is Position &&
@@ -116,7 +170,14 @@ class Position {
         other.speed == speed &&
         other.speedAccuracy == speedAccuracy &&
         other.timestamp == timestamp &&
-        other.isMocked == isMocked;
+        other.isMocked == isMocked &&
+        other.hasAccuracy == hasAccuracy &&
+        other.hasAltitude == hasAltitude &&
+        other.hasAltitudeAccuracy == hasAltitudeAccuracy &&
+        other.hasHeading == hasHeading &&
+        other.hasHeadingAccuracy == hasHeadingAccuracy &&
+        other.hasSpeed == hasSpeed &&
+        other.hasSpeedAccuracy == hasSpeedAccuracy;
 
     return areEqual;
   }
@@ -134,7 +195,14 @@ class Position {
       speed.hashCode ^
       speedAccuracy.hashCode ^
       timestamp.hashCode ^
-      isMocked.hashCode;
+      isMocked.hashCode ^
+      hasAccuracy.hashCode ^
+      hasAltitude.hashCode ^
+      hasAltitudeAccuracy.hashCode ^
+      hasHeading.hashCode ^
+      hasHeadingAccuracy.hashCode ^
+      hasSpeed.hashCode ^
+      hasSpeedAccuracy.hashCode;
 
   @override
   String toString() {
@@ -177,6 +245,24 @@ class Position {
       speed: _toDouble(positionMap['speed']),
       speedAccuracy: _toDouble(positionMap['speed_accuracy']),
       isMocked: positionMap['is_mocked'] ?? false,
+      // A platform that could not measure a value omits its key — see
+      // `LocationMapper.toHashMap` on Android, which guards every optional
+      // field with the platform's own predicate. `_toDouble` substitutes 0.0
+      // for the missing value; these flags record that nothing measured it.
+      //
+      // `toJson` always writes the numeric keys, so on a round trip key
+      // presence alone would report a measurement that never happened. The
+      // explicit `has_*` key therefore wins when it is present.
+      hasAccuracy: _presence(positionMap, 'has_accuracy', 'accuracy'),
+      hasAltitude: _presence(positionMap, 'has_altitude', 'altitude'),
+      hasAltitudeAccuracy:
+          _presence(positionMap, 'has_altitude_accuracy', 'altitude_accuracy'),
+      hasHeading: _presence(positionMap, 'has_heading', 'heading'),
+      hasHeadingAccuracy:
+          _presence(positionMap, 'has_heading_accuracy', 'heading_accuracy'),
+      hasSpeed: _presence(positionMap, 'has_speed', 'speed'),
+      hasSpeedAccuracy:
+          _presence(positionMap, 'has_speed_accuracy', 'speed_accuracy'),
     );
   }
 
@@ -195,7 +281,28 @@ class Position {
         'speed': speed,
         'speed_accuracy': speedAccuracy,
         'is_mocked': isMocked,
+        'has_accuracy': hasAccuracy,
+        'has_altitude': hasAltitude,
+        'has_altitude_accuracy': hasAltitudeAccuracy,
+        'has_heading': hasHeading,
+        'has_heading_accuracy': hasHeadingAccuracy,
+        'has_speed': hasSpeed,
+        'has_speed_accuracy': hasSpeedAccuracy,
       };
+
+  /// Whether [map] carries a measurement for a field.
+  ///
+  /// Prefers the explicit `has_*` key when the map carries one (a `toJson`
+  /// round trip), and otherwise falls back to the presence of the value key
+  /// itself (a platform-channel message, where an unmeasured field is omitted).
+  static bool _presence(
+      Map<dynamic, dynamic> map, String flagKey, String valueKey) {
+    final flag = map[flagKey];
+    if (flag is bool) {
+      return flag;
+    }
+    return map.containsKey(valueKey) && map[valueKey] != null;
+  }
 
   static double _toDouble(dynamic value) {
     if (value == null) {

--- a/geolocator_platform_interface/pubspec.yaml
+++ b/geolocator_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geolocator plugin.
 repository: https://github.com/baseflow/flutter-geolocator/tree/main/geolocator_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.2.8
+version: 4.3.0
 
 
 dependencies:

--- a/geolocator_platform_interface/test/src/models/position_unmeasured_test.dart
+++ b/geolocator_platform_interface/test/src/models/position_unmeasured_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator_platform_interface/src/models/position.dart';
+
+/// The Android platform channel omits a key when the value is unavailable —
+/// `LocationMapper.toHashMap` guards every optional field with the platform's
+/// own predicate (`hasAccuracy()`, `hasBearing()`, `hasSpeed()`, ...). The
+/// absence therefore arrives here correctly expressed, as a missing key.
+///
+/// These tests describe what should happen to it.
+void main() {
+  Map<String, dynamic> baseMap() => <String, dynamic>{
+        'latitude': 52.0,
+        'longitude': 5.0,
+        'timestamp': 0,
+      };
+
+  group('a value the platform could not measure', () {
+    test('is distinguishable from the same value measured as 0.0', () {
+      final unmeasured = Position.fromMap(baseMap());
+      final measuredZero = Position.fromMap(baseMap()..['accuracy'] = 0.0);
+
+      expect(unmeasured.hasAccuracy, isFalse,
+          reason: 'the accuracy key was absent, so nothing measured it');
+      expect(measuredZero.hasAccuracy, isTrue,
+          reason: 'the accuracy key was present and its value was 0.0');
+      expect(unmeasured, isNot(equals(measuredZero)),
+          reason: 'a position carrying no accuracy is not equal to one '
+              'reporting zero metres of error');
+    });
+
+    test('each optional field reports its own presence independently', () {
+      final p = Position.fromMap(baseMap()
+        ..['accuracy'] = 12.0
+        ..['speed'] = 3.0);
+
+      expect(p.hasAccuracy, isTrue);
+      expect(p.hasSpeed, isTrue);
+      expect(p.hasAltitude, isFalse);
+      expect(p.hasAltitudeAccuracy, isFalse);
+      expect(p.hasHeading, isFalse);
+      expect(p.hasHeadingAccuracy, isFalse);
+      expect(p.hasSpeedAccuracy, isFalse);
+    });
+
+    test(
+        'the reported value is unchanged, so existing consumers are unaffected',
+        () {
+      final unmeasured = Position.fromMap(baseMap());
+
+      expect(unmeasured.accuracy, 0.0);
+      expect(unmeasured.heading, 0.0);
+      expect(unmeasured.speed, 0.0);
+    });
+
+    test('survives a toJson/fromMap round trip', () {
+      final unmeasured = Position.fromMap(baseMap());
+      final roundTripped = Position.fromMap(unmeasured.toJson());
+
+      expect(roundTripped.hasAccuracy, isFalse);
+      expect(roundTripped, equals(unmeasured));
+    });
+
+    test('a directly constructed Position defaults to no measurement claimed',
+        () {
+      final p = Position(
+        longitude: 5.0,
+        latitude: 52.0,
+        timestamp: DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+        accuracy: 0.0,
+        altitude: 0.0,
+        altitudeAccuracy: 0.0,
+        heading: 0.0,
+        headingAccuracy: 0.0,
+        speed: 0.0,
+        speedAccuracy: 0.0,
+      );
+
+      expect(p.hasAccuracy, isFalse,
+          reason: 'nothing told this constructor a measurement was taken');
+    });
+  });
+}


### PR DESCRIPTION
Resolves #1733 and #1525.

## The problem

`Position.fromMap` cannot distinguish a value the platform did not measure from the same value measured as `0.0`.

The Android side already gets this right. `LocationMapper.toHashMap` guards every optional field with the platform's own predicate and omits the key when it is false:

```java
if (location.hasAltitude()) position.put("altitude", location.getAltitude());
if (location.hasAccuracy()) position.put("accuracy", (double) location.getAccuracy());
if (location.hasBearing()) position.put("heading", (double) location.getBearing());
```

So the absence arrives at the platform interface correctly expressed, as a missing key. It is then discarded here:

```dart
static double _toDouble(dynamic value) {
  if (value == null) {
    return 0.0;
  }
  return value.toDouble();
}
```

The consequence is in both issues, in opposite directions:

- @Priyantha-Kingslake in #1733: *"according to this we get `0`when there is no data. How do we distinguish whether this 0 means `no-data` or `real 0`?"* — and, in the same thread, *"I have ~30% out of all location fixes with 0, 0 for heading and heading_accuracy"*.
- @JaseElder in #1525: *"we were filtering out inaccurate heading readings using `Position.headingAccuracy`, but on some devices this always = 0.0 if `Location.hasBearingAccuracy()` returns `false`, so on those devices, we're throwing away all readings."*

A consumer filtering `accuracy < threshold` accepts a position carrying no accuracy at all, because `0.0` passes every threshold. A consumer filtering `headingAccuracy > 0` discards every reading on devices that cannot report it. Both are reasonable code against the current contract.

For what it is worth: my own previous PR here, #1783, edited the doc comment on `Position.heading` and left the sentence *"In these cases the value is 0.0"* standing in text I had just rewritten, while both of these issues were already open. I did not see it then.

## What this changes

Adds seven `bool` fields to `Position`, one per optional value:

`hasAccuracy` · `hasAltitude` · `hasAltitudeAccuracy` · `hasHeading` · `hasHeadingAccuracy` · `hasSpeed` · `hasSpeedAccuracy`

`fromMap` sets each from what the map actually carried. `toJson` emits them, and `fromMap` prefers an explicit `has_*` key over key presence, so a round trip does not resurrect a measurement that never happened.

No platform code changes. The predicates are already being called on Android; this just stops throwing the answer away.

## Backwards compatibility

- Every new field is optional and defaults to `false`, following the existing `floor` / `isMocked` pattern in the same constructor.
- The reported numeric values are unchanged. Code that reads `accuracy`, `heading` or `speed` behaves exactly as before.
- `flutter test` for `geolocator_platform_interface`: **120 passing**, of which **115 are the pre-existing tests**, unchanged.

## Verification

Run against `geolocator_platform_interface` per the checks in `.github/workflows/geolocator_platform_interface.yaml`:

| command | result |
|---|---|
| `flutter pub get` | ok |
| `dart format --set-exit-if-changed .` | 39 files, 0 changed |
| `flutter analyze` | No issues found! |
| `flutter test --coverage` | +120: All tests passed |

The new test file was written first and run against the unmodified tree, where it fails to compile (`The getter 'hasAccuracy' isn't defined for the type 'Position'`). It passes 5/5 after the change.

Verified on a Flutter build that is not on the `stable` channel your CI pins, so please treat the local `dart format` result as indicative rather than CI-equivalent.

## What this does not do

- Only `geolocator_platform_interface` is changed. `geolocator_android`, `geolocator_apple`, `geolocator_linux`, `geolocator_web` and `geolocator_windows` are untouched and were not built or tested here.
- `geolocator_linux` in particular still coalesces GeoClue's nulls: `geoclue_x.dart` sets `altitudeAccuracy`, `headingAccuracy` and `speedAccuracy` to `0` unconditionally and applies `?? 0` to `altitude`, `heading` and `speed`, even though `GeoClueLocation` reports those as nullable. Wiring these flags there would be a separate change; I did not want to bundle it.
- The docs on the affected fields still describe the `0.0` behaviour. @TimHoogstrate noted in #1733 that the platform interface documentation needed updating; I have left that alone rather than mix a doc rewrite into this diff. Happy to follow up separately if useful.

Happy to split this differently, rename the fields, or drop the `toJson` change if you would rather keep the serialized shape fixed.
