### PR TITLE
fix(android): call toARGB32() in the json test, and run the android/apple suites in CI

### DIFF
--- a/.github/workflows/geolocator_android.yaml
+++ b/.github/workflows/geolocator_android.yaml
@@ -59,6 +59,11 @@ jobs:
         run: flutter analyze
         working-directory: ${{env.source-directory}}
 
+      # Run all unit-tests with code coverage
+      - name: Run unit tests
+        run: flutter test --coverage
+        working-directory: ${{env.source-directory}}
+
       # Build Android version of the example App
       - name: Run Android build
         run: flutter build apk --release

--- a/.github/workflows/geolocator_apple.yaml
+++ b/.github/workflows/geolocator_apple.yaml
@@ -53,6 +53,11 @@ jobs:
         run: flutter analyze
         working-directory: ${{env.source-directory}}
 
+      # Run all unit-tests with code coverage
+      - name: Run unit tests
+        run: flutter test --coverage
+        working-directory: ${{env.source-directory}}
+
       # Build iOS version of the example App
       - name: Run iOS build
         run: flutter build ios --no-codesign --release

--- a/geolocator_android/test/geolocator_android_test.dart
+++ b/geolocator_android/test/geolocator_android_test.dart
@@ -1511,7 +1511,7 @@ void main() {
         );
         expect(
           jsonMap['foregroundNotificationConfig']['color'],
-          settings.foregroundNotificationConfig!.color!.toARGB32,
+          settings.foregroundNotificationConfig!.color!.toARGB32(),
         );
       });
 


### PR DESCRIPTION
## The failing test

`geolocator_android`'s json-serialization test compares a method tear-off against an int:

```
Expected: <Closure: () => int from Function 'toARGB32':.>
  Actual: <4294951175>
```

`geolocator_android_test.dart:1514` reads `color!.toARGB32` where the implementation writes `color?.toARGB32()` (`foreground_settings.dart:122`). The `Color.value` → `toARGB32()` migration in 4ddd301 (#1648) landed correctly in the implementation and without the parentheses in the test.

Measured: `geolocator_android` is `+48 -1` before, **`+49` after**. The fix is one character.

## Why it sat

`.github/workflows/geolocator_android.yaml` has no `flutter test` step — it runs `pub get`, `dart format`, `flutter analyze` and `flutter build apk`. `geolocator_apple` is the same. Between them that is **95 tests that have never run in CI**, while `geolocator_platform_interface`, `geolocator_linux`, `geolocator_web` and `geolocator` all run theirs.

So the second half of this change adds a `flutter test` step to both, copying the wording and placement already used in `geolocator_platform_interface.yaml`.

Measured before enabling: `geolocator_apple` is `+46` passing today, so turning its step on does not make CI red.

I am aware this is a one-character fix bundled with a CI change, and I would rather ask than assume: happy to split them if you would prefer the workflows handled separately.

## Verification

`geolocator_android`: `dart format --set-exit-if-changed .` 0 changed · `flutter analyze` no issues · `flutter test --coverage` **+49 passing**.
`geolocator_apple`: same three, **+46 passing**.

I could not run `flutter build apk --release` or the Apple build — no Android SDK and no macOS host here — so please treat those two as unverified on my side. The diff touches one test file and two workflow files and no build configuration.

For context on where this came from: I found it while running your suites against an unrelated branch, not by looking for it. My own project had the same shape of gap in its CI the same week — a package whose tests were in no job at all — so this is a defect I recognised because I had just shipped it myself.
